### PR TITLE
fix(agents): fix built-in handler arg corruption and opencode run format

### DIFF
--- a/src/agents/plugins/opencode/opencode.plugin.ts
+++ b/src/agents/plugins/opencode/opencode.plugin.ts
@@ -306,7 +306,9 @@ export const OpenCodePluginMetadata: AgentMetadata = {
           if (i > 0 && (arr[i - 1] === '-m' || arr[i - 1] === '--message')) return false;
           return true;
         });
-        return ['run', '-m', taskValue, ...otherArgs];
+        // Message is a positional arg: `opencode run <message>`
+        // Note: -m in upstream opencode-ai means --model, NOT --message.
+        return ['run', taskValue, ...otherArgs];
       }
       return args;
     },


### PR DESCRIPTION
## Summary

Fixes three bugs in the `codemie-code` built-in handler path and one bug in the `opencode` plugin's `--task` handling. None of these affect the external binary path when the whitelabel binary is installed.

## Changes

- **`BaseAgentAdapter` — pass original args to `customRunHandler`**: `enrichArgs` transforms args into OpenCode binary subcommand format (`--task foo` → `['run', 'foo']`). The built-in handler was receiving this already-transformed array and could no longer find `--task`, causing the task text to be silently dropped and the prompt `'run foo'` to be executed instead. Fix: pass the original `args` function parameter (pre-enrichArgs) to `customRunHandler`.

- **`BaseAgentAdapter` — remove redundant `Object.assign`**: The built-in handler block had a second `Object.assign(process.env, env)` that was already performed unconditionally at line 430 before the branch; removed the duplicate.

- **`codemie-code` plugin — remove dead `options.X` fallbacks**: `customRunHandler` is always invoked with `options = {}`, so `options.debug`, `options.task` etc. were always `undefined`. Removed the dead fallbacks; pure args-based parsing is now the sole source of truth. Renamed parameter to `_options`.

- **`codemie-code` plugin — improve binary-absent diagnostics**: `isInstalled()` was logging at `debug` level when the whitelabel binary was not found, so the absence was invisible in normal runs. Upgraded to `logger.warn` in both absent-binary branches. Also updated stale log messages from "LangGraph implementation" to "built-in CodeMieCode handler".

- **`opencode` plugin — fix `enrichArgs` message format**: `opencode run -m <task>` was sent to the upstream `opencode-ai` binary. In current opencode-ai, `-m` means `--model`, not `--message`. The task text was interpreted as a model name, and `run` received no message, producing "You must provide a message or a command". Fix: use positional format `['run', taskValue, ...otherArgs]`, matching both the upstream binary's API (`opencode run [message..]`) and the `codemie-code` plugin's own enrichArgs.

## Impact

- `bin/codemie-opencode.js --task "..."` now correctly sends the message to the upstream opencode-ai binary.
- Built-in CodeMieCode handler now correctly parses `--task`, `--debug`, `--plan`, `--plan-only` when no whitelabel binary is installed.
- Missing binary now emits a visible `warn`-level log rather than a silent `debug` entry.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)