### PR TITLE
fix(agents): use npm install for claude-acp instead of native installer

### DIFF
--- a/src/agents/plugins/claude/claude-acp.plugin.ts
+++ b/src/agents/plugins/claude/claude-acp.plugin.ts
@@ -1,5 +1,7 @@
 import type {AgentMetadata} from '../../core/types.js';
 import {ClaudePlugin, ClaudePluginMetadata} from './claude.plugin.js';
+import * as npm from '../../../utils/processes.js';
+import {NpmError} from '../../../utils/errors.js';
 
 /**
  * Claude Code ACP Plugin Metadata
@@ -69,5 +71,27 @@ export class ClaudeAcpPlugin extends ClaudePlugin {
    */
   async getVersion(): Promise<string | null> {
     return null;
+  }
+
+  /**
+   * Install via npm (override native installation from ClaudePlugin)
+   *
+   * ClaudeAcpPlugin uses @zed-industries/claude-code-acp which is npm-only.
+   * There's no native installer for this package.
+   */
+  async install(): Promise<void> {
+    const npmPackage = this.metadata.npmPackage;
+    if (!npmPackage) {
+      throw new Error(`${this.displayName} has no npm package configured`);
+    }
+
+    try {
+      await npm.installGlobal(npmPackage);
+    } catch (error: unknown) {
+      if (error instanceof NpmError) {
+        throw new Error(`Failed to install ${this.displayName}: ${error.message}`);
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix `codemie install claude-acp` failing because `ClaudeAcpPlugin` inherits `install()` from `ClaudePlugin` which uses native installation, but`@zed-industries/claude-code-acp` is an npm-only package with no native installer.

<img width="769" height="455" alt="image" src="https://github.com/user-attachments/assets/3e7eab06-3e87-4848-a1df-333023f0d04a" />

## Changes

- Override `install()` method in `ClaudeAcpPlugin` to use `npm.installGlobal()` instead of inherited native installation

## Impact

| Before | After |
|--------|-------|
| `Failed to install agent claude-acp: No installer URLs configured for native installation` | `✔ Claude Code ACP installed successfully` |

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
