### PR TITLE
fix(providers): implement automatic hook chaining for bedrock provider

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -236,7 +236,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     // Lifecycle hook: enrichArgs (provider-aware)
     // Enrich args with agent-specific defaults (e.g., --profile, --model)
     // Must run AFTER beforeRun so env vars like CODEMIE_CODEX_PROFILE are available
-    let enrichedArgs = executeEnrichArgs(this.metadata.lifecycle, this.metadata.name, args, this.extractConfig(env));
+    let enrichedArgs = await executeEnrichArgs(this.metadata.lifecycle, this.metadata.name, args, this.extractConfig(env));
 
     // Apply argument transformations using declarative flagMappings
     let transformedArgs: string[];
@@ -294,6 +294,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
         }
       }
     }
+
     logger.debug('=== End Configuration ===');
 
     if (!this.metadata.cliCommand) {


### PR DESCRIPTION
## Summary

Fixes AWS Bedrock provider integration for external agents (claude, codex, etc.) by implementing proper lifecycle hook chaining and plugin auto-registration.

## Problem

The Bedrock provider was configured correctly in `codemie setup`, and `codemie doctor` health checks passed, but external agents like `codemie-claude` failed with 403 errors:
- "Invalid API Key format" errors
- "The security token included in the request is invalid"
- AWS environment variables (AWS_PROFILE, AWS_REGION) were not being set

**Root Cause**: Provider plugin hooks were not executing due to two issues:
1. Missing `import '../../providers/index.js'` in lifecycle-helpers.ts (plugins weren't auto-registering)
2. Hook resolution returned agent-specific hook immediately, skipping wildcard hook execution

## Solution

Implemented automatic hook chaining in lifecycle-helpers.ts:
1. **Wildcard hook ('*')** runs first → transforms `CODEMIE_AWS_*` → `AWS_*` for all agents
2. **Agent-specific hook** runs second → applies agent-specific settings (e.g., CLAUDE_CODE_USE_BEDROCK)
3. **Automatic composition** in `resolveHook()` - no manual chaining needed

## Changes

### Core Fixes
- **lifecycle-helpers.ts**: Import providers/index.js to trigger plugin auto-registration
- **lifecycle-helpers.ts**: Implement automatic hook chaining (wildcard → agent-specific)
- **lifecycle-helpers.ts**: Make resolveHook async for ES module compatibility
- **BaseAgentAdapter.ts**: Add await to executeEnrichArgs call

### Bedrock Provider
- **bedrock.template.ts**: Add wildcard hook for AWS credential transformation
- **bedrock.template.ts**: Add Claude-specific hook for Bedrock mode enablement
- **bedrock.health.ts**: Override check() to use profile-configured region

## Environment Variables Set

Wildcard hook (`'*'` - all agents):
- `AWS_PROFILE`: Profile name for AWS SDK
- `AWS_REGION`: Region for Bedrock API calls
- `AWS_DEFAULT_REGION`: Fallback region

Claude-specific hook:
- `CLAUDE_CODE_USE_BEDROCK`: Enables Bedrock mode in Claude Code
- `ANTHROPIC_MODEL`: Model ID for inference
- `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: Token limit (4096)
- `MAX_THINKING_TOKENS`: Thinking tokens limit (1024)

## Testing

✅ **External agent execution**:
```bash
codemie-claude --profile bedrock --print "test"
# Output: Successfully connected to Bedrock, Claude responded
```

✅ **Health check**:
```bash
codemie doctor
# Bedrock provider: ✓ Connected (us-west-2)
```

✅ **Hook chaining verification**:
```bash
CODEMIE_DEBUG=1 codemie-claude --profile bedrock --print "test"
# Logs show:
# - Wildcard hook executed → AWS_PROFILE=bedrock, AWS_REGION=us-west-2
# - Claude hook executed → CLAUDE_CODE_USE_BEDROCK=1
# - No 403 errors ✅
```

## Architecture

```typescript
// Before: Only agent-specific hook ran
resolveHook() → specificHook || wildcardHook || agentDefault

// After: Automatic chaining
resolveHook() → compose(wildcardHook, specificHook) || specificHook || wildcardHook || agentDefault
```

When both wildcard and agent-specific hooks exist, they are automatically chained:
- Wildcard hook executes first, transforms env
- Agent-specific hook executes second, receives wildcard's result
- Final env is returned and passed to spawned agent process

## Breaking Changes

None - this is a bug fix that enables existing functionality.

## Related Issues

Fixes integration issues discovered during Bedrock provider testing.