### PR TITLE
fix: resolve Windows SessionEnd hook assertion failure

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -938,7 +938,9 @@ export function createHookCommand(): Command {
 
         // Flush logger before exit to ensure write completes
         await logger.close();
-        process.exit(0); // Success
+        // Use process.exitCode instead of process.exit() to allow graceful shutdown
+        // This prevents Windows libuv UV_HANDLE_CLOSING assertion failures
+        process.exitCode = 0;
 
       } catch (error: unknown) {
         const totalDuration = Date.now() - hookStartTime;
@@ -961,7 +963,9 @@ export function createHookCommand(): Command {
 
         // Flush logger before exit
         await logger.close();
-        process.exit(1); // Non-blocking warning
+        // Use process.exitCode instead of process.exit() to allow graceful shutdown
+        // This prevents Windows libuv UV_HANDLE_CLOSING assertion failures
+        process.exitCode = 1;
       }
     });
 }


### PR DESCRIPTION
## Summary
Fixes a Windows 11-specific crash in the SessionEnd hook that causes the assertion error:
```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

## Problem
The hook command handler was calling `process.exit()` immediately after `await logger.close()`, creating a race condition in Windows-specific libuv async handle cleanup:

1. `logger.close()` marks the file stream handle for closing
2. `process.exit()` forces immediate process termination
3. Windows libuv cleanup code tries to operate on the closing handle
4. Result: Assertion failure in `src\win\async.c`

## Solution
Replaced `process.exit(0)` and `process.exit(1)` with `process.exitCode` to allow **graceful shutdown**:

- `process.exitCode` sets the exit code without forcing immediate termination
- Node.js continues to run until all async operations complete
- libuv has time to properly clean up file handles
- Process exits naturally with the correct exit code

## Changes
- **File**: `src/cli/commands/hook.ts`
- Replaced `process.exit(0)` with `process.exitCode = 0` (success path)
- Replaced `process.exit(1)` with `process.exitCode = 1` (error path)
- Added detailed comments explaining the Windows-specific fix

## Testing
- ✅ Builds successfully (`npm run build`)
- ✅ Passes linting (`npm run lint`)
- ✅ Lint-staged pre-commit hooks passed

## Impact
- **Windows users**: Should no longer experience SessionEnd hook crashes
- **Linux/macOS**: No functional change (process.exitCode behaves identically)
- **Risk level**: Low - standard Node.js pattern for graceful shutdown

## Related Issues
Resolves the Windows 11 SessionEnd hook error reported in the codemie-code repository.