### PR TITLE
fix(agents): support --profile flag for codemie-code and codemie-opencode

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -681,10 +681,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       await executeOnSessionEnd(this, this.metadata.lifecycle, this.metadata.name, 1, env);
 
       // Clean up proxy on error (triggers final sync)
-      if (this.proxy) {
-        await this.proxy.stop();
-        this.proxy = null;
-      }
+      await cleanup();
 
       // Lifecycle hook: afterRun (provider-aware)
       await executeAfterRun(this, this.metadata.lifecycle, this.metadata.name, 1, env);


### PR DESCRIPTION
## Summary

Fixes `--profile` being ignored when running `node bin/agent-executor.js --profile <name>` or `node bin/codemie-opencode.js --profile <name>`. The selected profile's model, provider, and base URL were silently discarded — the default profile was always used instead. `codemie-claude` worked correctly because Claude reads env vars directly; codemie-code and codemie-opencode build their config dynamically in `beforeRun`.

## Changes

- **`codemie-code.plugin.ts`**: Fix `cliCommand` fallback from `'codemie'` (infinite loop) to `null` (triggers built-in handler). Add `agentConfig` parameter to `customRunHandler` so it can load the correct profile. `isInstalled()` now always returns `true` — the built-in LangGraph handler is always available as fallback.
- **`BaseAgentAdapter.ts`**: Add the missing execution path for `isBuiltIn + customRunHandler + !cliCommand` — the handler was previously unreachable dead code. Shared `cleanup` function hoisted above both the built-in and spawn paths.
- **`opencode-model-configs.ts`**: Add `qwen.qwen3-coder-30b-a3b-v1` and `qwen.qwen3-coder-480b-a35b-v1` model configs. Without these entries, `OPENCODE_CONFIG_CONTENT` referenced a model absent from the `codemie-proxy.models` list, causing opencode to fall back to the global `~/.config/opencode/` model (Sonnet 4.5) regardless of profile.
- **`codemie-code-plugin.test.ts`**: Update two `isInstalled` test expectations from `false` → `true` to match the new always-available semantics.

## Impact

Before: `node bin/agent-executor.js --profile jwt-bearer` → opencode started with default profile model (e.g. Sonnet 4.5)
After: `node bin/agent-executor.js --profile jwt-bearer` → opencode starts with the jwt-bearer profile model (e.g. `qwen.qwen3-coder-480b-a35b-v1`)

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)