### PR TITLE
fix(utils): implement compact mode in TodoPanel render and fix flaky test

### DIFF
--- a/src/agents/codemie-code/ui/__tests__/todoPanel.test.ts
+++ b/src/agents/codemie-code/ui/__tests__/todoPanel.test.ts
@@ -342,7 +342,7 @@ describe('TodoPanel', () => {
       
       compactPanel.update(todos);
       const output = compactPanel.render();
-      
+
       // Compact mode should produce shorter output
       expect(output.length).toBeLessThan(200);
     });

--- a/src/agents/codemie-code/ui/todoPanel.ts
+++ b/src/agents/codemie-code/ui/todoPanel.ts
@@ -64,6 +64,11 @@ export class TodoPanel {
       return this.renderEmptyState();
     }
 
+    // Compact mode: show single-line progress instead of full panel
+    if (this.options.compact) {
+      return this.renderCompactProgress();
+    }
+
     const sections: string[] = [];
 
     // Add header

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'tests/**/*.test.ts'],
     exclude: ['node_modules', 'dist'],
+    // Force color output for consistent test behavior (chalk output length varies with/without colors)
+    env: {
+      FORCE_COLOR: '1',
+    },
 
     // Enable parallel execution with isolated environments
     pool: 'threads',


### PR DESCRIPTION
## Summary

- Implement compact mode in `TodoPanel.render()` method to return `renderCompactProgress()` for shorter output
- Add `FORCE_COLOR=1` to vitest config for consistent test behavior across different environments
- Fixes flaky test where ANSI color codes caused string length to vary (128 chars without colors vs 274 chars with colors)

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)