### PR TITLE
feat(agents): add codemie-commit and codemie-pr commands to Claude plugin

### DIFF
--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/src/agents/plugins/claude/plugin/commands/codemie-commit.md
+++ b/src/agents/plugins/claude/plugin/commands/codemie-commit.md
@@ -1,0 +1,31 @@
+---
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git checkout:*)
+description: Create a git commit (not on main branch)
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Recent commits: !`git log --oneline -5`
+
+## Your task
+
+Based on the above changes, create a single git commit.
+
+**IMPORTANT**: If the current branch is `main` or `master`:
+1. Analyze the changes to determine the type (feat, fix, refactor, etc.)
+2. Suggest a branch name in format `<type>/<short-description>` (e.g., `feat/add-auth-header-support`, `fix/proxy-timeout-issue`)
+3. Ask user to confirm the branch name or provide an alternative
+4. After confirmation, create the branch with `git checkout -b <branch-name>` and proceed with the commit
+
+If on a feature branch:
+1. Stage all relevant changes
+2. Create a commit message following commitlint rules:
+   - Format: `<type>(<scope>): <subject>` or `<type>: <subject>`
+   - Types: feat, fix, docs, style, refactor, perf, test, chore, ci, revert
+   - Scopes (optional): cli, agents, providers, config, proxy, workflows, ci, analytics, utils, deps, tests
+   - Subject: max 100 characters, lowercase start, no period at end
+
+You have the capability to call multiple tools in a single response. Stage and create the commit using a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/src/agents/plugins/claude/plugin/commands/codemie-pr.md
+++ b/src/agents/plugins/claude/plugin/commands/codemie-pr.md
@@ -1,0 +1,25 @@
+---
+allowed-tools: Bash(git push:*), Bash(gh pr create:*)
+description: Push changes and create PR using GitHub template
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent commits on this branch: !`git log origin/main..HEAD --oneline`
+- PR template: !`cat .github/PULL_REQUEST_TEMPLATE.md`
+
+## Your task
+
+Based on the above changes:
+
+1. Push the current branch to origin (use the same branch name)
+2. Create a pull request using `gh pr create` following the PR template format from `.github/PULL_REQUEST_TEMPLATE.md`
+
+When creating the PR:
+- Generate a clear, concise title based on the changes
+- Use `--body` with content that follows the PR template structure
+- Fill in the Summary section with a brief overview based on the recent commits
+- Include the Checklist section with "Self-reviewed" marked as checked
+
+3. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -268,7 +268,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.1');
+      expect(result.sourceVersion).toBe('1.0.2');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -281,8 +281,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.1');
-      expect(result2.installedVersion).toBe('1.0.1');
+      expect(result2.sourceVersion).toBe('1.0.2');
+      expect(result2.installedVersion).toBe('1.0.2');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -296,7 +296,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.1');
+      expect(json.version).toBe('1.0.2');
     });
   });
 });


### PR DESCRIPTION
## Summary

Add two new slash commands to the Claude plugin for streamlined git workflows:
- **codemie-commit**: Streamlined git commit workflow with branch protection for main/master
- **codemie-pr**: Push changes and create PR using GitHub template

Also bumps plugin version to 1.0.2.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)