### PR TITLE
docs: add documentation for Claude Code plugin built-in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ codemie-gemini "Implement a REST API"
 
 For more detailed information on the available agents, see the [Agents Documentation](docs/AGENTS.md).
 
+### Claude Code Built-in Commands
+
+When using Claude Code (`codemie-claude`), you get access to powerful built-in commands for project documentation:
+
+**Project Documentation:**
+```bash
+# Generate AI-optimized docs (CLAUDE.md + guides). Can be added optional info as well
+/codemie-init
+
+# Generate project-specific subagents. Can be added optional info as well
+/codemie-subagents
+```
+
+**Memory Management:**
+```bash
+# Capture important learnings
+/memory-add
+
+# Audit and update documentation
+/memory-refresh
+```
+
+These commands analyze your actual codebase to create tailored documentation and specialized agents. See [Claude Plugin Documentation](src/agents/plugins/claude/plugin/README.md) for details.
+
 ## Commands
 
 The CodeMie CLI has a rich set of commands for managing agents, configuration, and more.
@@ -182,6 +206,7 @@ Comprehensive guides are available in the `docs/` directory:
 - **[Authentication](docs/AUTHENTICATION.md)** - SSO setup, token management, enterprise authentication
 - **[Examples](docs/EXAMPLES.md)** - Common workflows, multi-provider examples, CI/CD integration
 - **[Configuration Architecture](docs/ARCHITECTURE-CONFIGURATION.md)** - How configuration flows through the system from CLI to proxy plugins
+- **[Claude Code Plugin](src/agents/plugins/claude/plugin/README.md)** - Built-in commands, hooks system, and plugin architecture
 
 ## Contributing
 

--- a/src/agents/plugins/claude/plugin/README.md
+++ b/src/agents/plugins/claude/plugin/README.md
@@ -84,9 +84,45 @@ Once loaded, the plugin automatically:
 
 ### Available Commands
 
-#### `/codemie-status`
+The plugin provides several built-in commands for project documentation and memory management.
 
-Display current session tracking status:
+#### Documentation Generation
+
+**`/codemie-init`** - Generate AI-optimized project documentation
+```bash
+# Analyze codebase and create CLAUDE.md + guides
+/codemie-init
+
+# With additional context
+/codemie-init "focus on API patterns"
+```
+
+**`/codemie-subagents`** - Generate project-specific subagents
+```bash
+# Create tailored subagent files in .claude/agents/
+/codemie-subagents
+```
+
+#### Memory Management
+
+**`/memory-add`** - Capture important learnings
+```bash
+# Add knowledge to project documentation
+/memory-add
+
+# With specific context
+/memory-add "auth flow requires initialization"
+```
+
+**`/memory-refresh`** - Audit and update documentation
+```bash
+# Verify docs match current implementation
+/memory-refresh
+```
+
+#### Status
+
+**`/codemie-status`** - Display session tracking status:
 
 ```
 CodeMie Session Status
@@ -97,6 +133,8 @@ Metrics:        15,234 tokens | 42 tools | 23 files
 Sync:           ✓ Connected (last: 30s ago)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+**See [commands/README.md](./commands/README.md) for detailed usage and examples.**
 
 ## Hook Events
 

--- a/src/agents/plugins/claude/plugin/commands/README.md
+++ b/src/agents/plugins/claude/plugin/commands/README.md
@@ -1,0 +1,133 @@
+# Claude Code Plugin Commands
+
+Built-in commands for the CodeMie Claude Code plugin. These commands are automatically available when using `codemie-claude`.
+
+## Project Documentation
+
+### `/codemie-init` - Generate Project Documentation
+
+Analyzes your codebase and generates AI-optimized documentation:
+- Main `CLAUDE.md` file with project-specific workflows
+- Detailed guides in `.codemie/guides/` (only for patterns that exist in your code)
+
+**Usage:**
+```
+/codemie-init
+/codemie-init "focus on API patterns"
+```
+
+**What it does:**
+1. Analyzes project structure, tech stack, and patterns
+2. Detects which categories apply (Architecture, API, Testing, etc.)
+3. Generates guides only for detected patterns (no empty guides)
+4. Creates/updates `CLAUDE.md` with guide references
+5. Preserves existing customizations when updating
+
+**Output:**
+- `CLAUDE.md` (200-300 lines) - Project overview and guide references
+- `.codemie/guides/<category>/*.md` (200-400 lines each) - Detailed patterns
+
+### `/codemie-subagents` - Generate Specialized Agents
+
+Creates project-specific subagent files tailored to your codebase:
+
+**Usage:**
+```
+/codemie-subagents
+```
+
+**Generated Agents:**
+- `unit-tester-agent.md` - Knows your test framework and patterns
+- `solution-architect-agent.md` - Understands your architecture
+- `code-review-agent.md` - Applies your code standards
+- `refactor-cleaner-agent.md` - Uses your cleanup tools
+
+**What it does:**
+1. Reads existing guides from `.codemie/guides/` (if available)
+2. Analyzes project structure, test setup, linting rules
+3. Generates/updates agents in `.claude/agents/`
+4. Preserves custom content when updating existing agents
+
+## Memory Management
+
+### `/memory-add` - Capture Knowledge
+
+Adds important learnings to project documentation for future sessions.
+
+**Usage:**
+```
+/memory-add
+/memory-add "important context about auth flow"
+```
+
+**When to use:**
+- You learned something non-obvious about the project
+- User corrected a pattern or approach
+- You discovered an important architectural decision or gotcha
+
+**What it does:**
+1. Identifies what was learned during the session
+2. Determines scope (project-wide vs component-specific)
+3. Adds structured knowledge to appropriate documentation
+
+**Where it writes:**
+- Project-wide patterns → Root `CLAUDE.md` or main docs
+- Component-specific → Component `CLAUDE.md` or guide section
+
+### `/memory-refresh` - Audit Documentation
+
+Verifies and updates documentation to reflect current implementation.
+
+**Usage:**
+```
+/memory-refresh
+```
+
+**What it does:**
+1. Reviews recent code changes
+2. Compares documentation against actual implementation
+3. Updates only outdated/incorrect sections
+4. Validates all references and examples
+
+**When to use:**
+- After significant refactoring
+- When patterns have evolved
+- Before starting work on unfamiliar code
+- Periodically to keep docs accurate
+
+## Status Command
+
+### `/codemie-status` - Session Information
+
+Displays current session tracking status and metrics.
+
+**Usage:**
+```
+/codemie-status
+```
+
+**Output:**
+```
+CodeMie Session Status
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Session ID:     550e8400...
+Started:        2026-01-12 10:30:45 (15m ago)
+Metrics:        15,234 tokens | 42 tools | 23 files
+Sync:           ✓ Connected (last: 30s ago)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Command Principles
+
+**Project-Aware:** All commands analyze your actual codebase, not generic templates
+
+**Selective Updates:** Only creates/updates documentation when patterns actually exist
+
+**Preserves Customizations:** When updating, keeps user-added content
+
+**Size Conscious:** Enforces line limits to keep documentation scannable:
+- `CLAUDE.md`: 200-300 lines
+- Guides: 200-400 lines each
+- Subagents: 150-300 lines each
+
+**Examples From Code:** Uses real code examples, not hypothetical ones


### PR DESCRIPTION
## Summary

Added comprehensive documentation for Claude Code plugin's built-in commands (`/codemie-init`, `/codemie-subagents`, `/memory-add`, `/memory-refresh`). The documentation is now organized across three levels:

- Root README: Brief overview of built-in commands with quick examples
- Plugin README: Command categorization and usage patterns
- Commands README: Detailed documentation for each command

Changes include:
- Created `src/agents/plugins/claude/plugin/commands/README.md` with detailed command documentation
- Updated `src/agents/plugins/claude/plugin/README.md` to reference commands
- Updated root `README.md` with "Claude Code Built-in Commands" section
- Added plugin documentation link to main documentation section

All documentation follows the principle of being clear, brief, and actionable.

## Checklist

- [x] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)