### PR TITLE
fix(ci): improve PR and commit title validation error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,62 @@ jobs:
         run: npm ci
 
       - name: Validate commit messages
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to HEAD --verbose
+        run: |
+          echo "📋 Validating commit messages..."
+          echo ""
+          if ! npx commitlint --from ${{ github.event.pull_request.base.sha }} --to HEAD --verbose; then
+            echo ""
+            echo "❌ COMMIT MESSAGE VALIDATION FAILED"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "Commit messages must follow Conventional Commits format:"
+            echo ""
+            echo "  <type>(<scope>): <description>"
+            echo ""
+            # Parse valid types and scopes from commitlint config (single node invocation)
+            node -e "const c = require('./commitlint.config.cjs'); console.log('Valid types:', c.rules['type-enum'][2].join(', ')); console.log('Valid scopes (optional):', c.rules['scope-enum'][2].join(', '))"
+            echo ""
+            echo "Examples:"
+            echo "  ✅ fix: resolve null pointer exception"
+            echo "  ✅ feat(cli): add new doctor command"
+            echo "  ✅ chore(deps): update dependencies"
+            echo ""
+            echo "See: https://www.conventionalcommits.org/"
+            exit 1
+          fi
 
       - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "📋 Validating PR title..."
+          echo ""
+          echo "PR Title: \"$PR_TITLE\""
+          echo ""
+          if ! echo "$PR_TITLE" | npx commitlint --verbose; then
+            echo ""
+            echo "❌ PR TITLE VALIDATION FAILED"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "Your PR title: \"$PR_TITLE\""
+            echo ""
+            echo "PR titles must follow Conventional Commits format:"
+            echo ""
+            echo "  <type>(<scope>): <description>"
+            echo ""
+            # Parse valid types and scopes from commitlint config (single node invocation)
+            node -e "const c = require('./commitlint.config.cjs'); console.log('Valid types:', c.rules['type-enum'][2].join(', ')); console.log('Valid scopes (optional):', c.rules['scope-enum'][2].join(', '))"
+            echo ""
+            echo "Examples based on your title:"
+            echo "  ✅ fix: $PR_TITLE"
+            echo "  ✅ fix(agents): $PR_TITLE"
+            echo "  ✅ feat: $PR_TITLE"
+            echo ""
+            echo "To fix: Edit your PR title in GitHub to include the type prefix."
+            echo "See: https://www.conventionalcommits.org/"
+            exit 1
+          fi
+          echo "✅ PR title is valid!"
 
   secrets-detection:
     name: Secrets Detection


### PR DESCRIPTION
## Summary
- Show meaningful errors when commit/PR title validation fails instead of cryptic commitlint messages
- Display the actual PR title being validated
- Show valid types and scopes parsed dynamically from `commitlint.config.cjs`
- Provide fix examples using the user's actual title
- Single Node.js invocation for performance efficiency

## Context
Related to failed CI in #96 where the error message "subject may not be empty" was confusing when the actual issue was a missing conventional commit type prefix.

## Test plan
- [ ] Open a PR with an invalid title (e.g., "Fix something" without type prefix)
- [ ] Verify the error message shows the actual title, valid types/scopes, and suggested fixes