### PR TITLE
fix(cli): display raw log lines without transformation

### DIFF
--- a/src/cli/commands/log/formatter.ts
+++ b/src/cli/commands/log/formatter.ts
@@ -38,21 +38,12 @@ export class LogFormatter {
 
   /**
    * Format a single log entry
+   * Returns the raw log line exactly as written to the file
    */
   private formatLogEntry(entry: LogEntry): string {
-    const timestamp = this.formatTimestamp(entry.timestamp);
-    const level = this.formatLevel(entry.level);
-    const agent = this.colorize(chalk.cyan(`[${entry.agent}]`));
-
-    if (this.format.verbose) {
-      // Verbose format includes session ID and profile
-      const sessionId = entry.sessionId.substring(0, 8);
-      const profile = entry.profile ? this.colorize(chalk.magenta(`[${entry.profile}]`)) : '';
-      return `${timestamp} ${level} ${agent} ${this.colorize(chalk.dim(`[${sessionId}]`))} ${profile} ${entry.message}`.trim();
-    } else {
-      // Compact format
-      return `${timestamp} ${level} ${agent} ${entry.message}`;
-    }
+    // Return raw line without transformation to preserve all metadata
+    // (timestamp, level, agent, session ID, profile, context like [hook], etc.)
+    return entry.rawLine;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the `codemie log` command to display log entries exactly as written to the file, preserving all metadata.

**Problem:**
- Log command was parsing and reconstructing entries, causing:
  - Loss of context tags like `[hook]`, `[hook:normalize]`, etc.
  - Incorrect agent names (showing "unknown" instead of actual agent)
  - Truncated session IDs
  - Missing profile names

**Solution:**
- Modified `LogFormatter.formatLogEntry()` to return `entry.rawLine` directly
- Removed transformation logic that was reconstructing log entries from parsed fields
- All metadata now preserved: timestamp, level, agent, session ID, profile, context tags

**Before:**
```
2026-02-12T18:40:49.175Z DEBUG [unknown] .....
```

**After:**
```
[2026-02-12T19:09:15.884Z] [INFO] [claude] [0ed6f983-f15e-430c-95da-cb0d49734e5e] [codemie-sso] [hook:normalize] No mapping defined for agent claude, using event name as-is
```

## Test Plan

- [x] Build successful (TypeScript compilation)
- [x] Linting passed (0 warnings)
- [x] Manual testing: `codemie log --lines 10` shows raw entries with all metadata
- [x] Filters tested: `--grep`, `--agent`, `--level`, `--last` all work correctly
- [x] Verbose mode tested: `-v` flag works as expected
- [x] All metadata preserved: timestamp, level, agent, session ID, profile, context tags