### PR TITLE
feat(cli): add -s/--silent flag to suppress non-essential output

### DIFF
--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -57,6 +57,7 @@ export class AgentCLI {
       .name(programName)
       .description(`CodeMie ${this.adapter.displayName} - ${this.adapter.description}`)
       .version(this.version)
+      .option('-s, --silent', 'Enable silent mode')
       .option('--profile <name>', 'Use specific provider profile')
       .option('--provider <provider>', 'Override provider (ai-run-sso, litellm, ollama)')
       .option('-m, --model <model>', 'Override model')
@@ -120,6 +121,14 @@ export class AgentCLI {
         this.displayWindowsPathGuidance();
 
         process.exit(1);
+      }
+
+      // Apply silent mode from CLI flag (if provided)
+      if (options.silent) {
+        // Type-safe check: ensure adapter has setSilentMode method
+        if ('setSilentMode' in this.adapter && typeof this.adapter.setSilentMode === 'function') {
+          this.adapter.setSilentMode(true);
+        }
       }
 
       // Load configuration with CLI overrides
@@ -330,7 +339,7 @@ export class AgentCLI {
   ): string[] {
     const agentArgs = [...args];
     // Config-only options (not passed to agent, handled by CodeMie CLI)
-    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout', 'model'];
+    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout', 'model', 'silent'];
 
     for (const [key, value] of Object.entries(options)) {
       // Skip config-only options (handled by CodeMie CLI layer)

--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -32,9 +32,22 @@ import inquirer from 'inquirer';
  */
 export abstract class BaseAgentAdapter implements AgentAdapter {
   protected proxy: CodeMieProxy | null = null;
+  protected metadata: AgentMetadata;
 
-  constructor(protected metadata: AgentMetadata) {}
+  constructor(metadata: AgentMetadata) {
+    // Clone metadata to allow runtime overrides (e.g., CLI flags)
+    this.metadata = { ...metadata };
+  }
 
+  /**
+   * Override silent mode at runtime
+   * Used by CLI to apply --silent flag
+   *
+   * @param enabled - Whether to enable silent mode
+   */
+  setSilentMode(enabled: boolean): void {
+    this.metadata.silentMode = enabled;
+  }
 
   /**
    * Get metrics configuration for this agent

--- a/src/agents/core/__tests__/BaseAgentAdapter.test.ts
+++ b/src/agents/core/__tests__/BaseAgentAdapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { BaseAgentAdapter } from '../BaseAgentAdapter.js';
+import type { AgentMetadata } from '../types.js';
+
+/**
+ * Test adapter that extends BaseAgentAdapter
+ * Used to test protected methods and metadata access
+ */
+class TestAdapter extends BaseAgentAdapter {
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  // Expose protected metadata for testing
+  getMetadata(): AgentMetadata {
+    return this.metadata;
+  }
+
+  // Implement required abstract methods (no-ops for testing)
+  async run(): Promise<void> {
+    // No-op for testing
+  }
+}
+
+describe('BaseAgentAdapter', () => {
+  describe('setSilentMode', () => {
+    it('should set silentMode to true when enabled', () => {
+      const metadata: AgentMetadata = {
+        name: 'test',
+        displayName: 'Test Agent',
+        description: 'Test agent for unit testing',
+        npmPackage: null,
+        cliCommand: null,
+        envMapping: {},
+        supportedProviders: ['openai'],
+        silentMode: false // Start as false
+      };
+
+      const adapter = new TestAdapter(metadata);
+
+      // Initial state
+      expect(adapter.getMetadata().silentMode).toBe(false);
+
+      // Call setter
+      adapter.setSilentMode(true);
+
+      // Verify it changed
+      expect(adapter.getMetadata().silentMode).toBe(true);
+    });
+
+    it('should set silentMode to false when disabled', () => {
+      const metadata: AgentMetadata = {
+        name: 'test',
+        displayName: 'Test Agent',
+        description: 'Test agent for unit testing',
+        npmPackage: null,
+        cliCommand: null,
+        envMapping: {},
+        supportedProviders: ['openai'],
+        silentMode: true // Start as true
+      };
+
+      const adapter = new TestAdapter(metadata);
+
+      // Initial state
+      expect(adapter.getMetadata().silentMode).toBe(true);
+
+      // Call setter
+      adapter.setSilentMode(false);
+
+      // Verify it changed
+      expect(adapter.getMetadata().silentMode).toBe(false);
+    });
+
+    it('should not affect original metadata object (verify cloning)', () => {
+      const originalMetadata: AgentMetadata = {
+        name: 'test',
+        displayName: 'Test Agent',
+        description: 'Test agent for unit testing',
+        npmPackage: null,
+        cliCommand: null,
+        envMapping: {},
+        supportedProviders: ['openai'],
+        silentMode: false
+      };
+
+      const adapter = new TestAdapter(originalMetadata);
+
+      // Modify via setter
+      adapter.setSilentMode(true);
+
+      // Original should be unchanged (verify shallow copy worked)
+      expect(originalMetadata.silentMode).toBe(false);
+      expect(adapter.getMetadata().silentMode).toBe(true);
+    });
+  });
+
+  describe('constructor metadata cloning', () => {
+    it('should create a shallow copy of metadata', () => {
+      const envMapping = { apiKey: ['TEST_KEY'] };
+      const lifecycle = {
+        beforeRun: async (env: NodeJS.ProcessEnv) => env
+      };
+
+      const metadata: AgentMetadata = {
+        name: 'test',
+        displayName: 'Test Agent',
+        description: 'Test agent for unit testing',
+        npmPackage: null,
+        cliCommand: null,
+        envMapping,
+        supportedProviders: ['openai'],
+        lifecycle
+      };
+
+      const adapter = new TestAdapter(metadata);
+
+      // Top-level object should be different (cloned)
+      expect(adapter.getMetadata()).not.toBe(metadata);
+
+      // Nested objects should be same reference (shallow copy)
+      expect(adapter.getMetadata().envMapping).toBe(envMapping);
+      expect(adapter.getMetadata().lifecycle).toBe(lifecycle);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add global `-s/--silent` CLI parameter to enable silent mode for all agents (claude, gemini, codemie-code).

When enabled, suppresses:
- Welcome ASCII art and messages
- Version warning prompts
- Update available prompts
- Shutdown messages
- Goodbye messages

## Implementation Details

### Approach: Setter Method on Adapter (Option 3)

**Why this approach:**
- ✅ Explicit, type-safe API via public `setSilentMode(boolean)` method
- ✅ No breaking changes to existing code
- ✅ Backward compatible with plugins that have static `silentMode: true` in metadata
- ✅ Metadata mutation controlled through well-defined public method

### Changes

1. **`src/agents/core/AgentCLI.ts`**:
   - Added `-s, --silent` CLI option (line 60)
   - Call `setSilentMode(true)` when flag is present (lines 126-132)
   - Added `'silent'` to `configOnlyOptions` to prevent passing to agent executables (line 342)

2. **`src/agents/core/BaseAgentAdapter.ts`**:
   - Made metadata mutable by cloning in constructor: `this.metadata = { ...metadata }`
   - Added public `setSilentMode(enabled: boolean)` method

3. **`src/agents/core/__tests__/BaseAgentAdapter.test.ts`** (NEW):
   - 4 unit tests for `setSilentMode()` functionality
   - Tests verify: enable/disable, original metadata unchanged (cloning), shallow copy

## Test Results

✅ **All tests passing**: 1414 tests across 64 test files
✅ **Build successful**: No TypeScript compilation errors
✅ **New tests**: 4 tests added for BaseAgentAdapter

## Usage

```bash
# Enable silent mode (long form)
codemie-claude --silent

# Enable silent mode (short form)
codemie-gemini -s

# Works with all agents
codemie-code -s --task "hello"
```

## Backward Compatibility

- ✅ Existing plugins with `silentMode: true` in metadata continue to work
- ✅ No breaking API changes
- ✅ All existing tests pass
- ✅ Flag is consumed by CodeMie CLI and NOT passed to agent executables

## Test plan

- [x] Build project successfully
- [x] All unit tests pass (1414/1414)
- [x] Help text shows `-s, --silent` option
- [x] Flag does not get passed to underlying agent executable
- [x] setSilentMode() correctly mutates metadata
- [x] Original metadata unchanged (cloning verified)