### PR TITLE
fix(providers): support applicationsAdmin camelCase fallback in SSO user info

### DIFF
--- a/src/providers/plugins/sso/sso.http-client.ts
+++ b/src/providers/plugins/sso/sso.http-client.ts
@@ -17,6 +17,7 @@ export interface CodeMieUserInfo {
   isAdmin: boolean;
   applications: string[];
   applications_admin: string[];
+  applicationsAdmin?: string[];
   picture: string;
   knowledgeBases: string[];
   userType?: string;
@@ -192,6 +193,12 @@ export async function fetchCodeMieUserInfo(
 
   // Parse response
   const userInfo = JSON.parse(response.data) as CodeMieUserInfo;
+
+  // Normalize applications_admin: support both snake_case and camelCase variants
+  // applications_admin has higher priority; fall back to applicationsAdmin if missing
+  if (!Array.isArray(userInfo.applications_admin) && Array.isArray(userInfo.applicationsAdmin)) {
+    userInfo.applications_admin = userInfo.applicationsAdmin;
+  }
 
   // Validate response structure
   if (!userInfo || !Array.isArray(userInfo.applications) || !Array.isArray(userInfo.applications_admin)) {


### PR DESCRIPTION
## Summary

The SSO `/v1/user` endpoint may return admin applications under either `applications_admin` (snake_case) or `applicationsAdmin` (camelCase). This PR ensures both variants are handled correctly.

## Changes

- Added optional `applicationsAdmin?: string[]` field to `CodeMieUserInfo` interface to accept the camelCase API variant
- Added normalization logic in `fetchCodeMieUserInfo`: if `applications_admin` is absent and `applicationsAdmin` is present, copy `applicationsAdmin` into `applications_admin` before validation
- `applications_admin` retains higher priority — when both fields are present, `applications_admin` is used as-is

## Impact

Before: requests from SSO instances returning `applicationsAdmin` would throw `Invalid user info response: missing applications arrays`.

After: both `applications_admin` and `applicationsAdmin` are accepted; the value is always normalized to `applications_admin` for downstream consumers.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)