### PR TITLE
fix: sso credentials loading and profile display for built-in agent

### DIFF
--- a/src/agents/codemie-code/config.ts
+++ b/src/agents/codemie-code/config.ts
@@ -34,12 +34,14 @@ export async function loadCodeMieConfig(
     const provider = ProviderRegistry.getProvider(baseConfig.provider || '');
     if (provider?.authType === 'sso') {
       const store = CredentialStore.getInstance();
-      const credentials = await store.retrieveSSOCredentials();
+      // Retrieve credentials using the codeMieUrl from profile for URL-specific storage
+      const codeMieUrl = (baseConfig as any).codeMieUrl || baseConfig.baseUrl;
+      const credentials = await store.retrieveSSOCredentials(codeMieUrl);
 
       if (!credentials) {
         throw new ConfigurationError(
           'SSO credentials not found. Please run: codemie profile login',
-          { provider: baseConfig.provider }
+          { provider: baseConfig.provider, codeMieUrl }
         );
       }
 
@@ -67,7 +69,9 @@ export async function loadCodeMieConfig(
       displayProvider: originalProvider, // Keep original for display
       timeout: baseConfig.timeout || 300,
       workingDirectory: workDir,
-      debug: baseConfig.debug || false
+      debug: baseConfig.debug || false,
+      name: baseConfig.name, // Profile name for display
+      codeMieUrl: (baseConfig as any).codeMieUrl // CodeMie URL for SSO providers
     };
 
     // Validate agent-specific requirements

--- a/src/agents/codemie-code/types.ts
+++ b/src/agents/codemie-code/types.ts
@@ -37,6 +37,12 @@ export interface CodeMieConfig {
 
   /** Directory filtering configuration */
   directoryFilters?: FilterConfig;
+
+  /** Profile name */
+  name?: string;
+
+  /** CodeMie base URL (for SSO providers) */
+  codeMieUrl?: string;
 }
 
 /**

--- a/src/agents/plugins/codemie-code.plugin.ts
+++ b/src/agents/plugins/codemie-code.plugin.ts
@@ -51,20 +51,26 @@ export const CodeMieCodePluginMetadata: AgentMetadata = {
       let config;
       try {
         config = await loadCodeMieConfig(workingDir);
-      } catch {
-        throw new Error('CodeMie configuration required. Please run: codemie setup');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error('Configuration loading failed:', errorMessage);
+        throw new Error(`CodeMie configuration required: ${errorMessage}. Please run: codemie setup`);
       }
 
       // Show welcome message with session info
-      const profileName = config.name || 'default';
+      // Read from environment variables (same as BaseAgentAdapter)
+      const profileName = process.env.CODEMIE_PROFILE_NAME || config.name || 'default';
+      const provider = process.env.CODEMIE_PROVIDER || config.displayProvider || config.provider;
+      const model = process.env.CODEMIE_MODEL || config.model;
+      const codeMieUrl = process.env.CODEMIE_URL || config.codeMieUrl;
       const sessionId = process.env.CODEMIE_SESSION_ID || 'n/a';
       const cliVersion = process.env.CODEMIE_CLI_VERSION || 'unknown';
       console.log(
         renderProfileInfo({
             profile: profileName,
-            provider: config.provider,
-            model: config.model,
-            codeMieUrl: config.codeMieUrl,
+            provider,
+            model,
+            codeMieUrl,
             agent: BUILTIN_AGENT_NAME,
             cliVersion,
             sessionId


### PR DESCRIPTION
This commit fixes multiple issues with the codemie-code built-in agent when using SSO providers:

1. **SSO Credential Retrieval**: Fixed URL-specific credential loading
   - CredentialStore.retrieveSSOCredentials() now receives the codeMieUrl parameter
   - Credentials are stored per-URL, so we need to pass the URL to retrieve them
   - Fixes "SSO credentials not found" error when credentials exist

2. **Error Handling**: Improved error reporting
   - Show actual error message instead of generic "configuration required"
   - Helps users understand what went wrong during config loading

3. **Profile Information**: Added profile metadata to CodeMieConfig
   - Added name and codeMieUrl fields to CodeMieConfig interface
   - Copy these fields from baseConfig when creating agentConfig
   - Enables proper profile display in welcome message

4. **Unified Profile Display**: Consistent profile rendering across agents
   - Read profile info from environment variables (same as BaseAgentAdapter)
   - Ensures codemie-code shows correct profile name and provider
   - Matches behavior of external agents (claude, codex, etc.)

Changes:
- src/agents/codemie-code/config.ts: Pass codeMieUrl to retrieveSSOCredentials
- src/agents/codemie-code/types.ts: Add name and codeMieUrl to CodeMieConfig
- src/agents/plugins/codemie-code.plugin.ts: Read profile from env vars

Generated with AI

## Summary

<!-- Brief overview of changes -->

## Checklist

- [ ] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)
