### PR TITLE
fix(agents): fix duplicate metrics records caused by multiple hook invocations

### DIFF
--- a/src/agents/core/session/BaseProcessor.ts
+++ b/src/agents/core/session/BaseProcessor.ts
@@ -45,7 +45,28 @@ export interface ProcessingResult {
   /** Optional status message */
   message?: string;
   /** Optional metadata for tracking */
-  metadata?: Record<string, unknown>;
+  metadata?: {
+    recordsProcessed?: number;
+    /** Session state updates to be applied by the adapter */
+    syncUpdates?: {
+      metrics?: {
+        processedRecordIds?: string[];
+        lastProcessedTimestamp?: number;
+        totalDeltas?: number;
+        totalSynced?: number;
+        totalFailed?: number;
+      };
+      conversations?: {
+        lastSyncedMessageUuid?: string;
+        lastSyncedHistoryIndex?: number;
+        totalMessagesSynced?: number;
+        totalSyncAttempts?: number;
+        conversationId?: string;
+        lastSyncAt?: number;
+      };
+    };
+    [key: string]: unknown;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Multiple hooks (handleStop, handleSubagentStop, handleSessionEnd) can process the same session during its lifecycle. Each invocation of MetricsProcessor previously created a fresh local processedIds Set with no persistence mechanism. This caused duplicate delta records to be written to metrics files and synced to the backend, inflating token counts by 1.6-1.8x.                                                                                                                                                   
                                                                                                                                                                                                                                                                 
## Changes                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                 
**Session State-Based Deduplication:**                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                               
- Load previously processed record IDs from session metadata (SessionStore) before delta generation                                                                                                                                                            
- Pass existing processed IDs to transformMessagesToDeltas() instead of creating empty Set                                                                                                                                                                     
- Persist newly processed record IDs back to session state after processing                                                                                                                                                                                    
- Added debug logging to track loaded/saved processed record IDs                                                                                                                                                                                               
                                                                                                                                                                                                                                                               
**Architectural Improvement - Centralized Session Persistence:**                                                                                                                                                                                                   
                                                                                                                                                                                                                                                               
- Processors no longer directly update session state - they return sync updates in ProcessingResult.metadata.syncUpdates                                                                                                                                       
- Adapter handles all persistence via new applySyncUpdates() method that:                                                                                                                                                                                      
  - Collects sync updates from all processors                                                                                                                                                                                                                  
  - Merges updates into session metadata in a single batch                                                                                                                                                                                                     
  - Writes session state once per hook invocation (instead of once per processor)                                                                                                                                                                              
  - Properly handles counters (increment) vs tracking fields (latest wins)                                                                                                                                                                                     
- Better separation of concerns: processors focus on processing logic, adapter manages persistence                                                                                                                                                             
- More efficient: reduces file I/O from N writes (one per processor) to 1 write per hook                                                                                                                                                                       
                                                                                                                                                                                                                                                               
**Key Implementation Details:**                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                               
- sessionMetadata.sync.metrics.processedRecordIds acts as persistent cache of processed message IDs                                                                                                                                                            
- Eliminates need to read entire metrics JSONL file for duplicate detection                                                                                                                                                                                    
- Session state checked on processor entry (via adapter), updated on processor exit (via applySyncUpdates)                                                                                                                                                     
- Base processor interface updated with ProcessingResult.metadata.syncUpdates contract (src/agents/core/session/BaseProcessor.ts:48-68)                                                                                                                        
                                                                                                                                                                                                                                                                 
 ## Impact                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                 
Before: Hook 1 writes 8 deltas → Hook 2 writes 48 deltas (including 8 duplicates) → 56 records, 21,438 tokens sent                                                                                                                                             
                                                                                                                                                                                                                                                               
After: Hook 1 writes 8 deltas → Hook 2 writes 40 new deltas (8 duplicates filtered) → 48 records, 13,136 tokens sent                                                                                                                                           
                                                                                                                                                                                                                                                               
Additional Benefits:                                                                                                                                                                                                                                           
- Cleaner architecture with proper separation of concerns                                                                                                                                                                                                      
- Reduced file I/O operations per hook invocation                                                                                                                                                                                                              
- Easier to test processors in isolation (no direct session store dependencies)                                                                                                                                                                                
- Consistent sync update pattern for all processor types (metrics, conversations, analytics)      
