### PR TITLE
feat(agents): add Claude Code ACP plugin for IDE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can also install and use external agents like Claude Code and Gemini.
 
 **Available Agents:**
 - **Claude Code** (`codemie-claude`) - Anthropic's official CLI with advanced code understanding
+- **Claude Code ACP** (`codemie-claude-acp`) - Claude Code for IDE integration via ACP protocol (Zed, JetBrains, Emacs)
 - **Gemini CLI** (`codemie-gemini`) - Google's Gemini for coding tasks
 - **OpenCode** (`codemie-opencode`) - Open-source AI coding assistant with session analytics
 
@@ -154,6 +155,10 @@ codemie-gemini "Implement a REST API"
 # Install OpenCode
 codemie install opencode
 codemie-opencode "Generate unit tests for my service"
+
+# Install Claude Code ACP (for IDE integration)
+codemie install claude-acp
+# Configure in your IDE (see docs/AGENTS.md for details)
 ```
 
 **Version Management:**

--- a/bin/codemie-claude-acp.js
+++ b/bin/codemie-claude-acp.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code ACP Agent Entry Point
+ * Direct entry point for codemie-claude-acp command
+ *
+ * ACP (Agent Communication Protocol) adapter for editor integration.
+ * Uses Zed's claude-code-acp wrapper for stdio JSON-RPC communication.
+ */
+
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+
+const agent = AgentRegistry.getAgent('claude-acp');
+if (!agent) {
+  console.error('✗ Claude ACP agent not found in registry');
+  process.exit(1);
+}
+
+const cli = new AgentCLI(agent);
+await cli.run(process.argv);

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -59,6 +59,73 @@ codemie-claude -p "message"      # Non-interactive/print mode
 codemie-claude health            # Health check
 ```
 
+## Claude Code ACP
+
+Claude Code adapter for IDE integration via ACP (Agent Communication Protocol).
+
+**Installation:** `codemie install claude-acp`
+
+**What is ACP?**
+ACP (Agent Communication Protocol) is a stdio-based JSON-RPC protocol that enables AI agents to communicate with editors and IDEs. It provides a standardized way for editors like Zed, JetBrains, and Emacs to integrate with AI coding assistants.
+
+**Requirements:**
+- Node.js 20.0.0 or higher
+- Supported providers: LiteLLM, AI/Run SSO, or direct Anthropic API access
+- IDE with ACP support (Zed, JetBrains, Emacs, etc.)
+
+**Features:**
+- Stdio-based JSON-RPC communication
+- Silent mode (no console output interfering with protocol)
+- Full CodeMie proxy integration for enterprise SSO
+- Profile-based configuration support
+- All Claude Code capabilities via ACP protocol
+
+**IDE Configuration:**
+
+After installation, configure your IDE to use `codemie-claude-acp`:
+
+**Zed** (`~/.config/zed/settings.json`):
+```json
+{
+  "agent_servers": {
+    "claude": {
+      "command": "codemie-claude-acp",
+      "args": ["--profile", "work"]
+    }
+  }
+}
+```
+
+**JetBrains** (`~/.jetbrains/acp.json`):
+```json
+{
+  "agent_servers": {
+    "Claude Code via CodeMie": {
+      "command": "codemie-claude-acp",
+      "args": ["--profile", "work"]
+    }
+  }
+}
+```
+
+**Emacs** (with acp.el):
+```elisp
+(setq acp-claude-command "codemie-claude-acp")
+(setq acp-claude-args '("--profile" "work"))
+```
+
+**Usage:**
+```bash
+# Install the ACP adapter
+codemie install claude-acp
+
+# The command is typically invoked by your IDE, not directly
+# But you can test it manually:
+codemie-claude-acp --profile work
+```
+
+**Note:** Unlike `codemie-claude`, the ACP adapter is designed to be invoked by editors, not used interactively in a terminal. All output goes through the JSON-RPC protocol.
+
 ## Gemini CLI
 
 Google's Gemini AI coding assistant with advanced code understanding.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -68,6 +68,7 @@ All external agents share the same command pattern:
 ```bash
 # Basic usage
 codemie-claude "message"         # Claude Code agent
+codemie-claude-acp               # Claude Code ACP (invoked by IDEs)
 codemie-gemini "message"         # Gemini CLI agent
 codemie-opencode "message"       # OpenCode agent
 
@@ -75,6 +76,9 @@ codemie-opencode "message"       # OpenCode agent
 codemie-claude health
 codemie-gemini health
 codemie-opencode health
+
+# Note: codemie-claude-acp doesn't have interactive mode or health check
+# It's designed to be invoked by IDEs via ACP protocol
 
 # With configuration overrides
 codemie-claude --model claude-4-5-sonnet --api-key sk-... "review code"
@@ -306,7 +310,9 @@ codemie install <agent>
 
 **Supported Agents:**
 - `claude` - Claude Code (npm-based)
+- `claude-acp` - Claude Code ACP adapter for IDE integration (npm-based)
 - `gemini` - Gemini CLI (npm-based)
+- `opencode` - OpenCode AI assistant (npm-based)
 
 ### `codemie uninstall [agent]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,10 @@
       "bin": {
         "codemie": "bin/codemie.js",
         "codemie-claude": "bin/codemie-claude.js",
+        "codemie-claude-acp": "bin/codemie-claude-acp.js",
         "codemie-code": "bin/agent-executor.js",
-        "codemie-gemini": "bin/codemie-gemini.js"
+        "codemie-gemini": "bin/codemie-gemini.js",
+        "codemie-opencode": "bin/codemie-opencode.js"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.2.0",
@@ -2158,6 +2160,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.0.5.tgz",
       "integrity": "sha512-9Hy/b9+j+mm0Bhnm8xD9B0KpBYTidroLrDHdbrHoMC2DqXoY2umvi1M3M/9D744qsMSaIMP0ZwFcy5YbqI/dGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -3407,6 +3410,7 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3516,6 +3520,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -3834,6 +3839,7 @@
       "integrity": "sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.10",
         "fflate": "^0.8.2",
@@ -3883,6 +3889,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4528,6 +4535,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4913,6 +4921,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7067,6 +7076,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.9.0.tgz",
       "integrity": "sha512-n2sJRYmM+xfJ0l3OfH8eNnIyv3nQY7L08gZQu3dw6wSdfPtKAk92L83M2NIP5SS8Cl/bsBBG3yKzEOjkx0O+7A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -8313,6 +8323,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8437,6 +8448,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8518,6 +8530,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8611,6 +8624,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8624,6 +8638,7 @@
       "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.10",
         "@vitest/mocker": "4.0.10",
@@ -8901,6 +8916,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "codemie": "./bin/codemie.js",
     "codemie-code": "./bin/agent-executor.js",
     "codemie-claude": "./bin/codemie-claude.js",
+    "codemie-claude-acp": "./bin/codemie-claude-acp.js",
     "codemie-gemini": "./bin/codemie-gemini.js",
     "codemie-opencode": "./bin/codemie-opencode.js"
   },

--- a/src/agents/__tests__/registry.test.ts
+++ b/src/agents/__tests__/registry.test.ts
@@ -12,8 +12,8 @@ describe('AgentRegistry', () => {
     it('should register all default agents', () => {
       const agentNames = AgentRegistry.getAgentNames();
 
-      // Should have all 4 default agents (codemie-code, claude, gemini, opencode)
-      expect(agentNames).toHaveLength(4);
+      // Should have all 5 default agents (codemie-code, claude, claude-acp, gemini, opencode)
+      expect(agentNames).toHaveLength(5);
     });
 
     it('should register built-in agent', () => {
@@ -43,6 +43,13 @@ describe('AgentRegistry', () => {
       expect(agent).toBeDefined();
       expect(agent?.name).toBe('opencode');
     });
+
+    it('should register Claude ACP plugin', () => {
+      const agent = AgentRegistry.getAgent('claude-acp');
+
+      expect(agent).toBeDefined();
+      expect(agent?.name).toBe('claude-acp');
+    });
   });
 
   describe('Agent Retrieval', () => {
@@ -55,7 +62,7 @@ describe('AgentRegistry', () => {
     it('should return all registered agents', () => {
       const agents = AgentRegistry.getAllAgents();
 
-      expect(agents).toHaveLength(4);
+      expect(agents).toHaveLength(5);
       expect(agents.every((agent) => agent.name)).toBe(true);
     });
 
@@ -64,6 +71,7 @@ describe('AgentRegistry', () => {
 
       expect(names).toContain(BUILTIN_AGENT_NAME);
       expect(names).toContain('claude');
+      expect(names).toContain('claude-acp');
       expect(names).toContain('gemini');
       expect(names).toContain('opencode');
     });

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -11,6 +11,7 @@ import { ClaudePluginMetadata } from '../plugins/claude/claude.plugin.js';
 import { CodeMieCodePluginMetadata } from '../plugins/codemie-code.plugin.js';
 import { GeminiPluginMetadata } from '../plugins/gemini/gemini.plugin.js';
 import { OpenCodePluginMetadata } from '../plugins/opencode/opencode.plugin.js';
+import {ClaudeAcpPluginMetadata} from "../plugins/claude/claude-acp.plugin.js";
 
 /**
  * Universal CLI builder for any agent
@@ -334,6 +335,7 @@ export class AgentCLI {
       [BUILTIN_AGENT_NAME]: CodeMieCodePluginMetadata,
       'gemini': GeminiPluginMetadata,
       'opencode': OpenCodePluginMetadata,
+      'claude-acp': ClaudeAcpPluginMetadata,
     };
     return metadataMap[this.adapter.name];
   }

--- a/src/agents/core/types.ts
+++ b/src/agents/core/types.ts
@@ -3,6 +3,12 @@
  */
 
 /**
+ * Post-install hint - simple text lines shown after installation
+ * Used to show custom setup instructions (e.g., IDE configuration)
+ */
+export type PostInstallHint = string;
+
+/**
  * Mapping types for flag transformation
  */
 export type FlagMappingType = 'flag' | 'subcommand' | 'positional';
@@ -212,6 +218,19 @@ export interface AgentMetadata {
   // === Runtime Behavior ===
   /** Declarative mapping for multiple CLI flags */
   flagMappings?: FlagMappings;
+
+  /**
+   * Silent mode - skip welcome/goodbye messages in console
+   * Used by ACP adapters where stdout is JSON-RPC protocol
+   */
+  silentMode?: boolean;
+
+  /**
+   * Custom post-install hints for IDE configuration
+   * Used instead of default "Interactive mode" / "Single task" hints
+   * For ACP adapters, shows IDE configuration examples
+   */
+  postInstallHints?: PostInstallHint[];
 
   lifecycle?: AgentLifecycle;
 

--- a/src/agents/plugins/claude/claude-acp.plugin.ts
+++ b/src/agents/plugins/claude/claude-acp.plugin.ts
@@ -1,0 +1,73 @@
+import type {AgentMetadata} from '../../core/types.js';
+import {ClaudePlugin, ClaudePluginMetadata} from './claude.plugin.js';
+
+/**
+ * Claude Code ACP Plugin Metadata
+ *
+ * Extends ClaudePluginMetadata with ACP-specific overrides.
+ * ACP (Agent Communication Protocol) adapter for Claude Code.
+ * Enables integration with editors like Zed, Emacs, Neovim via stdio JSON-RPC.
+ *
+ * Uses @zed-industries/claude-code-acp - Zed's official ACP adapter.
+ * https://github.com/zed-industries/claude-code-acp
+ */
+export const ClaudeAcpPluginMetadata: AgentMetadata = {
+  // Inherit all from Claude plugin
+  ...ClaudePluginMetadata,
+
+  // ACP-specific overrides
+  name: 'claude-acp',
+  displayName: 'Claude Code ACP',
+  description: 'Claude Code ACP adapter for editor integration (Zed, Emacs, etc.)',
+
+  // Zed's ACP adapter package (separate from Claude CLI!)
+  npmPackage: '@zed-industries/claude-code-acp',
+  cliCommand: 'claude-code-acp',
+
+  // No native installer - npm only
+  installerUrls: undefined,
+
+  // SSO config - separate clientType for analytics distinction
+  ssoConfig: {
+    enabled: true,
+    clientType: 'codemie-claude-acp'
+  },
+
+  // No flag mappings - ACP protocol handles everything via stdio
+  flagMappings: {},
+
+  // Silent mode for ACP - stdout is JSON-RPC protocol
+  silentMode: true,
+
+  // Post-install hints for IDE configuration
+  postInstallHints: [
+    'Configure in your IDE:',
+    '',
+    'Zed (~/.config/zed/settings.json):',
+    '  "agent_servers": { "claude": { "command": "codemie-claude-acp", "args": ["--profile", "work"] } }',
+    '',
+    'JetBrains (~/.jetbrains/acp.json):',
+    '  "agent_servers": { "Claude Code via CodeMie": { "command": "codemie-claude-acp", "args": ["--profile", "work"] } }',
+  ],
+};
+
+/**
+ * Claude Code ACP Plugin
+ *
+ * Extends ClaudePlugin with ACP-specific metadata.
+ * Inherits all functionality (proxy, lifecycle, analytics, session adapter).
+ */
+export class ClaudeAcpPlugin extends ClaudePlugin {
+  constructor() {
+    super();
+    // Override metadata with ACP-specific values
+    (this as any).metadata = ClaudeAcpPluginMetadata;
+  }
+
+  /**
+   * Skip version check - ACP adapter version not critical
+   */
+  async getVersion(): Promise<string | null> {
+    return null;
+  }
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,4 +1,5 @@
 import { ClaudePlugin } from './plugins/claude/claude.plugin.js';
+import { ClaudeAcpPlugin } from './plugins/claude/claude-acp.plugin.js';
 import { CodeMieCodePlugin } from './plugins/codemie-code.plugin.js';
 import { GeminiPlugin } from './plugins/gemini/gemini.plugin.js';
 import { OpenCodePlugin } from './plugins/opencode/index.js';
@@ -27,6 +28,7 @@ export class AgentRegistry {
 
     AgentRegistry.registerPlugin(new CodeMieCodePlugin());
     AgentRegistry.registerPlugin(new ClaudePlugin());
+    AgentRegistry.registerPlugin(new ClaudeAcpPlugin());
     AgentRegistry.registerPlugin(new GeminiPlugin());
     AgentRegistry.registerPlugin(new OpenCodePlugin());
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -161,12 +161,24 @@ export function createInstallCommand(): Command {
 
             // Show how to run the newly installed agent
             console.log();
-            console.log(chalk.cyan('💡 Next steps:'));
-            // Handle special case where agent name already includes 'codemie-' prefix
-            const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
-            console.log(chalk.white(`   Interactive mode:`), chalk.blueBright(command));
-            console.log(chalk.white(`   Single task:`), chalk.blueBright(`${command} --task "your task"`));
-            console.log();
+
+            // Check for custom post-install hints (for ACP adapters, IDE integrations, etc.)
+            const metadata = (agent as any).metadata;
+            if (metadata?.postInstallHints && metadata.postInstallHints.length > 0) {
+              console.log(chalk.cyan('💡 Next steps:'));
+              for (const line of metadata.postInstallHints) {
+                console.log(chalk.white(`   ${line}`));
+              }
+              console.log();
+            } else {
+              // Default hints for regular agents
+              console.log(chalk.cyan('💡 Next steps:'));
+              // Handle special case where agent name already includes 'codemie-' prefix
+              const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
+              console.log(chalk.white(`   Interactive mode:`), chalk.blueBright(command));
+              console.log(chalk.white(`   Single task:`), chalk.blueBright(`${command} --task "your task"`));
+              console.log();
+            }
           } catch (error: unknown) {
             spinner.fail(`Failed to install ${agent.displayName}`);
             throw error;


### PR DESCRIPTION
## Summary
Add Claude Code ACP plugin for IDE integration via ACP (Agent Communication Protocol).

- New `ClaudeAcpPlugin` for Zed, JetBrains, Emacs integration
- `silentMode` support for ACP stdout compatibility
- `postInstallHints` for custom IDE configuration guidance
- Session analytics via `ClaudeSessionAdapter`

## Motivation
Enable Claude Code usage in IDEs that support ACP protocol (stdio JSON-RPC). Uses Zed's `@zed-industries/claude-code-acp` adapter package.

## Changes
- `src/agents/plugins/claude/claude-acp.plugin.ts` - new plugin
- `bin/codemie-claude-acp.js` - CLI entry point
- `src/agents/core/types.ts` - add `silentMode`, `postInstallHints`
- `src/agents/core/BaseAgentAdapter.ts` - silentMode support
- `src/cli/commands/install.ts` - postInstallHints output
- `src/agents/registry.ts` - register new plugin
- Documentation updates (README, AGENTS.md, COMMANDS.md)
- Registry tests updated for new agent count

## Testing
- All 721 tests pass (`npm test`)
- Manual testing with `codemie install claude-acp`
- Verified in JetBrains IDE

## IDE Configuration Examples

**Zed** (`~/.config/zed/settings.json`):
```json
{
  "assistant": {
    "anthropic": {
      "command": "codemie-claude-acp",
      "args": ["--profile", "work"]
    }
  }
}
```

**JetBrains** (`~/.jetbrains/acp.json`):
```json
{
  "agent_servers": {
    "Claude Code via CodeMie": {
      "command": "codemie-claude-acp",
      "args": ["--profile", "work"]
    }
  }
}
```