### PR TITLE
fix(providers): align CodeMieUserInfo interface with snake_case API response

### DIFF
--- a/src/providers/plugins/sso/sso.http-client.ts
+++ b/src/providers/plugins/sso/sso.http-client.ts
@@ -16,7 +16,7 @@ export interface CodeMieUserInfo {
   username: string;
   isAdmin: boolean;
   applications: string[];
-  applicationsAdmin: string[];
+  applications_admin: string[];
   picture: string;
   knowledgeBases: string[];
   userType?: string;
@@ -144,7 +144,7 @@ export async function fetchCodeMieUserInfo(
   const userInfo = JSON.parse(response.data) as CodeMieUserInfo;
 
   // Validate response structure
-  if (!userInfo || !Array.isArray(userInfo.applications) || !Array.isArray(userInfo.applicationsAdmin)) {
+  if (!userInfo || !Array.isArray(userInfo.applications) || !Array.isArray(userInfo.applications_admin)) {
     throw new Error('Invalid user info response: missing applications arrays');
   }
 

--- a/src/providers/plugins/sso/sso.setup-steps.ts
+++ b/src/providers/plugins/sso/sso.setup-steps.ts
@@ -92,7 +92,7 @@ export const SSOSetupSteps: ProviderSetupSteps = {
 
       // Merge applications and applicationsAdmin arrays (deduplicated)
       const applications = userInfo.applications || [];
-      const applicationsAdmin = userInfo.applicationsAdmin || [];
+      const applicationsAdmin = userInfo.applications_admin || [];
       const allProjects = [...new Set([...applications, ...applicationsAdmin])];
 
       // Validate that user has at least one project


### PR DESCRIPTION
## Summary

Fixes `codemie setup` failing after successful SSO authentication with:
`✗ Project selection failed: Invalid user info response: missing applications arrays`

The `/v1/user` API returns `applications_admin` (snake_case), but the TypeScript interface declared it as `applicationsAdmin` (camelCase). Since `JSON.parse` does not transform field names, the field was always `undefined`, causing validation to fail.

## Changes

- Renamed `applicationsAdmin` → `applications_admin` in `CodeMieUserInfo` interface
- Updated validation check to use `applications_admin`
- Updated consumer in `sso.setup-steps.ts` to read `applications_admin`

## Impact

Before: Setup always failed at project selection step for SSO users
After: Project list is correctly populated from both `applications` and `applications_admin` fields

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)