### PR TITLE
feat: add custom authorization header support for litellm provider

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -43,6 +43,8 @@ All agent shortcuts support these options:
 --api-key <key>          # Override API key
 --base-url <url>         # Override base URL
 --timeout <seconds>      # Override timeout (in seconds)
+--auth-header <name>     # Custom authorization header name (default: Authorization)
+--auth-value <format>    # Authorization value format with {key} placeholder (default: Bearer {key})
 ```
 
 ### Built-in Agent (codemie-code)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,9 @@ Profiles are stored in `~/.codemie/codemie-cli.config.json`:
       "baseUrl": "https://litellm.company.com",
       "apiKey": "sk-***",
       "model": "claude-4-5-sonnet",
-      "timeout": 300
+      "timeout": 300,
+      "authHeader": "api-key",
+      "authValue": "{key}"
     },
     "personal-openai": {
       "name": "personal-openai",
@@ -133,6 +135,8 @@ Environment variables override config file values and are useful for CI/CD, Dock
 | `CODEMIE_MODEL` | Model to use | - | `claude-sonnet-4-5-20250929` |
 | `CODEMIE_TIMEOUT` | Request timeout in milliseconds | `300000` | `600000` |
 | `CODEMIE_DEBUG` | Enable debug logging | `false` | `true` |
+| `CODEMIE_AUTH_HEADER` | Custom authorization header name | `Authorization` | `api-key` |
+| `CODEMIE_AUTH_VALUE` | Authorization value format with `{key}` placeholder | `Bearer {key}` | `{key}` |
 
 #### AI/Run SSO Configuration
 
@@ -195,6 +199,27 @@ export CODEMIE_BASE_URL=http://localhost:4000
 export CODEMIE_MODEL=claude-sonnet-4-5-20250929
 
 codemie-claude "Refactor this function"
+```
+
+**Using LiteLLM with custom authorization header:**
+```bash
+# API expects "api-key: {key}" instead of "Authorization: Bearer {key}"
+export CODEMIE_PROVIDER=litellm
+export CODEMIE_BASE_URL=http://localhost:4000
+export CODEMIE_API_KEY=sk-xxx
+export CODEMIE_AUTH_HEADER=api-key
+export CODEMIE_AUTH_VALUE="{key}"
+
+codemie-claude "Review this code"
+```
+
+**Using custom auth scheme via CLI:**
+```bash
+# Custom header with prefix
+codemie-code --api-key sk-xxx --auth-header "X-API-Key" --auth-value "Token {key}"
+
+# Raw key without Bearer prefix
+codemie-claude --provider litellm --api-key sk-xxx --auth-header "api-key" --auth-value "{key}"
 ```
 
 **Enable analytics:**

--- a/src/agents/codemie-code/config.ts
+++ b/src/agents/codemie-code/config.ts
@@ -73,7 +73,10 @@ export async function loadCodeMieConfig(
       name: baseConfig.name, // Profile name for display
       codeMieUrl: (baseConfig as any).codeMieUrl, // CodeMie URL for SSO providers
       hooks: (baseConfig as any).hooks, // Pass through hooks configuration
-      maxHookRetries: (baseConfig as any).maxHookRetries || 5 // Default to 5 retries
+      maxHookRetries: (baseConfig as any).maxHookRetries || 5, // Default to 5 retries
+      // Custom authorization header configuration (from env or profile)
+      authHeader: process.env.CODEMIE_AUTH_HEADER || (baseConfig as any).authHeader,
+      authValue: process.env.CODEMIE_AUTH_VALUE || (baseConfig as any).authValue
     };
 
     // Validate agent-specific requirements

--- a/src/agents/codemie-code/types.ts
+++ b/src/agents/codemie-code/types.ts
@@ -56,6 +56,12 @@ export interface CodeMieConfig {
 
   /** Maximum number of times to retry when Stop hook returns exit code 2 (default: 5) */
   maxHookRetries?: number;
+
+  /** Custom authorization header name (default: 'Authorization') */
+  authHeader?: string;
+
+  /** Authorization value format using {key} placeholder (default: 'Bearer {key}') */
+  authValue?: string;
 }
 
 /**

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -61,6 +61,8 @@ export class AgentCLI {
       .option('--api-key <key>', 'Override API key')
       .option('--base-url <url>', 'Override base URL')
       .option('--timeout <seconds>', 'Override timeout (in seconds)', parseInt)
+      .option('--auth-header <name>', 'Custom authorization header name (default: Authorization)')
+      .option('--auth-value <format>', 'Authorization value format using {key} placeholder (default: Bearer {key})')
       .option('--task <prompt>', 'Execute a single task (agent-specific flag mapping)')
       .allowUnknownOption()
       .argument('[args...]', `Arguments to pass to ${this.adapter.displayName}`)
@@ -111,7 +113,9 @@ export class AgentCLI {
         model: options.model as string | undefined,
         apiKey: options.apiKey as string | undefined,
         baseUrl: options.baseUrl as string | undefined,
-        timeout: options.timeout as number | undefined
+        timeout: options.timeout as number | undefined,
+        authHeader: options.authHeader as string | undefined,
+        authValue: options.authValue as string | undefined
       });
 
       // Validate essential configuration
@@ -302,7 +306,7 @@ export class AgentCLI {
   ): string[] {
     const agentArgs = [...args];
     // Config-only options (not passed to agent, handled by CodeMie CLI)
-    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout'];
+    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout', 'authHeader', 'authValue'];
 
     for (const [key, value] of Object.entries(options)) {
       // Skip config-only options (handled by CodeMie CLI layer)

--- a/src/env/types.ts
+++ b/src/env/types.ts
@@ -58,6 +58,10 @@ export interface ProviderProfile {
 
   // Hooks configuration
   hooks?: HooksConfiguration;
+
+  // Custom authorization header configuration
+  authHeader?: string;  // Header name (default: 'Authorization')
+  authValue?: string;   // Value format with {key} placeholder (default: 'Bearer {key}')
 }
 
 /**

--- a/src/providers/plugins/litellm/litellm.template.ts
+++ b/src/providers/plugins/litellm/litellm.template.ts
@@ -25,6 +25,23 @@ export const LiteLLMTemplate = registerProvider<ProviderTemplate>({
   capabilities: ['streaming', 'tools', 'function-calling'],
   supportsModelInstallation: false,
   supportsStreaming: true,
+
+  // Export custom auth header configuration for litellm provider
+  exportEnvVars: (config) => {
+    const env: Record<string, string> = {};
+
+    // Export custom authorization header configuration
+    // These can be used by agents or litellm proxy for custom auth schemes
+    if (config.authHeader) {
+      env.CODEMIE_AUTH_HEADER = config.authHeader;
+    }
+    if (config.authValue) {
+      env.CODEMIE_AUTH_VALUE = config.authValue;
+    }
+
+    return env;
+  },
+
   setupInstructions: `
 # LiteLLM Setup Instructions
 

--- a/src/providers/plugins/sso/proxy/plugins/auth-header.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/auth-header.plugin.ts
@@ -1,0 +1,64 @@
+/**
+ * Auth Header Plugin
+ * Priority: 15 (runs after SSO auth, before other headers)
+ *
+ * Handles custom authorization header injection for:
+ * - LiteLLM provider with custom auth header configuration
+ * - Any provider that needs non-standard auth header format
+ *
+ * SOLID: Single responsibility = inject authorization header
+ * KISS: Simple header injection with customizable format
+ */
+
+import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+import { buildAuthHeader } from '../../../../../utils/auth-header.js';
+
+export class AuthHeaderPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-auth-header';
+  name = 'Auth Header';
+  version = '1.0.0';
+  priority = 15; // After SSO auth (10), before general headers (20)
+
+  async createInterceptor(context: PluginContext): Promise<ProxyInterceptor> {
+    // Only create interceptor if:
+    // 1. We have an API key AND
+    // 2. This is NOT SSO auth (SSO uses cookies, not API key header)
+    if (!context.config.apiKey) {
+      throw new Error('Auth header plugin disabled: no API key configured');
+    }
+
+    if (context.credentials) {
+      throw new Error('Auth header plugin disabled: SSO credentials present (using cookie auth)');
+    }
+
+    return new AuthHeaderInterceptor(context);
+  }
+}
+
+class AuthHeaderInterceptor implements ProxyInterceptor {
+  name = 'auth-header';
+
+  constructor(private context: PluginContext) {}
+
+  async onRequest(context: ProxyContext): Promise<void> {
+    const { apiKey, authHeader, authValue } = this.context.config;
+
+    if (!apiKey) {
+      return;
+    }
+
+    // Build auth header using utility (supports custom header name and value format)
+    const header = buildAuthHeader({
+      apiKey,
+      headerName: authHeader,
+      valueFormat: authValue
+    });
+
+    // Inject the authorization header
+    context.headers[header.name] = header.value;
+
+    logger.debug(`[${this.name}] Injected auth header: ${header.name}`);
+  }
+}

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -8,6 +8,7 @@
 import { getPluginRegistry } from './registry.js';
 import { EndpointBlockerPlugin } from './endpoint-blocker.plugin.js';
 import { SSOAuthPlugin } from './sso-auth.plugin.js';
+import { AuthHeaderPlugin } from './auth-header.plugin.js';
 import { HeaderInjectionPlugin } from './header-injection.plugin.js';
 import { LoggingPlugin } from './logging.plugin.js';
 import { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
@@ -21,17 +22,18 @@ export function registerCorePlugins(): void {
 
   // Register in any order (priority determines execution order)
   registry.register(new EndpointBlockerPlugin()); // Priority 5 - blocks unwanted endpoints early
-  registry.register(new SSOAuthPlugin());
-  registry.register(new HeaderInjectionPlugin());
-  registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
-  registry.register(new SSOSessionSyncPlugin()); // Priority 100 - syncs sessions via multiple processors
+  registry.register(new SSOAuthPlugin());         // Priority 10 - SSO cookie auth
+  registry.register(new AuthHeaderPlugin());      // Priority 15 - API key auth (for litellm, etc.)
+  registry.register(new HeaderInjectionPlugin()); // Priority 20 - X-CodeMie-* headers
+  registry.register(new LoggingPlugin());         // Always enabled - logs to log files at INFO level
+  registry.register(new SSOSessionSyncPlugin());  // Priority 100 - syncs sessions via multiple processors
 }
 
 // Auto-register on import
 registerCorePlugins();
 
 // Re-export for convenience
-export { EndpointBlockerPlugin, SSOAuthPlugin, HeaderInjectionPlugin, LoggingPlugin };
+export { EndpointBlockerPlugin, SSOAuthPlugin, AuthHeaderPlugin, HeaderInjectionPlugin, LoggingPlugin };
 export { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 export { getPluginRegistry, resetPluginRegistry } from './registry.js';
 export * from './types.js';

--- a/src/providers/plugins/sso/proxy/proxy-types.ts
+++ b/src/providers/plugins/sso/proxy/proxy-types.ts
@@ -23,6 +23,11 @@ export interface ProxyConfig {
   sessionId?: string;
   version?: string;         // CLI version for metrics and headers
   profileConfig?: CodeMieConfigOptions; // Full profile config (read once at CLI level)
+
+  // API key authentication (for non-SSO providers like litellm)
+  apiKey?: string;          // API key for authorization header
+  authHeader?: string;      // Custom header name (default: 'Authorization')
+  authValue?: string;       // Custom value format with {key} placeholder (default: 'Bearer {key}')
 }
 
 /**

--- a/src/utils/auth-header.ts
+++ b/src/utils/auth-header.ts
@@ -1,0 +1,58 @@
+/**
+ * Auth Header Utility
+ *
+ * Provides consistent authorization header construction for HTTP requests.
+ * Supports custom header names and value formats to accommodate various API authentication schemes.
+ */
+
+/**
+ * Configuration for building authorization headers
+ */
+export interface AuthHeaderConfig {
+  /** The API key or authentication token */
+  apiKey: string;
+  /** Custom header name (default: 'Authorization') */
+  headerName?: string;
+  /** Value format using {key} placeholder (default: 'Bearer {key}') */
+  valueFormat?: string;
+}
+
+/**
+ * Result of building an authorization header
+ */
+export interface AuthHeader {
+  /** The header name (e.g., 'Authorization', 'api-key', 'X-API-Key') */
+  name: string;
+  /** The fully constructed header value */
+  value: string;
+}
+
+/**
+ * Build an authorization header from configuration
+ *
+ * @example
+ * // Default behavior (Authorization: Bearer sk-xxx)
+ * buildAuthHeader({ apiKey: 'sk-xxx' })
+ * // { name: 'Authorization', value: 'Bearer sk-xxx' }
+ *
+ * @example
+ * // Custom header with raw key (api-key: sk-xxx)
+ * buildAuthHeader({ apiKey: 'sk-xxx', headerName: 'api-key', valueFormat: '{key}' })
+ * // { name: 'api-key', value: 'sk-xxx' }
+ *
+ * @example
+ * // Custom scheme (X-API-Key: Token sk-xxx)
+ * buildAuthHeader({ apiKey: 'sk-xxx', headerName: 'X-API-Key', valueFormat: 'Token {key}' })
+ * // { name: 'X-API-Key', value: 'Token sk-xxx' }
+ */
+export function buildAuthHeader(config: AuthHeaderConfig): AuthHeader {
+  const name = config.headerName || 'Authorization';
+  const format = config.valueFormat || 'Bearer {key}';
+
+  // Replace {key} placeholder with actual API key, or use format as literal if no placeholder
+  const value = format.includes('{key}')
+    ? format.replace('{key}', config.apiKey)
+    : format;
+
+  return { name, value };
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -230,6 +230,10 @@ export class ConfigLoader {
       };
     }
 
+    // Custom authorization header configuration
+    if (process.env.CODEMIE_AUTH_HEADER) env.authHeader = process.env.CODEMIE_AUTH_HEADER;
+    if (process.env.CODEMIE_AUTH_VALUE) env.authValue = process.env.CODEMIE_AUTH_VALUE;
+
     return env;
   }
 
@@ -799,6 +803,10 @@ export class ConfigLoader {
     if (config.model) env.CODEMIE_MODEL = config.model;
     if (config.timeout) env.CODEMIE_TIMEOUT = String(config.timeout);
     if (config.debug) env.CODEMIE_DEBUG = String(config.debug);
+
+    // Custom authorization header configuration
+    if (config.authHeader) env.CODEMIE_AUTH_HEADER = config.authHeader;
+    if (config.authValue) env.CODEMIE_AUTH_VALUE = config.authValue;
 
     // Provider-specific environment variables (pluggable)
     // Each provider defines its own exportEnvVars function


### PR DESCRIPTION
## Summary

- Add `--auth-header` and `--auth-value` CLI options to allow custom authorization header configuration
- Reuse existing proxy infrastructure for litellm provider when custom auth headers are configured
- Support custom header names (e.g., `api-key` instead of `Authorization`) and value formats (e.g., raw key without `Bearer` prefix)

## Changes

### New Files
- `src/utils/auth-header.ts` - Utility for building custom auth headers
- `src/providers/plugins/sso/proxy/plugins/auth-header.plugin.ts` - Proxy plugin for auth header injection

### Modified Files
- CLI options added to `AgentCLI.ts`
- Environment variables: `CODEMIE_AUTH_HEADER`, `CODEMIE_AUTH_VALUE`
- Proxy auto-enabled for litellm + custom auth in `BaseAgentAdapter.ts`
- Documentation updated in `docs/COMMANDS.md` and `docs/CONFIGURATION.md`

## Usage Examples

```bash
# Default behavior (Authorization: Bearer sk-xxx)
codemie-code --api-key sk-xxx

# Custom header name with raw key (api-key: sk-xxx)
codemie-code --api-key sk-xxx --auth-header "api-key" --auth-value "{key}"

# External agents with litellm provider
codemie-claude --provider litellm --api-key sk-xxx --auth-header "api-key" --auth-value "{key}"
```

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Manual test: `codemie-code --api-key test --auth-header "api-key" --auth-value "{key}" --debug`
- [ ] Verify CLI help shows new options: `codemie-code --help`