### PR TITLE
fix(agents): ensure clean plugin installation by removing stale files

### DIFF
--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -268,7 +268,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.5');
+      expect(result.sourceVersion).toBe('1.0.6');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -281,8 +281,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.5');
-      expect(result2.installedVersion).toBe('1.0.5');
+      expect(result2.sourceVersion).toBe('1.0.6');
+      expect(result2.installedVersion).toBe('1.0.6');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -296,7 +296,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.5');
+      expect(json.version).toBe('1.0.6');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug in plugin installation where version updates would leave orphaned files from previous versions. The old implementation only copied/overwrote files but never removed files that no longer exist in the new version, leading to stale files accumulating over time.

## Changes

- **BaseExtensionInstaller**: Added `rm()` operation to delete old plugin directory before copying new version
- **Logging**: Changed to info-level logging for better installation visibility
- **Claude Plugin**: Bumped version from 1.0.5 to 1.0.6
- **Tests**: Updated version expectations to match Claude plugin v1.0.6
- **Release Skill**: Enhanced codemie-release skill with automatic version detection from conventional commits and improved release notes generation

## Impact

**Before**: Plugin updates would accumulate stale files:
- Removed files from old versions remained in installation directory
- Renamed files resulted in both old and new files existing
- Directory restructuring left orphaned folders

**After**: Clean installation on every update:
- Old installation directory is completely removed before copying new version
- No stale files, duplicate files from renames, or orphaned directories
- Reliable and predictable plugin updates

Applies to both Claude and Gemini plugins (both use BaseExtensionInstaller).

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)