### PR TITLE
feat(agents): add extensions scan for session metrics

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -1,4 +1,4 @@
-import { AgentMetadata, AgentAdapter, AgentConfig, MCPConfigSummary, VersionCompatibilityResult } from './types.js';
+import { AgentMetadata, AgentAdapter, AgentConfig, MCPConfigSummary, ExtensionsScanSummary, VersionCompatibilityResult } from './types.js';
 import * as npm from '../../utils/processes.js';
 import { NpmError, createErrorContext } from '../../utils/errors.js';
 import { exec } from '../../utils/processes.js';
@@ -18,6 +18,7 @@ import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { resolveHomeDir } from '../../utils/paths.js';
 import { getMCPConfigSummary as getMCPConfigSummaryUtil } from '../../utils/mcp-config.js';
+import { getExtensionsScanSummary } from '../../utils/extensions-scan.js';
 import {
   executeOnSessionStart,
   executeBeforeRun,
@@ -71,6 +72,17 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
    */
   async getMCPConfigSummary(cwd: string): Promise<MCPConfigSummary> {
     return getMCPConfigSummaryUtil(this.metadata.mcpConfig, cwd);
+  }
+
+  /**
+   * Get extensions scan summary for session metrics
+   * Counts agents/commands/skills/hooks/rules at project and global scopes
+   *
+   * @param cwd - Current working directory
+   * @returns Extensions scan summary with counts per scope
+   */
+  async getExtensionsSummary(cwd: string): Promise<ExtensionsScanSummary> {
+    return getExtensionsScanSummary(this.metadata.extensionsConfig, cwd);
   }
 
   get name(): string {

--- a/src/agents/core/types.ts
+++ b/src/agents/core/types.ts
@@ -284,6 +284,13 @@ export interface AgentMetadata {
    * Agent-specific locations for MCP config files
    */
   mcpConfig?: AgentMCPConfig;
+
+  // === Extensions Configuration ===
+  /**
+   * Agent-specific extensions directory paths
+   * Defines where to find agents/commands/skills/hooks/rules for this agent
+   */
+  extensionsConfig?: AgentExtensionsConfig;
 }
 
 /**
@@ -351,6 +358,82 @@ export interface MCPConfigSummary {
   projectServerNames: string[];
   /** Server names in user scope */
   userServerNames: string[];
+}
+
+/**
+ * Agent-specific extensions directory configuration
+ * Defines where agents/commands/skills/hooks/rules live for this agent
+ *
+ * Supports '~/' prefix for home-relative paths and relative paths from cwd
+ */
+export interface AgentExtensionsConfig {
+  /**
+   * Project-level extensions directory (relative to cwd)
+   * Example: '.claude' → scans {cwd}/.claude/{agents,commands,skills,hooks,rules}/
+   */
+  project?: string;
+
+  /**
+   * Global extensions directory (user-level, across all projects)
+   * Example: '~/.claude' → scans ~/.claude/{agents,commands,skills,hooks,rules}/
+   */
+  global?: string;
+
+  /**
+   * Exact filename that represents one skill entry (case-insensitive match)
+   * When set, only files with this name are counted as skills (e.g., 'SKILL.md' for Claude)
+   * When unset, all .md files in the skills/ directory are counted
+   * Example: Claude uses subdirectory-per-skill with a 'SKILL.md' entry file
+   */
+  skillsEntryFile?: string;
+}
+
+/**
+ * Extension counts for a single .claude/ scope directory
+ */
+export interface ExtensionsCount {
+  /** Agent definition files (.md) in agents/ */
+  agents: number;
+  /** Command definition files (.md) in commands/ */
+  commands: number;
+  /** Skill definition files (.md) in skills/ */
+  skills: number;
+  /** Hook scripts (.sh/.js/.py/.ts) in hooks/ */
+  hooks: number;
+  /** Rule definition files (.md) in rules/ */
+  rules: number;
+}
+
+/**
+ * Extension names for a single scope directory
+ * Mirrors MCPConfigSummary's per-scope server name arrays
+ */
+export interface ExtensionsNames {
+  /** Agent names (.md filenames without extension) in agents/ */
+  agents: string[];
+  /** Command names (.md filenames without extension) in commands/ */
+  commands: string[];
+  /** Skill names (directory names for SKILL.md pattern, or .md filenames) in skills/ */
+  skills: string[];
+  /** Hook filenames (.sh/.js/.py/.ts) in hooks/ */
+  hooks: string[];
+  /** Rule names (.md filenames without extension) in rules/ */
+  rules: string[];
+}
+
+/**
+ * Extensions scan result covering project and global scopes
+ * Used for session start metrics
+ */
+export interface ExtensionsScanSummary {
+  /** Extension counts in {cwd}/.claude/ (project-specific, version controlled) */
+  project: ExtensionsCount;
+  /** Extension counts in ~/.claude/ (user-level, all projects) */
+  global: ExtensionsCount;
+  /** Extension names in {cwd}/.claude/ — mirrors MCP's per-scope server name arrays */
+  projectNames: ExtensionsNames;
+  /** Extension names in ~/.claude/ — mirrors MCP's per-scope server name arrays */
+  globalNames: ExtensionsNames;
 }
 
 /**
@@ -543,6 +626,15 @@ export interface AgentAdapter {
    * @returns MCP configuration summary
    */
   getMCPConfigSummary?(cwd: string): Promise<MCPConfigSummary>;
+
+  /**
+   * Get extensions scan summary for session metrics
+   * Returns counts of agents/commands/skills/hooks/rules at project and global scopes
+   *
+   * @param cwd - Current working directory
+   * @returns Extensions scan summary
+   */
+  getExtensionsSummary?(cwd: string): Promise<ExtensionsScanSummary>;
 
   /**
    * Install specific version of agent (optional, for version-managed agents)

--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -105,6 +105,16 @@ export const ClaudePluginMetadata: AgentMetadata = {
     excludeErrorsFromTools: ['Bash'],
   },
 
+  // Extensions configuration for Claude Code
+  // - project: {cwd}/.claude/ (project-specific, version controlled)
+  // - global: ~/.claude/ (user-level, available across all projects)
+  // - skillsEntryFile: each skill is a subdirectory with a SKILL.md entry file
+  extensionsConfig: {
+    project: '.claude',
+    global: '~/.claude',
+    skillsEntryFile: 'SKILL.md',
+  },
+
   // MCP configuration paths for Claude Code
   // - Local: ~/.claude.json → projects[cwd].mcpServers (project-specific, private)
   // - Project: .mcp.json → mcpServers (shared with team)

--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.9"
+  "version": "1.0.10"
 }

--- a/src/agents/plugins/claude/plugin/hooks/hooks.json
+++ b/src/agents/plugins/claude/plugin/hooks/hooks.json
@@ -101,7 +101,12 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": ["~/.codemie/claude-plugin/scripts/bash/rtk-auto-wrapper.sh"]
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.codemie/claude-plugin/scripts/bash/rtk-auto-wrapper.sh"
+          }
+        ]
       }
     ]
   }

--- a/src/agents/plugins/gemini/gemini.plugin.ts
+++ b/src/agents/plugins/gemini/gemini.plugin.ts
@@ -65,6 +65,17 @@ const metadata = {
     settings: 'settings.json'
   },
 
+  // Extensions configuration for Gemini CLI
+  // - project: {cwd}/.gemini/ (shared with team, version controlled)
+  // - global: ~/.gemini/ (user-level, available across all workspaces)
+  // - agents: .gemini/agents/*.md and ~/.gemini/agents/*.md
+  // - skills: each skill is a subdirectory with a SKILL.md entry file
+  extensionsConfig: {
+    project: '.gemini',
+    global: '~/.gemini',
+    skillsEntryFile: 'SKILL.md',
+  },
+
   // MCP configuration paths for Gemini CLI
   // - User: ~/.gemini/settings.json → mcpServers (available across all projects)
   // - Project: .gemini/settings.json → mcpServers (project-specific)

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { logger } from '../../utils/logger.js';
 import { AgentRegistry } from '../../agents/registry.js';
 import { getSessionPath, getSessionMetricsPath, getSessionConversationPath } from '../../agents/core/session/session-config.js';
-import type { BaseHookEvent, HookTransformer, MCPConfigSummary } from '../../agents/core/types.js';
+import type { BaseHookEvent, HookTransformer, MCPConfigSummary, ExtensionsScanSummary } from '../../agents/core/types.js';
 import type { ProcessingContext } from '../../agents/core/session/BaseProcessor.js';
 
 /**
@@ -717,16 +717,31 @@ async function sendSessionStartMetrics(event: SessionStartEvent, sessionId: stri
     // Determine working directory
     const workingDirectory = event.cwd || process.cwd();
 
-    // Detect MCP servers using agent-specific configuration (non-blocking)
+    // Detect MCP servers and extensions in parallel (non-blocking)
     let mcpSummary: MCPConfigSummary | undefined;
+    let extensionsSummary: ExtensionsScanSummary | undefined;
     try {
       const agent = AgentRegistry.getAgent(agentName);
-      if (agent?.getMCPConfigSummary) {
-        mcpSummary = await agent.getMCPConfigSummary(workingDirectory);
+      const [mcp, ext] = await Promise.allSettled([
+        agent?.getMCPConfigSummary ? agent.getMCPConfigSummary(workingDirectory) : Promise.resolve(undefined),
+        agent?.getExtensionsSummary ? agent.getExtensionsSummary(workingDirectory) : Promise.resolve(undefined),
+      ]);
+
+      if (mcp.status === 'fulfilled' && mcp.value) {
+        mcpSummary = mcp.value;
         logger.debug('[hook:SessionStart] MCP detection', { total: mcpSummary.totalServers });
+      } else if (mcp.status === 'rejected') {
+        logger.debug('[hook:SessionStart] MCP detection failed', mcp.reason);
+      }
+
+      if (ext.status === 'fulfilled' && ext.value) {
+        extensionsSummary = ext.value;
+        logger.debug('[hook:SessionStart] Extensions scan', { project: ext.value.project, global: ext.value.global });
+      } else if (ext.status === 'rejected') {
+        logger.debug('[hook:SessionStart] Extensions scan failed', ext.reason);
       }
     } catch (error) {
-      logger.debug('[hook:SessionStart] MCP detection failed, continuing without MCP data', error);
+      logger.debug('[hook:SessionStart] Setup scan failed, continuing without scan data', error);
     }
 
     // Load SSO credentials if not provided in config
@@ -787,8 +802,9 @@ async function sendSessionStartMetrics(event: SessionStartEvent, sessionId: stri
       },
       workingDirectory,
       status,
-      undefined,   // error
-      mcpSummary   // MCP configuration summary
+      undefined,          // error
+      mcpSummary,         // MCP configuration summary
+      extensionsSummary   // Extensions scan summary
     );
 
     logger.info('[hook:SessionStart] Session start metrics sent successfully');

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
@@ -17,7 +17,7 @@
 
 import type { SessionMetric, MetricsApiConfig, MetricsSyncResponse, MetricsApiError } from './metrics-types.js';
 import type { Session } from '../../../../../../agents/core/session/types.js';
-import type { MCPConfigSummary } from '../../../../../../agents/core/types.js';
+import type { MCPConfigSummary, ExtensionsScanSummary } from '../../../../../../agents/core/types.js';
 import { logger } from '../../../../../../utils/logger.js';
 import { detectGitBranch } from '../../../../../../utils/processes.js';
 import { CODEMIE_ENDPOINTS } from '../../../sso.http-client.js';
@@ -244,13 +244,15 @@ export class MetricsSender {
    * @param status - Session start status object with status and optional reason
    * @param error - Optional error information (required if status=failed)
    * @param mcpSummary - Optional MCP configuration summary
+   * @param extensionsSummary - Optional extensions scan summary (project + global scopes)
    */
   async sendSessionStart(
     session: Pick<Session, 'sessionId' | 'agentName' | 'provider' | 'project' | 'startTime' | 'workingDirectory'> & { model?: string },
     workingDirectory: string,
     status: SessionStartStatus = { status: 'started' },
     error?: SessionError,
-    mcpSummary?: MCPConfigSummary
+    mcpSummary?: MCPConfigSummary,
+    extensionsSummary?: ExtensionsScanSummary
   ): Promise<MetricsSyncResponse> {
     // Detect git branch
     const branch = await detectGitBranch(workingDirectory);
@@ -303,6 +305,37 @@ export class MetricsSender {
         mcp_local_server_names: mcpSummary.localServerNames,
         mcp_project_server_names: mcpSummary.projectServerNames,
         mcp_user_server_names: mcpSummary.userServerNames
+      }),
+
+      // Extensions scan (only if provided)
+      ...(extensionsSummary && {
+        // Counts per scope
+        agents_project: extensionsSummary.project.agents,
+        agents_global: extensionsSummary.global.agents,
+        commands_project: extensionsSummary.project.commands,
+        commands_global: extensionsSummary.global.commands,
+        skills_project: extensionsSummary.project.skills,
+        skills_global: extensionsSummary.global.skills,
+        hooks_project: extensionsSummary.project.hooks,
+        hooks_global: extensionsSummary.global.hooks,
+        rules_project: extensionsSummary.project.rules,
+        rules_global: extensionsSummary.global.rules,
+        // Names per scope + unique totals across both scopes
+        agent_names: [...new Set([...extensionsSummary.projectNames.agents, ...extensionsSummary.globalNames.agents])].sort(),
+        agents_project_names: extensionsSummary.projectNames.agents,
+        agents_global_names: extensionsSummary.globalNames.agents,
+        command_names: [...new Set([...extensionsSummary.projectNames.commands, ...extensionsSummary.globalNames.commands])].sort(),
+        commands_project_names: extensionsSummary.projectNames.commands,
+        commands_global_names: extensionsSummary.globalNames.commands,
+        skill_names: [...new Set([...extensionsSummary.projectNames.skills, ...extensionsSummary.globalNames.skills])].sort(),
+        skills_project_names: extensionsSummary.projectNames.skills,
+        skills_global_names: extensionsSummary.globalNames.skills,
+        hook_names: [...new Set([...extensionsSummary.projectNames.hooks, ...extensionsSummary.globalNames.hooks])].sort(),
+        hooks_project_names: extensionsSummary.projectNames.hooks,
+        hooks_global_names: extensionsSummary.globalNames.hooks,
+        rule_names: [...new Set([...extensionsSummary.projectNames.rules, ...extensionsSummary.globalNames.rules])].sort(),
+        rules_project_names: extensionsSummary.projectNames.rules,
+        rules_global_names: extensionsSummary.globalNames.rules
       })
     };
 

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-types.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-types.ts
@@ -71,6 +71,35 @@ export interface SessionAttributes {
   mcp_project_server_names?: string[];   // Server names in project scope
   mcp_user_server_names?: string[];      // Server names in user scope
 
+  // Extensions - Counts per scope (optional, only at session start)
+  agents_project?: number;               // Agent .md files in project .claude/agents/
+  agents_global?: number;                // Agent .md files in ~/.claude/agents/
+  commands_project?: number;             // Command .md files in project .claude/commands/
+  commands_global?: number;              // Command .md files in ~/.claude/commands/
+  skills_project?: number;               // Skill .md files in project .claude/skills/
+  skills_global?: number;                // Skill .md files in ~/.claude/skills/
+  hooks_project?: number;                // Hook scripts in project .claude/hooks/
+  hooks_global?: number;                 // Hook scripts in ~/.claude/hooks/
+  rules_project?: number;                // Rule .md files in project .claude/rules/
+  rules_global?: number;                 // Rule .md files in ~/.claude/rules/
+
+  // Extensions - Names per scope (optional, only at session start)
+  agent_names?: string[];                // All unique agent names across both scopes
+  agents_project_names?: string[];       // Agent names in project .claude/agents/
+  agents_global_names?: string[];        // Agent names in ~/.claude/agents/
+  command_names?: string[];              // All unique command names across both scopes
+  commands_project_names?: string[];     // Command names in project .claude/commands/
+  commands_global_names?: string[];      // Command names in ~/.claude/commands/
+  skill_names?: string[];                // All unique skill names across both scopes
+  skills_project_names?: string[];       // Skill names in project .claude/skills/
+  skills_global_names?: string[];        // Skill names in ~/.claude/skills/
+  hook_names?: string[];                 // All unique hook filenames across both scopes
+  hooks_project_names?: string[];        // Hook filenames in project .claude/hooks/
+  hooks_global_names?: string[];         // Hook filenames in ~/.claude/hooks/
+  rule_names?: string[];                 // All unique rule names across both scopes
+  rules_project_names?: string[];        // Rule names in project .claude/rules/
+  rules_global_names?: string[];         // Rule names in ~/.claude/rules/
+
   count: number;                         // Always 1 (Prometheus compatibility)
 }
 

--- a/src/utils/extensions-scan.ts
+++ b/src/utils/extensions-scan.ts
@@ -1,0 +1,207 @@
+/**
+ * Extensions Scan Utilities
+ *
+ * Scans agent extension directories at project and global levels.
+ * Reports counts and names of agents, commands, skills, hooks, and rules installed.
+ *
+ * Agent-agnostic: each agent declares its own directory paths via AgentExtensionsConfig.
+ *
+ * Security Notes:
+ * - ONLY counts/names files, never reads their contents
+ * - All failures return zero counts and empty name arrays (graceful degradation)
+ */
+
+import { readdir } from 'fs/promises';
+import path from 'path';
+import { homedir } from 'os';
+import { logger } from './logger.js';
+import type { AgentExtensionsConfig, ExtensionsCount, ExtensionsNames, ExtensionsScanSummary } from '../agents/core/types.js';
+
+// Re-export types for convenience
+export type { AgentExtensionsConfig, ExtensionsCount, ExtensionsNames, ExtensionsScanSummary };
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SCRIPT_EXTENSIONS = new Set(['.sh', '.js', '.py', '.ts']);
+
+// ============================================================================
+// Path Resolution
+// ============================================================================
+
+/**
+ * Resolve extensions base directory path
+ * Handles '~/' prefix (home-relative) and relative paths from cwd
+ */
+function resolveExtensionsPath(dirPath: string, cwd: string): string {
+  if (dirPath.startsWith('~/')) {
+    return path.join(homedir(), dirPath.slice(2));
+  }
+  if (path.isAbsolute(dirPath)) {
+    return dirPath;
+  }
+  return path.join(cwd, dirPath);
+}
+
+// ============================================================================
+// File Listing
+// ============================================================================
+
+/**
+ * List markdown files recursively in a directory, returning their names.
+ *
+ * @param dirPath - Directory to scan
+ * @param exactName - If provided, only match files with this exact name (case-insensitive).
+ *                    When set (e.g. 'SKILL.md'), the returned name is the parent directory
+ *                    name — i.e. the skill's directory name, not the entry file itself.
+ *                    When unset, the name is the filename without the .md extension.
+ */
+async function listMdFiles(dirPath: string, exactName?: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dirPath, { recursive: true, withFileTypes: true });
+    const names: string[] = [];
+
+    for (const e of entries) {
+      if (!e.isFile()) continue;
+      const lowerName = e.name.toLowerCase();
+
+      if (exactName) {
+        // Skill-directory pattern: SKILL.md lives inside a named skill subdirectory.
+        // The meaningful name is the parent directory (the skill name), not the file.
+        if (lowerName === exactName.toLowerCase()) {
+          names.push(path.basename(e.parentPath));
+        }
+      } else {
+        if (lowerName.endsWith('.md') && lowerName !== 'readme.md') {
+          names.push(e.name.slice(0, -3)); // strip .md extension
+        }
+      }
+    }
+
+    return names;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List script files (.sh, .js, .py, .ts) recursively in a directory
+ * Used for hooks directory
+ */
+async function listScriptFiles(dirPath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dirPath, { recursive: true, withFileTypes: true });
+    return entries
+      .filter(e => e.isFile() && SCRIPT_EXTENSIONS.has(path.extname(e.name).toLowerCase()))
+      .map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================================
+// Directory Scanning
+// ============================================================================
+
+/**
+ * Scan an agent's extension base directory and return counts and names per category.
+ * Each subdirectory (agents/, commands/, skills/, hooks/, rules/) is scanned independently.
+ *
+ * @param baseDir - Resolved absolute path to the agent's extensions base directory
+ * @param skillsEntryFile - If set, only count/name skills files with this exact name (e.g. 'SKILL.md')
+ */
+async function scanExtensionsDir(
+  baseDir: string,
+  skillsEntryFile?: string
+): Promise<{ counts: ExtensionsCount; names: ExtensionsNames }> {
+  const [agents, commands, skills, hooks, rules] = await Promise.all([
+    listMdFiles(path.join(baseDir, 'agents')),
+    listMdFiles(path.join(baseDir, 'commands')),
+    listMdFiles(path.join(baseDir, 'skills'), skillsEntryFile),
+    listScriptFiles(path.join(baseDir, 'hooks')),
+    listMdFiles(path.join(baseDir, 'rules')),
+  ]);
+
+  return {
+    counts: {
+      agents: agents.length,
+      commands: commands.length,
+      skills: skills.length,
+      hooks: hooks.length,
+      rules: rules.length,
+    },
+    names: {
+      agents: agents.sort(),
+      commands: commands.sort(),
+      skills: skills.sort(),
+      hooks: hooks.sort(),
+      rules: rules.sort(),
+    },
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Scan agent extension directories at project and global levels
+ *
+ * Main entry point for metrics integration.
+ * Uses agent-declared paths from AgentExtensionsConfig (set in agent metadata).
+ * Returns empty counts and empty name arrays for any scope not declared by the agent.
+ *
+ * @param extensionsConfig - Agent's extensions directory config (from metadata)
+ * @param cwd - Current working directory (for resolving relative project paths)
+ * @returns ExtensionsScanSummary with counts and names per scope
+ */
+export async function getExtensionsScanSummary(
+  extensionsConfig: AgentExtensionsConfig | undefined,
+  cwd: string
+): Promise<ExtensionsScanSummary> {
+  const emptyCount: ExtensionsCount = { agents: 0, commands: 0, skills: 0, hooks: 0, rules: 0 };
+  const emptyNames: ExtensionsNames = { agents: [], commands: [], skills: [], hooks: [], rules: [] };
+
+  if (!extensionsConfig) {
+    return {
+      project: { ...emptyCount },
+      global: { ...emptyCount },
+      projectNames: { ...emptyNames },
+      globalNames: { ...emptyNames },
+    };
+  }
+
+  try {
+    const { skillsEntryFile } = extensionsConfig;
+
+    const [projectResult, globalResult] = await Promise.all([
+      extensionsConfig.project
+        ? scanExtensionsDir(resolveExtensionsPath(extensionsConfig.project, cwd), skillsEntryFile)
+        : Promise.resolve({ counts: { ...emptyCount }, names: { ...emptyNames } }),
+      extensionsConfig.global
+        ? scanExtensionsDir(resolveExtensionsPath(extensionsConfig.global, cwd), skillsEntryFile)
+        : Promise.resolve({ counts: { ...emptyCount }, names: { ...emptyNames } }),
+    ]);
+
+    logger.debug('[extensions-scan] Scan complete', {
+      project: projectResult.counts,
+      global: globalResult.counts,
+    });
+
+    return {
+      project: projectResult.counts,
+      global: globalResult.counts,
+      projectNames: projectResult.names,
+      globalNames: globalResult.names,
+    };
+  } catch (error) {
+    logger.debug('[extensions-scan] Unexpected error:', error);
+    return {
+      project: { ...emptyCount },
+      global: { ...emptyCount },
+      projectNames: { ...emptyNames },
+      globalNames: { ...emptyNames },
+    };
+  }
+}

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -280,7 +280,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.9');
+      expect(result.sourceVersion).toBe('1.0.10');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -293,8 +293,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.9');
-      expect(result2.installedVersion).toBe('1.0.9');
+      expect(result2.sourceVersion).toBe('1.0.10');
+      expect(result2.installedVersion).toBe('1.0.10');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -308,7 +308,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.9');
+      expect(json.version).toBe('1.0.10');
     });
   });
 });


### PR DESCRIPTION
## Summary

Introduces an agent-agnostic extensions scanner that counts agents, commands, skills, hooks, and rules installed at project and global scope. Results are forwarded to SSO session-start metrics so extension usage can be tracked per session.

## Changes

- **New `src/utils/extensions-scan.ts`** — scans `agents/`, `commands/`, `skills/`, `hooks/`, `rules/` subdirectories under an agent's project/global extension base directory; returns counts and names; gracefully returns zeroes on any filesystem error
- **New types in `src/agents/core/types.ts`** — `AgentExtensionsConfig`, `ExtensionsCount`, `ExtensionsNames`, `ExtensionsScanSummary`; optional `getExtensionsSummary()` added to `AgentAdapter` interface
- **`BaseAgentAdapter`** — implements `getExtensionsSummary()` delegating to the new utility
- **Claude & Gemini plugin metadata** — each declares its own `extensionsConfig` (project dir, global dir, skills entry file)
- **`metrics-api-client` / `metrics-types`** — `sendSessionStart` accepts an optional `ExtensionsScanSummary` and maps it to per-scope metric fields (`agents_project`, `commands_global`, etc.)
- **`hooks.json`** — RTK auto-wrapper hook updated to the new `{ type, command }` object format; bumps Claude plugin to `1.0.10`

## Impact

- Session-start metrics now include extension counts broken down by scope (project vs global) — enables analytics on how many and which extensions users have installed
- Zero breaking changes: `extensionsConfig` is optional in agent metadata; `extensionsSummary` parameter to `sendSessionStart` is optional

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)