### PR TITLE
fix (utils): trim command paths

### DIFF
--- a/src/utils/which.ts
+++ b/src/utils/which.ts
@@ -42,7 +42,7 @@ export async function getCommandPath(command: string): Promise<string | null> {
 
     if (result.code === 0) {
       // On Windows, 'where' can return multiple paths, take the first one
-      const paths = result.stdout.split('\n').filter(p => p.trim());
+      const paths = result.stdout.split('\n').map(p => p.trim()).filter(p => p);
       return paths[0] || null;
     }
 


### PR DESCRIPTION
## Summary
On windows getCommandPath utility returned path with trailing \r, running such command caused ENOENT error.

<img width="959" height="343" alt="image" src="https://github.com/user-attachments/assets/0e74bdf0-4059-40ec-bb8e-b3172a427615" />
