### PR TITLE
fix(agents): correct isInstalled check for Claude Code ACP plugin

### DIFF
--- a/src/agents/plugins/claude/claude-acp.plugin.ts
+++ b/src/agents/plugins/claude/claude-acp.plugin.ts
@@ -76,6 +76,17 @@ export class ClaudeAcpPlugin extends ClaudePlugin {
   }
 
   /**
+   * Check if claude-code-acp binary is installed.
+   * Overrides ClaudePlugin.isInstalled() which hardcodes a check for
+   * ~/.local/bin/claude (Claude Code native binary) - wrong for ACP.
+   * Uses BaseAgentAdapter's implementation that checks claude-code-acp in PATH.
+   */
+  async isInstalled(): Promise<boolean> {
+    const { BaseAgentAdapter } = await import('../../core/BaseAgentAdapter.js');
+    return BaseAgentAdapter.prototype.isInstalled.call(this);
+  }
+
+  /**
    * Skip version check - ACP adapter version not critical
    */
   async getVersion(): Promise<string | null> {


### PR DESCRIPTION
## Summary

`ClaudeAcpPlugin` inherited `ClaudePlugin.isInstalled()` which hardcodes a check for `~/.local/bin/claude` (Claude Code's native binary path). This caused the ACP plugin to always report as "installed" whenever Claude Code itself was installed natively, even if `@zed-industries/claude-code-acp` was never installed.

Fixes https://github.com/codemie-ai/codemie-code/issues/149

## Changes

- Added `isInstalled()` override to `ClaudeAcpPlugin` that calls `BaseAgentAdapter.prototype.isInstalled.call(this)` — correctly checks for `claude-code-acp` binary in PATH instead of `~/.local/bin/claude`
- Follows the same bypass pattern already used by `install()` in the same class

## Impact

**Before**: `codemie doctor` showed `✓ Claude Code ACP` and `codemie install claude-acp` reported "already installed" even when the package was never installed → runtime crash: `spawn claude-code-acp ENOENT`

**After**: `isInstalled()` correctly returns `false` when `claude-code-acp` binary is missing, so users get the actionable "not installed / run `codemie install claude-acp`" message instead of a confusing ENOENT spawn failure

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)