### PR TITLE
feat(agents): add claude-setup-audit skill to claude plugin

### DIFF
--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.10"
+  "version": "1.0.11"
 }

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/SKILL.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: claude-setup-audit
+description: This skill should be used when the user asks to "audit my claude setup", "check my claude configuration", "assess my claude code setup", "audit claude", "review my .claude folder", "is my claude setup correct", "check repo health", "assess my skills quality", "review my agents", "check my CLAUDE.md", "validate my hooks", "audit claude configuration", "check my MCP config", "how good is my claude setup", "scan my .claude folder", or wants a comprehensive quality assessment of all Claude Code components in a repository. Evaluates skills, subagents, CLAUDE.md rules, commands, hooks, and MCP configuration against established best practices. Produces a graded health report (A–F per component) with good/bad example references and prioritized recommendations.
+allowed-tools: [Read, Grep, Glob, Bash, Write]
+version: 1.0.0
+tags: [quality, audit, claude-setup, assessment, production-readiness]
+---
+
+# Claude Setup Audit
+
+Comprehensive quality assessment of Claude Code configuration and components in a repository. Evaluates skills, agents, CLAUDE.md rules, commands, hooks, and MCP configuration against established best practices. Produces a graded health report with concrete good/bad example references and actionable fixes.
+
+## Assessment Scope
+
+| Component | Primary Locations | Max Score |
+|-----------|------------------|-----------|
+| **Skills** | `.claude/skills/*/SKILL.md`, `plugins/*/skills/*/SKILL.md` | 32 pts each |
+| **Agents** | `.claude/agents/*.md`, `plugins/*/agents/*.md` | 32 pts each |
+| **CLAUDE.md** | `CLAUDE.md`, `.claude/CLAUDE.md`, `**/CLAUDE.md` (subdirs), `CLAUDE.local.md` | 36 pts each |
+| **Commands** | `.claude/commands/**/*.md`, `plugins/*/commands/**/*.md` | 20 pts each |
+| **Hooks** | `.claude/settings.json` (hooks array) | 20 pts total |
+| **MCP Config** | `.mcp.json`, `.claude/mcp.json` | 20 pts |
+
+## 5-Phase Workflow
+
+### Phase 1: Discovery
+
+Run `scripts/scan-repo.sh` or manually scan:
+
+```bash
+find . \( \
+  -path '*/.claude/agents/*.md' -o \
+  -path '*/skills/*/SKILL.md' -o \
+  -path '*/.claude/commands/**/*.md' -o \
+  -name 'CLAUDE.md' -o \
+  -name 'CLAUDE.local.md' -o \
+  -name '.mcp.json' -o \
+  -path '*/.claude/settings.json' \
+\) -not -path '*/node_modules/*' 2>/dev/null
+```
+
+**CLAUDE.md knowledge organisation scan** (run separately):
+```bash
+# Find all CLAUDE.md files
+find . -name 'CLAUDE.md' -o -name 'CLAUDE.local.md' \
+  | grep -v node_modules | sort
+
+# Find dedicated guide directories
+find . -type d \( -name 'guides' -o -name 'references' -o -name '.codemie' \) \
+  | grep -v node_modules | sort
+```
+
+**Detect which pattern is in use** — both are valid, mutually exclusive:
+
+| Pattern | Signals | Scoring note |
+|---------|---------|-------------|
+| **A — Single CLAUDE.md + Guide Files** | 1 CLAUDE.md at root + guide files in `guides/`, `.codemie/guides/`, `references/`, `docs/` | R5.3 full credit if CLAUDE.md references guide paths |
+| **B — Hierarchical CLAUDE.md** | Multiple CLAUDE.md files at different directory depths | R5.3 N/A (hierarchy IS the delegation); run hierarchy checks |
+
+Print discovery summary:
+```
+Found: X skills, Y agents, Z commands
+CLAUDE.md pattern: A (single + guides) | B (hierarchical) | unknown
+CLAUDE.md locations: [list each path found]
+Guide dirs: [list if present]
+Hooks: ✓/✗ | MCP: ✓/✗
+```
+
+### Phase 2: Per-Component Scoring
+
+Apply checklists from `references/component-checklists.md`. Mark each criterion:
+- ✅ **Pass** — full points
+- ⚠️ **Partial** — half points (present but incomplete or weak)
+- ❌ **Fail** — 0 points
+
+**Skills — classify type first, then score**:
+
+> **Before scoring any skill, detect its type:**
+> ```bash
+> grep -i "codemie.*assistant\|codemie.*chat\|assistants chat" SKILL.md
+> ```
+> - **Match found** → **Codemie-delegating skill** (API wrapper): applies reduced rubric (21 pts max)
+> - **No match** → **Standard skill**: full 32-pt rubric applies
+
+**Standard Skills (32 pts max)**:
+- Structure (3×): Valid SKILL.md filename, `[a-z0-9-]+` name, description >20 chars, `allowed-tools` field
+- Content (2×): Methodology/workflow section, output format, examples, checklists (`- [ ]`)
+- Technical (1×): No absolute paths, no hardcoded UUIDs/secrets, dependencies documented
+- Design (2×): Single responsibility, "When to use" triggers, no >50% overlap, <8K tokens
+
+**Codemie-delegating Skills (21 pts max — exemptions apply)**:
+- Structure (3×): Valid SKILL.md, valid name, description >20 chars — `allowed-tools` is **N/A** (no local tool execution)
+- Content: **All content criteria N/A** — output format, workflow, examples, checklists are determined by the backend assistant
+- Technical (1×): No absolute paths, no secrets, deps documented
+- Design (2×): Single responsibility, "When to use" triggers, no overlap, token budget
+- Score = (pts obtained / 21) × 100 — **do not penalise for exempted criteria**
+
+**Agents (32 pts max)**:
+- Identity (3×): Descriptive name, description has "when"/"use"/"trigger" keywords, model specified, tools justified
+- Prompt Quality (2×): "You are…" role statement, output format section, scope/limits, anti-hallucination keywords
+- Validation (1×): 3+ examples, edge cases, error handling described
+- Design (2×): Single responsibility, composable (references skills), <8K tokens
+
+**CLAUDE.md Rules (36 pts max)**:
+- Coverage (3×): Coding standards, workflow policies, explicit critical rules with triggers
+- Clarity (3×): Actionable instructions, trigger conditions stated, prohibitions explicit
+- Structure (2×): Section organization, quick-reference tables, correct/incorrect pattern examples
+- Maintenance (1×): No contradictions, technology versions noted, project context stated
+- Efficiency (2×): Concise body (≤400 non-code words), no anti-pattern noise, delegates detail via `@import`
+
+**CLAUDE.md hierarchy** — score each file separately, then run hierarchy analysis (Phase 3).
+
+**Commands (20 pts max)**:
+- Structure (3×): Frontmatter (name + description), `argument-hint` if uses `$ARGUMENTS`, numbered phases, usage examples
+- Quality (2×): Error/failure handling, output format defined, validation gates, argument parsing shown
+
+**Hooks (20 pts max)**:
+- Validity (3×): Valid JSON, recognized event types, valid matchers
+- Security (2×): No hardcoded credentials, bash scripts use `set -e`/`trap`
+- Quality (2×): Hook purpose documented, tool restriction scope appropriate
+
+**MCP Config (20 pts max)**:
+- Structure (3×): Valid JSON, `mcpServers` key, each server has `command`/`url` + type
+- Security (2×): No hardcoded tokens/passwords, env vars used for credentials
+- Documentation (2×): Descriptive server names, required env vars listed
+
+### Phase 3: Cross-Component Analysis
+
+After individual scoring, check repository-wide health:
+
+1. **Coverage gaps** — CLAUDE.md present if agents exist? Skills referenced by agents available?
+2. **Naming consistency** — All files use `lowercase-kebab-case`?
+3. **Duplication** — Any agents/skills with >50% description keyword overlap?
+4. **Security sweep** — Grep all `.claude/` content for `/Users/`, `/home/`, `password=`, `api_key`, `token=`
+5. **Integration** — Agents reference the skills they use? Commands invoke relevant agents?
+6. **CLAUDE.md knowledge organisation analysis** — see checklist in `references/component-checklists.md` (Pattern A and B checks are separate)
+
+### Phase 4: Grading
+
+```
+Component Score = (Points Obtained / Max Points) × 100
+Overall Score   = Average of all component scores
+```
+
+| Grade | Range | Label |
+|-------|-------|-------|
+| A | 90–100% | Production-ready |
+| B | 80–89% | Good — meets production threshold |
+| C | 70–79% | Needs improvement |
+| D | 60–69% | Significant gaps |
+| F | <60% | Critical issues — rewrite needed |
+
+**Production threshold**: Grade B (≥80%) required per component.
+
+### Phase 5: Report Generation
+
+Generate a report following `examples/sample-report.md` structure.
+
+For each failed criterion, cite the relevant example:
+```
+❌ No role statement ("You are...") found
+   → See examples/bad-agent.md (line 10) vs examples/good-agent.md (line 8)
+```
+
+Prioritize findings:
+- 🔴 **Critical** (fix immediately): Security issues OR grade F
+- 🟡 **Important** (fix soon): Grade D–C OR missing key structural elements
+- 🔵 **Minor** (polish): Grade B OR optional improvements
+
+## Quick Wins (High-Impact, Low-Effort Fixes)
+
+| Issue | Score Impact | Fix Effort |
+|-------|-------------|------------|
+| Missing `model:` in agent | +3 pts | 1 line |
+| No `allowed-tools` in standard skill | +3 pts | 1 line |
+
+| No "When to use" trigger section | +2–3 pts | 1 paragraph |
+| Hardcoded `/Users/` path | +1 pt + removes security risk | Find + replace |
+| No `argument-hint` for command with args | +3 pts | 1 line |
+| Missing "You are…" role statement in agent | +2 pts | 1 sentence |
+| No output format section | +2 pts | 1 short section |
+| Description uses second person ("Use this...") | +1–2 pts | Rephrase |
+| CLAUDE.md >400 non-code words | +2 pts + reduces instruction loss | Prune noise |
+| `CLAUDE.local.md` not in `.gitignore` | removes security risk | 1 line in .gitignore |
+| Pattern A: guides exist but not referenced by path | +2 pts | Add guide paths to CLAUDE.md |
+| Pattern B: subdir CLAUDE.md duplicates root | +2 pts | Remove duplication, scope to module only |
+
+## Reference Files
+
+### Scoring Details
+- **`references/component-checklists.md`** — Full rubric: all criteria, point values, detection patterns
+- **`references/best-practices.md`** — Rationale per criterion, anti-patterns to avoid, quick-fix examples
+
+### Examples
+
+| Component | Good Example | Bad Example |
+|-----------|-------------|-------------|
+| Skill | `examples/good-skill.md` | `examples/bad-skill.md` |
+| Agent | `examples/good-agent.md` | `examples/bad-agent.md` |
+| CLAUDE.md | `examples/good-claude-md-snippet.md` | `examples/bad-claude-md-snippet.md` |
+| Command | `examples/good-command.md` | `examples/bad-command.md` |
+| Hooks config | `examples/good-hooks.json` | `examples/bad-hooks.json` |
+| Full report | `examples/sample-report.md` | — |
+
+### Utilities
+- **`scripts/scan-repo.sh`** — Discover and inventory all Claude Code components

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-agent.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-agent.md
@@ -1,0 +1,45 @@
+---
+# ❌ BAD AGENT EXAMPLE
+# Score: ~7/32 pts (Grade F)
+# What's wrong: See inline comments marked ❌
+#
+# ❌ A1.1: Generic name "reviewer" — not descriptive
+# ❌ A1.2: Description has no trigger context, wrong person
+# ❌ A1.3: No model specified
+# ❌ A1.4: Bash in tools with no justification; overly broad tool set
+# ❌ A2.1: No "You are..." role statement
+# ❌ A2.2: No output format defined
+# ❌ A2.3: No scope, no "When NOT to use"
+# ❌ A2.4: No anti-hallucination measures
+# ❌ A3.1: No examples
+# ❌ A3.2: No edge cases
+# ❌ A3.3: No error handling
+# ❌ A4.1: Multi-purpose (code + architecture + docs + CI/CD + DB)
+# ❌ A4.3: No skill references
+---
+name: reviewer
+description: Use this agent to review things and provide feedback on code
+  and other project artifacts.
+tools: [Read, Grep, Glob, Bash, Write, WebFetch, WebSearch]
+
+---
+
+# Code Review Agent
+
+This agent will review your code and tell you if there are any issues. It can
+handle many different types of reviews and will help you improve your code
+quality across all aspects of your project.
+
+Review the code and provide feedback:
+- Check for bugs
+- Check for security issues
+- Check for style issues
+- Check for performance issues
+- Check for test coverage
+- Review architecture decisions
+- Suggest improvements to documentation
+- Help with CI/CD configuration
+- Review database schemas
+- Check API design
+
+Provide thorough feedback on everything you find. Be comprehensive.

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-claude-md-snippet.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-claude-md-snippet.md
@@ -1,0 +1,40 @@
+# ❌ BAD CLAUDE.md SNIPPET EXAMPLE
+# Score: ~6/30 pts (Grade F)
+#
+# ❌ R1.1: No coding standards defined
+# ❌ R1.2: Workflow policies are vague ("try to follow")
+# ❌ R1.3: No MANDATORY/NEVER/ALWAYS directives
+# ❌ R2.1: Not actionable — uses "try", "be careful", "consider"
+# ❌ R2.2: No trigger conditions specified
+# ❌ R2.3: No explicit prohibitions
+# ❌ R3.1: Wall of text, no section organization
+# ❌ R3.2: No quick-reference tables
+# ❌ R3.3: No ✅/❌ examples
+# ❌ R4.1: Contradictions — "always write tests" vs later "only write tests when asked"
+# ❌ R4.2: No version requirements mentioned
+# ❌ R4.3: No project context
+
+---
+
+This project uses TypeScript and Node.js. When working on it, try to follow
+good coding practices and be careful with the code you write. Make sure to
+use modern JavaScript features when possible.
+
+For git operations, try to use descriptive commit messages and be careful
+with what you commit. Remember to test your changes before committing and
+try to follow the team's conventions.
+
+Testing is important. Always write tests for your code to make sure everything
+works. Make sure tests pass before finishing.
+
+Only write tests when the user explicitly asks for them.
+
+When using imports, be careful with the paths and make sure they work.
+Consider using TypeScript properly.
+
+For builds, run the build command when you're done. Be careful about
+environment variables and make sure you're not leaking any sensitive
+information. Try to follow security best practices in general.
+
+If something isn't working, check the logs and try to figure out what's
+wrong. Usually errors have helpful messages. Consider using the debugger.

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-command.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-command.md
@@ -1,0 +1,30 @@
+---
+# ❌ BAD COMMAND EXAMPLE
+# Score: ~4/20 pts (Grade F)
+#
+# ❌ C1.1: Frontmatter missing description field
+# ❌ C1.2: Uses $ARGUMENTS in body but no argument-hint in frontmatter
+# ❌ C1.3: No phases or structured workflow — just a list of bullets
+# ❌ C1.4: No usage examples section
+# ❌ C2.1: No error handling for failures
+# ❌ C2.2: No output format defined
+# ❌ C2.3: No validation gates or confirmation step
+# ❌ C2.4: $ARGUMENTS used but no parsing logic shown
+name: jira
+---
+
+# Jira Ticket Creator
+
+Create a jira ticket using this command. Just describe what you want and
+the ticket will be created in Jira.
+
+The command will figure out the type and priority automatically based on
+what you write.
+
+Make sure JIRA_TOKEN is set before using this.
+
+Steps:
+- Figure out what kind of ticket $ARGUMENTS is asking for
+- Write a description
+- Create the ticket
+- Tell the user the ticket ID

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-hooks.json
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-hooks.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "❌ BAD HOOKS EXAMPLE — Score: ~3/20 pts (Grade F)",
+  "_notes": {
+    "H1.1": "✅ Valid JSON (only thing that passes)",
+    "H1.2": "❌ 'PreToolCall' is not a valid event type — should be 'PreToolUse'",
+    "H2.1": "❌ Hardcoded API key 'sk-abc123def456' in command string",
+    "H2.2": "❌ No set -e or trap — script will silently fail",
+    "H3.1": "❌ Matcher '.*' matches ALL tool uses — runs on every single action",
+    "H3.2": "❌ No description field — no way to know what this hook is for"
+  },
+  "hooks": [
+    {
+      "event": "PreToolCall",
+      "matcher": ".*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash -c 'curl https://api.mycompany.com/audit -d \"tool=$CLAUDE_TOOL_NAME&session=$CLAUDE_SESSION_ID\" -H \"Authorization: Bearer sk-abc123def456\" -H \"Content-Type: application/json\"'"
+        }
+      ]
+    }
+  ]
+}

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-skill.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/bad-skill.md
@@ -1,0 +1,48 @@
+---
+# ❌ BAD SKILL EXAMPLE
+# Score: ~8/32 pts (Grade F)
+# What's wrong: See inline comments marked ❌
+#
+# ❌ S1.2: Name "Git Helper" has uppercase and space (should be git-helper)
+# ❌ S1.3: Description uses second person ("Use this skill"), vague, no trigger phrases
+# ❌ S1.4: No allowed-tools field — no tool restriction
+# ❌ S2.1: No methodology or structured workflow
+# ❌ S2.2: No output format defined
+# ❌ S2.3: No concrete examples
+# ❌ S2.4: No actionable checklists
+# ❌ S3.1: Hardcoded absolute path /Users/developer/projects
+# ❌ S4.1: Multi-purpose (commits AND branches AND rebasing AND PRs)
+# ❌ S4.2: No "When to use" or trigger conditions
+# ❌ Writing style: second person throughout ("you can", "you should")
+---
+name: Git Helper
+description: Use this skill when you need to do git things like commits and
+  pushing code and other git operations.
+
+---
+
+# Git Helper Skill
+
+This skill helps you with git. You can use it for commits, pushes, branches,
+and various git operations when working on your projects.
+
+When you need to do git things, this skill will help you do them correctly.
+It works with any git repository on your machine.
+
+Instructions:
+- Do git status first to see what files you have
+- Then you should stage the files you want to commit
+- Try to write a good commit message
+- Be careful with the commit message format
+- You should also check what files are staged
+- Make sure everything looks good before committing
+- Don't forget to push when you're done
+
+For branches: you can create new branches when needed. Try to use descriptive
+names. You should merge or rebase depending on the situation.
+
+Working directory note: this skill assumes you're working in
+/Users/developer/projects as the base path for all repositories.
+
+Note: This skill also handles pull requests, rebasing, cherry-picking,
+stash management, and GitHub integration.

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-agent.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-agent.md
@@ -1,0 +1,145 @@
+---
+# ✅ GOOD AGENT EXAMPLE
+# Score: ~30/32 pts (Grade A)
+# What makes it good: See inline comments marked ✅
+#
+# ✅ A1.1: Descriptive, domain-specific name
+# ✅ A1.2: Description has "when" and "use" trigger context
+# ✅ A1.3: Model explicitly specified
+# ✅ A1.4: Bash justified with inline comment
+# ✅ A2.1: "You are..." role statement
+# ✅ A2.2: Output format section defined
+# ✅ A2.3: Scope + "When NOT to use"
+# ✅ A2.4: Anti-hallucination section
+# ✅ A3.1: 3+ usage examples
+# ✅ A3.2: Edge cases documented
+# ✅ A3.3: Error handling described
+# ✅ A4.1: Single responsibility (code review only)
+# ✅ A4.3: References related skills/agents
+#
+# ⚠️ Minor gap: A3.4 — integration docs could be more explicit
+---
+name: code-reviewer
+description: This agent should be used when the user asks to "review my code",
+  "check code quality", "review this PR", "look for bugs", "security review",
+  or "give feedback on my implementation". Reviews staged or committed changes
+  for quality, security, and correctness issues.
+model: claude-sonnet-4-6
+tools: [Read, Grep, Glob, Bash]
+# Bash required for: git diff, git log, running lint checks
+
+---
+
+# Code Reviewer Agent
+
+Reviews code changes for quality, security, and correctness. Provides structured
+feedback with severity levels and concrete improvement suggestions.
+
+## Role
+
+You are a senior code reviewer with expertise in security vulnerabilities,
+performance patterns, and maintainability. Your job is to identify real issues
+that would cause problems in production — not stylistic preferences or micro-
+optimizations. Focus on bugs, security vulnerabilities, logic errors, and
+maintainability problems.
+
+## Scope
+
+**Review**: Staged changes (`git diff --cached`), committed changes (`git diff HEAD~1`),
+or specific files provided by the user.
+
+**Do NOT review**: Generated files, `node_modules/`, `dist/`, `*.lock` files,
+binary files.
+
+**When NOT to use this agent**:
+- Architecture decisions → use `solution-architect` agent
+- Writing tests → use `test-writer` agent
+- Performance profiling → run profiler first, then use this agent on hotspots
+
+## Methodology
+
+1. Identify changed files: `git diff --name-only` or user-provided files
+2. For each file: read with context (surrounding code, not just diff)
+3. Evaluate against criteria below
+4. Generate structured report
+
+### Review Criteria
+
+**Security** (Critical — block production):
+- SQL injection, XSS, command injection vectors
+- Hardcoded credentials or secrets in code
+- Unvalidated input at system boundaries (user input, API responses, file reads)
+- Overly permissive CORS, auth bypass patterns
+
+**Correctness** (High — likely causes bugs):
+- Off-by-one errors, logic inversions
+- Unhandled exceptions or null/undefined dereferences
+- Race conditions in async code
+- Incorrect error propagation (swallowing errors)
+
+**Performance** (Medium — degrades at scale):
+- N+1 query patterns
+- Synchronous I/O in async contexts
+- Unbounded loops or missing pagination
+
+**Maintainability** (Low — increases tech debt):
+- Functions >40 lines without clear justification
+- Missing error context in catch blocks
+- Unclear naming in non-trivial logic
+
+## Output Format
+
+```markdown
+## Code Review: [file or PR title]
+
+**Summary**: [1–2 sentence overall assessment]
+**Verdict**: APPROVE / REQUEST CHANGES / BLOCKING
+
+### 🔴 Critical (must fix before merge)
+- **[File:Line]** [Issue]
+  - Impact: [what goes wrong in production]
+  - Fix: [concrete actionable suggestion]
+
+### 🟡 Important (should fix)
+- **[File:Line]** [Issue]
+  - Fix: [suggestion]
+
+### 🔵 Minor (optional polish)
+...
+
+### ✅ Positives
+[2–3 specific things done well — required, not optional]
+```
+
+## Source Verification
+
+- Base all feedback on actual code seen in the diff — never assume patterns not shown
+- If uncertain whether something is a bug: "This may cause issues if [condition]…"
+- Never invent API signatures, library behaviors, or version requirements
+- Do not cite performance numbers without measurement evidence
+
+## Examples
+
+1. "Review my changes before commit" → run `git diff --cached`, review staged changes
+2. "Review the auth PR" → run `git diff main...HEAD`, review branch changes
+3. "Check this file for security issues" → review specified file for security criteria only
+4. "Quick review" → focus on Critical and High issues only, skip Low
+
+## Edge Cases
+
+- **Empty diff**: Warn "No staged/changed files found" and exit
+- **Binary files**: Skip with note "Binary file skipped (not reviewable)"
+- **Very large diffs (>200 files)**: Ask user to scope to specific directories
+- **Generated code** (e.g., `*.generated.ts`): Skip automatically
+
+## Error Handling
+
+- If `git` is not available: switch to direct file analysis
+- If file cannot be read: note in report and continue with other files
+- If user provides invalid path: report "File not found: [path]"
+
+## Works With
+
+- After review: use `commit-helper` skill for conventional commit message
+- For test gaps found: mention `test-writer` agent for coverage
+- For architecture concerns: escalate to `solution-architect` agent

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-claude-md-snippet.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-claude-md-snippet.md
@@ -1,0 +1,126 @@
+# ✅ GOOD CLAUDE.md SNIPPET EXAMPLE
+# Score: ~27/30 pts (Grade A)
+#
+# ✅ R1.1: Coding standards defined (TypeScript section)
+# ✅ R1.2: Workflow policies explicit (Git, Testing)
+# ✅ R1.3: Critical rules with MANDATORY/NEVER + triggers
+# ✅ R2.1: Actionable — starts with verbs (Use, Run, Add, Never)
+# ✅ R2.2: Trigger conditions stated ("when user says", "for TypeScript files")
+# ✅ R2.3: Explicit prohibitions with examples
+# ✅ R3.1: Organized H2 sections
+# ✅ R3.2: Quick-reference table
+# ✅ R3.3: ✅/❌ pattern examples
+# ✅ R4.2: Technology versions mentioned
+# ✅ R4.3: Project context stated
+#
+# ⚠️ Minor gap: R4.1 — one minor contradiction possible (needs manual check)
+
+---
+# CLAUDE.md — Acme API Service
+
+**Project**: REST API backend for Acme platform (Node.js 22, TypeScript 5.4)
+**Team**: Platform Engineering
+
+---
+
+## ⚡ Task Classifier (Scan First)
+
+| Keywords in request | Apply policy |
+|--------------------|-------------|
+| "commit", "push", "branch", "PR" | → Git Policy below |
+| "test", "spec", "vitest" | → Testing Policy below |
+| TypeScript, imports, types | → TypeScript Standards below |
+| "deploy", "release", "build" | → Build Policy below |
+
+---
+
+## 🚨 Critical Rules (MANDATORY)
+
+🚨 **NEVER commit to `main` directly.** Always use feature branches.
+
+🚨 **NEVER use `--no-verify` on git hooks.** If a hook fails, fix the underlying issue first.
+
+🚨 **NEVER write tests unless user explicitly asks.** Wait for "write tests", "add coverage", "create specs".
+
+🚨 **ALWAYS use `.js` extensions in TypeScript imports.** TypeScript compiles to ESM. Missing extension = runtime crash.
+
+---
+
+## TypeScript Standards
+
+**Imports** — ES modules only:
+```typescript
+✅ import { foo } from './utils.js'
+✅ import type { Bar } from './types.js'
+❌ import { foo } from './utils'          // missing .js extension
+❌ const { foo } = require('./utils')     // CommonJS not allowed
+```
+
+**Types** — strict mode, no `any` shortcuts:
+```typescript
+✅ function process(input: unknown): Result { ... }
+✅ const value = data as UserProfile       // explicit assertion
+❌ function process(input: any) { ... }    // defeats type safety
+```
+
+**Async patterns**:
+```typescript
+✅ const result = await Promise.all([a(), b()])  // parallel where possible
+❌ const r1 = await a()                           // sequential bottleneck
+❌ const r2 = await b()
+```
+
+---
+
+## Git Policy
+
+**Branch naming**: `<type>/<description>` — e.g., `feat/add-oauth`, `fix/token-refresh`
+
+**Commit format**: Conventional Commits:
+```
+feat(auth): add token refresh on 401 response
+fix(api): handle null user in profile endpoint
+chore: update eslint to v9
+```
+
+**PR requirements**:
+- [ ] Branch is up to date with `main`
+- [ ] All CI checks pass
+- [ ] No `console.log` or debug code
+
+**Never do**:
+- ❌ `git push --force` to `main` (destructive, permanently loses history)
+- ❌ `git commit --amend` on published commits (breaks teammates' history)
+
+---
+
+## Testing Policy
+
+**MANDATORY**: Write tests ONLY when user explicitly says "write tests", "add coverage", "create unit tests".
+
+**Never proactively write or suggest tests.**
+
+Test commands:
+```bash
+npm test              # all tests
+npm run test:unit     # unit only
+npm run test:coverage # with coverage report
+```
+
+Framework: Vitest 4.x. All tests use dynamic imports for mocking (not static).
+
+---
+
+## Build Policy
+
+**Node.js**: >= 22.0.0 required (`node --version`)
+**npm**: bundled with Node — no yarn or pnpm
+**Build output**: `dist/` (gitignored)
+
+```bash
+npm run build    # TypeScript → dist/
+npm run lint     # ESLint (zero warnings required)
+npm run ci       # Full pipeline: lint + build + test
+```
+
+**Before deploying**: All CI checks must pass. No bypassing.

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-command.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-command.md
@@ -1,0 +1,170 @@
+---
+# ✅ GOOD COMMAND EXAMPLE
+# Score: ~19/20 pts (Grade A)
+#
+# ✅ C1.1: Valid frontmatter with name + description
+# ✅ C1.2: argument-hint matches $ARGUMENTS usage
+# ✅ C1.3: Phase-based numbered workflow
+# ✅ C1.4: Usage examples section present
+# ✅ C2.1: Error handling table with failure cases
+# ✅ C2.2: Output format defined
+# ✅ C2.3: Validation gates (confirm before creating)
+# ✅ C2.4: Argument parsing with defaults shown
+#
+# ⚠️ Minor gap: C2.4 — could show more complex argument validation
+name: create-jira-ticket
+description: Create a structured Jira ticket from code context, error analysis, or user description
+argument-hint: "<type> <title> [--priority high|medium|low]"
+---
+
+# Create Jira Ticket
+
+Creates a well-structured Jira ticket in the EPM-CDME project based on code
+context, error analysis, or user description. Follows project template with
+acceptance criteria and technical notes.
+
+## Arguments
+
+| Argument | Values | Default | Description |
+|----------|--------|---------|-------------|
+| `<type>` | `bug`, `story`, `task`, `epic` | required | Ticket type |
+| `<title>` | string | required | Brief ticket title |
+| `--priority` | `high`, `medium`, `low` | `medium` | Priority level |
+
+## Usage
+
+```bash
+/create-jira-ticket bug "Login fails on mobile Safari"
+/create-jira-ticket story "Add dark mode toggle" --priority high
+/create-jira-ticket task "Update API documentation"
+/create-jira-ticket epic "Authentication system refactor"
+```
+
+---
+
+## Phase 1: Parse and Validate Arguments
+
+Parse `$ARGUMENTS`:
+
+1. Extract `<type>` — first token. If missing or invalid:
+   ```
+   Valid types: bug, story, task, epic
+   What type of ticket? [bug/story/task/epic]
+   ```
+
+2. Extract `<title>` — remaining text before flags. If missing:
+   ```
+   What should the ticket title be?
+   ```
+
+3. Extract `--priority` flag. Default: `medium`
+
+4. Validate:
+   - [ ] Type is one of: bug, story, task, epic
+   - [ ] Title is not empty
+   - [ ] Title length ≤ 255 characters (Jira limit)
+
+**Abort if**: `JIRA_TOKEN` env var is not set — print:
+```
+Error: JIRA_TOKEN environment variable is required.
+Set it with: export JIRA_TOKEN=your-token
+```
+
+---
+
+## Phase 2: Gather Context
+
+Collect relevant context based on type:
+
+**For `bug`**:
+- Run `git log --oneline -5` to show recent changes
+- Read any error output or stack traces mentioned by user
+- Identify affected file(s) if mentioned
+
+**For `story`**:
+- Read related files to understand current implementation
+- Note what's missing vs what's needed
+
+**For `task`** or **`epic`**:
+- Review scope from user description
+- Check for related existing tickets if mentioned
+
+---
+
+## Phase 3: Generate Ticket Description
+
+Use the EPM-CDME template:
+
+```markdown
+## Problem Statement
+[Concrete, observable description of the bug or need.
+For bugs: what happens vs what should happen.
+For stories: what capability is missing.]
+
+## Acceptance Criteria
+- [ ] Criterion 1 (testable, pass/fail)
+- [ ] Criterion 2
+- [ ] Criterion 3 (minimum 3 criteria)
+
+## Technical Notes
+[Implementation hints, related files, potential approach, dependencies]
+
+## Priority Justification
+[Why this priority level: high = user-blocking, medium = important, low = nice-to-have]
+```
+
+Checklist before proceeding:
+- [ ] Problem is concrete and observable (not vague)
+- [ ] Acceptance criteria are testable (binary pass/fail)
+- [ ] Technical notes reference actual files or components
+- [ ] Priority matches user impact
+
+---
+
+## Phase 4: Confirm Before Creating
+
+Show the draft ticket for user approval:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Creating Jira Ticket:
+  Project: EPM-CDME
+  Type: [Bug | Story | Task | Epic]
+  Title: [title]
+  Priority: [High | Medium | Low]
+
+Description preview:
+  [first 200 chars of description...]
+
+Create ticket? [y/n/edit]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+- If `n`: Print "Cancelled." Exit cleanly.
+- If `edit`: Re-prompt for which field to change.
+- If `y`: Proceed to Phase 5.
+
+---
+
+## Phase 5: Create and Report
+
+1. POST to Jira API using `JIRA_TOKEN`
+2. On success:
+   ```
+   ✓ Created: EPM-CDME-1234
+     https://jira.example.com/browse/EPM-CDME-1234
+   ```
+3. On failure: see Error Handling
+
+---
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `JIRA_TOKEN` not set | Print setup instructions. Exit without saving draft. |
+| API 401 Unauthorized | "Invalid token. Check JIRA_TOKEN value." |
+| API 403 Forbidden | "No permission for EPM-CDME project. Contact admin." |
+| API 429 Rate Limited | Wait 30s, retry once. If fails again: save draft. |
+| Network unreachable | Save draft to `./jira-ticket-draft.md`, print path. |
+| Title >255 chars | Truncate to 252 chars, append "...", warn user. |

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-hooks.json
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-hooks.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "✅ GOOD HOOKS EXAMPLE — Score: ~18/20 pts (Grade A)",
+  "_notes": {
+    "H1.1": "✅ Valid JSON structure",
+    "H1.2": "✅ All event types are recognized (PreToolUse, PostToolUse)",
+    "H2.1": "✅ No hardcoded credentials — uses env var $AUDIT_WEBHOOK_URL",
+    "H2.2": "✅ Bash scripts use set -e and trap for error handling",
+    "H3.1": "✅ Matchers are scoped to specific tools (Write|Edit, Bash) not .*",
+    "H3.2": "✅ Each hook has a description field explaining its purpose"
+  },
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "description": "Block direct file writes to main branch — prevents accidental commits to protected branch",
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash -c 'set -e; trap \"echo Hook check failed >&2\" ERR; BRANCH=$(git branch --show-current 2>/dev/null || echo \"\"); if [ \"$BRANCH\" = \"main\" ] || [ \"$BRANCH\" = \"master\" ]; then echo \"ERROR: Direct writes to $BRANCH are blocked. Create a feature branch first.\" >&2; exit 1; fi'"
+        }
+      ]
+    },
+    {
+      "event": "PostToolUse",
+      "description": "Run ESLint after TypeScript file modifications to catch issues immediately",
+      "matcher": "Edit|Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash -c 'set -e; trap \"echo Lint hook failed on line $LINENO >&2\" ERR; FILE=$(echo \"$CLAUDE_TOOL_OUTPUT\" | grep -o \"[^ ]*\\.ts\" | head -1 || true); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then npx eslint \"$FILE\" --max-warnings=0 --quiet 2>&1 | tail -10; fi'"
+        }
+      ]
+    },
+    {
+      "event": "PostToolUse",
+      "description": "Log tool usage for audit trail — posts to team webhook for compliance tracking",
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash -c 'set -e; if [ -n \"$AUDIT_WEBHOOK_URL\" ]; then curl -sf -X POST \"$AUDIT_WEBHOOK_URL\" -H \"Content-Type: application/json\" -d \"{\\\"event\\\": \\\"bash_used\\\", \\\"session\\\": \\\"$CLAUDE_SESSION_ID\\\"}\" > /dev/null 2>&1 || true; fi'"
+        }
+      ]
+    }
+  ]
+}

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-skill.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/good-skill.md
@@ -1,0 +1,144 @@
+---
+# ✅ GOOD SKILL EXAMPLE
+# Score: ~30/32 pts (Grade A)
+# What makes it good: See inline comments marked ✅
+#
+# ✅ S1.1: Named SKILL.md in skills/ directory
+# ✅ S1.2: name is [a-z0-9-]+ pattern
+# ✅ S1.3: Description >20 chars, third-person, specific triggers
+# ✅ S1.4: allowed-tools explicitly specified
+# ✅ S2.1: Step-by-step methodology
+# ✅ S2.2: Output format section defined
+# ✅ S2.3: Concrete examples provided
+# ✅ S2.4: Actionable checklists present
+# ✅ S3.1: No absolute paths
+# ✅ S3.2: No secrets
+# ✅ S4.1: Single focused purpose
+# ✅ S4.2: "When to use" section present
+#
+# ⚠️ Minor gap: S3.4 — no dependencies section (would add 1 pt)
+---
+name: commit-helper
+description: This skill should be used when the user asks to "commit my changes",
+  "create a conventional commit", "write a commit message", "stage and commit files",
+  or wants to follow conventional commits format. Guides through staged file review,
+  semantic commit message generation, and commit creation with pre-commit validation.
+allowed-tools: [Read, Bash, Glob]
+version: 1.0.0
+
+---
+
+# Commit Helper
+
+Guides staged commit creation following the Conventional Commits specification.
+Generates semantic commit messages based on diff analysis and confirms before committing.
+
+## When to Use
+
+Use this skill when:
+- User has staged changes and wants a commit message
+- User wants to follow conventional commits format automatically
+- User needs to review staged changes before committing
+- User says "commit", "create a commit", "stage and commit"
+
+Do NOT use this skill for:
+- Pushing to remote (that's a separate action requiring user confirmation)
+- Creating pull requests (use `pr-creator` skill)
+- Branch management operations
+
+## Methodology
+
+### Step 1: Review Staged Changes
+
+1. Run `git status` to list staged and unstaged files
+2. Run `git diff --cached` to review the full staged diff
+3. If no files staged: warn user and exit — do not commit unstaged work
+
+### Step 2: Determine Commit Type
+
+Map changes to conventional commit types:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or behavior added |
+| `fix` | Bug fix |
+| `refactor` | Code change that neither fixes a bug nor adds feature |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `chore` | Build process, tooling, dependencies |
+| `ci` | CI/CD pipeline changes |
+| `perf` | Performance improvement |
+
+### Step 3: Generate Commit Message
+
+Format:
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+Checklist:
+- [ ] Type is lowercase and from the table above
+- [ ] Scope is the module, component, or area affected
+- [ ] Description is imperative mood ("add" not "added"), lowercase, <72 chars, no period
+- [ ] Body explains WHY (not WHAT — the diff shows WHAT)
+- [ ] Breaking changes use `feat!:` or `fix!:` and include `BREAKING CHANGE:` footer
+
+### Step 4: Confirm and Commit
+
+Show the proposed commit for user approval:
+```
+Staged files:
+  modified: src/auth/login.ts
+  modified: src/auth/token.ts
+
+Proposed commit:
+  fix(auth): refresh OAuth token before expiry on 401 response
+
+  Tokens were silently expiring mid-session causing user logout.
+  Refresh is now triggered proactively when token age > 80% of TTL.
+
+Commit? [y/n/edit]
+```
+
+- [ ] User confirmed `y` before running `git commit`
+- [ ] If user says `edit`: re-prompt for message
+- [ ] Never use `--no-verify` unless user explicitly requests it
+
+## Output Format
+
+```
+Staged: [list of files]
+
+Proposed message:
+  [type(scope): description]
+
+  [body if needed]
+
+✓ Committed: [hash] [message]
+```
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| No staged files | Print: "No staged files. Use `git add` first." Exit. |
+| User cancels | Print: "Commit cancelled." Exit cleanly. |
+| Pre-commit hook fails | Print hook output, do NOT retry, suggest fixing the issue |
+| `git commit` fails | Show error message, do not suppress it |
+
+## Examples
+
+```bash
+# User: "commit my changes"
+→ Run git status + diff, generate message, show for confirmation
+
+# User: "commit the auth fix as a hotfix"
+→ Use type=fix, analyze staged auth files, generate message
+
+# User: "commit with message 'update readme'"
+→ Use user's message, format to conventional commits if needed
+```

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/sample-report.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/examples/sample-report.md
@@ -1,0 +1,223 @@
+# Claude Setup Audit Report
+
+**Project**: `/Users/developer/my-app`
+**Date**: 2026-03-02
+**Assessed by**: claude-setup-audit v1.0.0
+
+---
+
+## Overall Score: 71% (Grade C)
+
+> ⚠️ **3 of 8 components are below the production threshold (80% / Grade B)**
+
+| Component | Files | Avg Score | Grade | Production Ready |
+|-----------|-------|-----------|-------|-----------------|
+| Skills | 3 | 84% | B | 2/3 (67%) ✅ |
+| Agents | 2 | 58% | F | 0/2 (0%) ❌ |
+| CLAUDE.md | 1 | 73% | C | 0/1 ⚠️ |
+| Commands | 2 | 90% | A | 2/2 (100%) ✅ |
+| Hooks | 1 | 65% | D | 0/1 ❌ |
+| MCP Config | 1 | 85% | B | 1/1 (100%) ✅ |
+
+---
+
+## Issues by Priority
+
+### 🔴 Critical (Fix Before Production)
+
+**1. Hardcoded API key in `.claude/settings.json`** (Hook: `audit-logger`)
+- **Issue**: Literal API key `sk-prod-abc123` found in hook command string
+- **Risk**: Credential exposed in version control if file is committed
+- **Fix**: Replace with env var reference: `$AUDIT_API_KEY`
+- **Reference**: See `examples/bad-hooks.json` line 12 → `examples/good-hooks.json` line 18
+
+**2. Agent `analyzer.md` — Grade F (47%)**
+- **Issue**: No model specified, no role statement, no output format, Bash unjustified
+- **Risk**: Unpredictable behavior and cost; Bash access without constraints
+- **Fix**: Add frontmatter `model: claude-sonnet-4-6`; add "You are..." role; justify Bash
+- **Reference**: See `examples/bad-agent.md` → `examples/good-agent.md`
+
+---
+
+### 🟡 Important (Fix Soon)
+
+**3. Agent `summarizer.md` — Grade D (63%)**
+- Missing: model (−3 pts), anti-hallucination section (−2 pts), 3+ examples (−1 pt)
+- **Quick fix**: Add 3 lines to frontmatter + one "Source Verification" section
+
+**4. CLAUDE.md — Grade C (73%)**
+- Missing: quick-reference task classifier table (−2 pts), ✅/❌ pattern examples (−2 pts)
+- Has: coding standards, workflow policies, critical rules ✓
+- **Fix**: Add a "Task Classifier" table and one before/after code example per major rule
+
+**5. Hook `audit-logger` — Grade D (65%)** *(aside from the Critical security issue above)*
+- Matcher is `.*` (runs on every tool use) — should target `Bash` only
+- No `description` field on the hook object
+- No error handling in bash script (`set -e` missing)
+
+---
+
+### 🔵 Minor (Polish)
+
+**6. Skill `data-processor` — Grade B (81%)**
+- Missing: actionable checklists `- [ ]` (−2 pts)
+- Easy win: add 3 checkbox items to the workflow section
+
+**7. Naming inconsistency**
+- Agent file `Summarizer.md` uses PascalCase — rename to `summarizer.md`
+- Skill `data_processor/` uses underscore — rename to `data-processor/`
+
+---
+
+## Per-Component Details
+
+<details>
+<summary>Skills — 3 files, avg 84%, Grade B</summary>
+
+| File | Score | Grade | Top Issues |
+|------|-------|-------|------------|
+| `.claude/skills/commit-helper/SKILL.md` | 94% | A | None |
+| `.claude/skills/data-processor/SKILL.md` | 81% | B | Missing checklists (-2 pts) |
+| `.claude/skills/deploy-helper/SKILL.md` | 78% | C | No "When to use" triggers (-2), no output format (-2) |
+
+**deploy-helper gaps**:
+```
+❌ S4.2: No "When to use" section
+   → Add: "## When to Use / Do NOT use this for..."
+   → See: examples/good-skill.md line 14–22
+
+❌ S2.2: Output format not defined
+   → Add: "## Output Format" section
+```
+</details>
+
+<details>
+<summary>Agents — 2 files, avg 58%, Grade F</summary>
+
+| File | Score | Grade | Top Issues |
+|------|-------|-------|------------|
+| `.claude/agents/analyzer.md` | 47% | F | No model, no role, Bash unjustified, no examples |
+| `.claude/agents/summarizer.md` | 69% | D | No model, no anti-hallucination, weak examples |
+
+**analyzer.md failed criteria**:
+```
+❌ A1.3: No model specified (−3 pts)
+   → Add to frontmatter: model: claude-sonnet-4-6
+
+❌ A2.1: No role statement (−2 pts)
+   → Add: "You are a data analyst specializing in..."
+
+❌ A1.4: Bash in tools without justification (−3 pts)
+   → Add comment: # Bash required for: running analysis scripts
+
+❌ A2.4: No anti-hallucination measures (−2 pts)
+   → Add "## Source Verification" section
+   → See: examples/good-agent.md line 47–51
+
+❌ A3.1: Only 1 example (needs ≥3) (−1 pt)
+```
+</details>
+
+<details>
+<summary>CLAUDE.md — 73%, Grade C</summary>
+
+**Passing criteria** (19/30 pts):
+- ✅ R1.1: Coding standards section present
+- ✅ R1.2: Git workflow policy documented
+- ✅ R1.3: MANDATORY/NEVER directives present
+- ✅ R2.1: Instructions are actionable
+- ✅ R2.3: Prohibitions stated
+
+**Failing criteria** (−8 pts):
+```
+❌ R2.2: No trigger conditions on rules (−3 pts)
+   → Rules say "NEVER use --no-verify" but don't say when this applies
+   → Add: "When user says 'commit': NEVER use --no-verify"
+   → See: examples/good-claude-md-snippet.md line 18–22
+
+❌ R3.2: No quick-reference table (−2 pts)
+   → Add a "Task Classifier" table mapping keywords to policies
+   → See: examples/good-claude-md-snippet.md line 9–15
+
+❌ R3.3: No ✅/❌ pattern examples (−2 pts)
+   → Add one before/after code block for TypeScript imports or git commits
+   → See: examples/good-claude-md-snippet.md line 32–40
+
+❌ R4.2: Technology versions not mentioned (−1 pt)
+   → Add: "Node.js >=20.0.0 required"
+```
+</details>
+
+<details>
+<summary>Commands — 2 files, avg 90%, Grade A</summary>
+
+| File | Score | Grade | Notes |
+|------|-------|-------|-------|
+| `.claude/commands/create-ticket.md` | 95% | A | Excellent |
+| `.claude/commands/summarize-pr.md` | 85% | B | Missing validation gates |
+
+</details>
+
+<details>
+<summary>Hooks — 65%, Grade D (+ Critical security issue)</summary>
+
+See Critical issue #1 above. Additional failures:
+- H3.1: `.*` matcher runs on all tools (should be `Bash` only)
+- H3.2: No `description` field on hook
+- H2.2: No `set -e` in bash command
+</details>
+
+<details>
+<summary>MCP Config — 85%, Grade B</summary>
+
+**Passing**: Valid JSON, `mcpServers` structure, env var references, descriptive names.
+
+**Gaps**:
+```
+⚠️ M3.2: Required env vars not documented in README (−3 pts)
+   → Add a ## MCP Configuration section to README.md listing:
+     - JIRA_TOKEN: your Jira API token (Settings > Personal Access Tokens)
+     - GITHUB_TOKEN: GitHub PAT with repo scope
+```
+</details>
+
+---
+
+## Cross-Component Analysis
+
+### Coverage Gaps
+- ✅ CLAUDE.md present (agents exist)
+- ⚠️ `analyzer.md` references `parse-data` skill — but `.claude/skills/parse-data/` not found
+- ✅ Commands have corresponding agents
+
+### Naming Consistency Issues
+- `Summarizer.md` → rename to `summarizer.md`
+- `data_processor/` → rename to `data-processor/`
+
+### Duplication Check
+- `analyzer.md` and `summarizer.md` descriptions have 52% Jaccard overlap — consider merging or differentiating scope
+
+### Security Sweep
+```
+⚠️ .claude/settings.json: sk-prod-abc123  [line 14]
+```
+
+---
+
+## Recommended Action Plan
+
+**Week 1 (Critical)**:
+1. Remove hardcoded key from `settings.json` → use `$AUDIT_API_KEY`
+2. Fix `analyzer.md`: add model, role statement, Bash justification
+
+**Week 2 (Important)**:
+3. Fix `summarizer.md`: model + anti-hallucination + examples
+4. Improve CLAUDE.md: add task classifier table + pattern examples
+5. Fix hook matcher from `.*` to `Bash`
+
+**Week 3 (Polish)**:
+6. Add checklists to `data-processor` skill
+7. Fix file naming: PascalCase and underscore → kebab-case
+8. Document required MCP env vars in README
+
+**Re-run after fixes**: Target overall score ≥85% (Grade B).

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/references/best-practices.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/references/best-practices.md
@@ -1,0 +1,510 @@
+# Best Practices Reference
+
+Rationale, anti-patterns, and quick-fix guidance for each component type.
+
+---
+
+## Skill Types
+
+### Codemie-Delegating Skills: Reduced Rubric Applies
+
+**What they are**: Thin wrapper skills that route a user request to a Codemie AI assistant via API (`codemie assistants chat <uuid>`). They do not execute local tool calls, have no step-by-step workflow, and do not control output format — the backend assistant handles all of that.
+
+**Detection**:
+```bash
+grep -i "codemie.*assistant\|codemie.*chat\|assistants chat" SKILL.md
+```
+
+**What to skip** (do NOT penalise for these — they are architecturally N/A):
+- `allowed-tools` — no local tool execution happens
+- Methodology / workflow section — delegation is the entire process
+- Output format section — determined by the assistant
+- Examples section — invocation differs from standard skills
+- Checklists — no process steps to enumerate
+
+**What still matters** (always assessed):
+- Identity: name convention, description quality (users still need to find and trigger it)
+- Technical hygiene: especially **no hardcoded UUIDs** (see below)
+- Design: single responsibility, clear triggers, token budget
+
+---
+
+## Skills
+
+### ✅ Description: Third-person with specific trigger phrases
+
+**Why it matters**: The `description` field is the only signal Claude uses to decide whether to load a skill. Vague descriptions cause the skill to never load (misses) or load on unrelated tasks (false positives). Specific trigger phrases make the skill predictable.
+
+```yaml
+# ✅ Good — third person, specific phrases
+description: This skill should be used when the user asks to "commit changes",
+  "create a conventional commit", "stage and commit", or wants to write a commit
+  message following the conventional commits standard.
+
+# ❌ Bad — vague, wrong person, no triggers
+description: Use this skill for git operations and commits.
+```
+
+### ✅ `allowed-tools`: Always specify explicitly
+
+**Why it matters**: Without `allowed-tools`, Claude defaults to its full toolset. Explicit restrictions enforce least-privilege and prevent a documentation skill from accidentally running shell commands.
+
+```yaml
+# ✅ Good
+allowed-tools: [Read, Grep, Glob]
+
+# ❌ Bad — missing entirely (defaults to unconstrained)
+# (no allowed-tools field in frontmatter)
+```
+
+### ✅ Keep SKILL.md lean — move details to `references/`
+
+**Why it matters**: SKILL.md loads into context every time the skill triggers. A 6,000-token SKILL.md consumes substantial context even when 80% of the content isn't relevant to the current task. Lean SKILL.md + on-demand references = efficient context use.
+
+**Target**: SKILL.md body 1,500–2,000 words. Move detailed docs to `references/`.
+
+### ✅ Single focused purpose
+
+**Why it matters**: Multi-purpose skills have ambiguous trigger conditions ("does this trigger for commits OR for PRs?") and are harder to maintain (fixing a commit bug might break the PR flow).
+
+```
+# ✅ Good
+name: commit-helper          # one responsibility: commits
+name: pr-creator             # one responsibility: pull requests
+
+# ❌ Bad — three concerns in one
+name: git-workflow-helper    # commits + PRs + branch management
+```
+
+### ✅ Include actionable checklists (`- [ ]`)
+
+**Why it matters**: Checklists make the skill's criteria explicit and verifiable. They give the executing Claude instance something to tick off, reducing missed steps.
+
+---
+
+## Agents
+
+### ✅ Always specify `model:`
+
+**Why it matters**: Without a model, Claude selects the default. The default may be over-powered (costly for simple classification) or under-powered (Haiku for complex reasoning). Explicit model choice is an intentional architectural decision.
+
+```yaml
+# ✅ Good — match model to task complexity
+model: claude-haiku-4-5-20251001    # fast lookups, classification
+model: claude-sonnet-4-6            # balanced reasoning, most tasks
+model: claude-opus-4-6              # complex analysis, architecture
+model: inherit                       # intentionally use calling context's model
+
+# ❌ Bad — no model
+# (no model: field)
+```
+
+**`model: inherit` is valid**: It means the agent deliberately adopts the model of whoever invokes it. This is a legitimate architectural choice (e.g., when agents are invoked from other agents and should match capability). Do **not** penalise `model: inherit` — penalise only a missing `model:` field entirely.
+
+### ✅ Justify powerful tools inline
+
+**Why it matters**: Bash is the most powerful and risky tool, but Write, Edit, WebFetch, and WebSearch also have significant side effects. An agent with an 8-tool list gives no signal about why each tool is needed. Justification creates an audit trail and forces minimum-privilege thinking.
+
+**Rule**: Any tool from `[Bash, Write, Edit, WebFetch, WebSearch]` in a tool list of 4+ tools should be accompanied by an inline comment within 3 lines of the `tools:` declaration.
+
+```yaml
+# ✅ Good — comment immediately after tools line
+tools: [Read, Grep, Bash]
+# Bash required for: git diff, git log to inspect changed files
+
+# ✅ Also good — comment on same line (if format allows)
+tools: [Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, Edit, Write, Bash]
+# Bash: run tests/scripts; Edit/Write: create spec files; WebFetch/WebSearch: look up API docs
+
+# ❌ Bad — no justification for Bash (or any powerful tool)
+tools: [Read, Grep, Glob, Bash, Write, WebFetch]
+# (nothing explaining why Bash, Write, or WebFetch are needed)
+```
+
+**Partial credit**: A comment that says "for running commands" or "for file operations" is better than nothing but too vague — partial credit applies.
+
+### ✅ Description: Third-person with trigger phrases and negative cases
+
+**Why it matters**: The description determines when the agent auto-loads. Three failure modes exist:
+1. **Second-person user-directed** ("Use this agent when **you** need to…") — places the user as subject; awkward in agent routing context
+2. **Object-directed but no negatives** ("Use this agent when the user requests…") — acceptable but incomplete
+3. **Third-person with positives AND negatives** — ideal; routes correctly and prevents over-invocation
+
+```yaml
+# ✅ Best — third person, positive triggers, negative cases
+description: |-
+  This agent should be invoked when code needs to be reviewed for quality or security.
+  Invoke after completing a feature, bug fix, or refactor.
+  Do NOT invoke for: architecture decisions, test writing, or deployment tasks.
+
+# ⚠️ Acceptable — object-directed, missing negative cases
+description: |-
+  Use this agent when the user requests a code review.
+  Focuses on Git-tracked changes only.
+
+# ❌ Bad — user-directed second person, vague
+description: Use this agent when you need to review code.
+```
+
+**Scoring**: Full pass → third-person with negatives; partial → "Use this agent when the user…" with triggers; lower partial → "Use this agent when you…" with triggers.
+
+### ✅ Include anti-hallucination guardrails
+
+**Why it matters**: Without explicit instructions, agents confidently state incorrect information (wrong version numbers, invented API signatures, fabricated statistics). Guardrails reduce this significantly.
+
+```markdown
+# ✅ Good — explicit guardrails
+## Source Verification
+- Cite documentation or tool output when stating facts
+- State "I don't have verified info on..." when uncertain
+- Never invent: statistics, version numbers, API signatures, error messages
+
+# ❌ Bad — no accuracy guidance at all
+```
+
+### ✅ Define scope with negative cases ("When NOT to use")
+
+**Why it matters**: Without negative cases, agents are invoked for everything related to their domain. A "code-reviewer" agent without negative cases might be invoked to review architecture decisions — which is a separate concern.
+
+```markdown
+# ✅ Good
+## Scope
+**DO NOT use this agent for**: architecture decisions, test writing, deployment.
+Use `solution-architect` agent for architecture. Use `test-writer` for tests.
+```
+
+### ✅ "You are…" role statement
+
+**Why it matters**: Role statements calibrate the agent's persona, expertise level, and decision-making style. Without one, behavior is generic and inconsistent across tasks.
+
+```markdown
+# ✅ Good
+You are a senior security engineer with expertise in OWASP Top 10 and secure
+code review. Your job is to identify real vulnerabilities, not style issues.
+
+# ❌ Bad — no role
+# (starts directly with instructions, no persona)
+```
+
+---
+
+## CLAUDE.md
+
+### ✅ Keep CLAUDE.md short — ≤400 non-code words
+
+**Why it matters**: Claude reads CLAUDE.md at the start of every session. Bloated files cause rules to get lost — Claude may miss instructions buried in long prose. The official guidance: *"For each line, ask: 'Would removing this cause Claude to make mistakes?' If not, cut it."*
+
+**Target**: ≤400 words of non-code text. Use code blocks freely (they're scanned, not parsed as prose).
+
+```markdown
+# ✅ Good — lean, verb-first, essential only
+## Code Style
+- ES modules only (import/export), never require()
+- .js extension on all imports
+- Throw specific error classes from src/utils/errors.ts
+
+## Workflow
+- Run `npm run lint` after any TypeScript change
+- NEVER commit to main directly — use feature branches
+
+# ❌ Bad — bloated with obvious or redundant content
+## Code Style
+TypeScript is a strongly typed superset of JavaScript that helps catch errors.
+You should write clean code that follows best practices. Variable names should
+be meaningful and descriptive. Use camelCase for variables and PascalCase for
+classes, which is the standard TypeScript convention...
+```
+
+**Pruning test**: If Claude already follows a rule without being told, delete it. If the rule is about standard language conventions (camelCase, etc.), delete it. If it's project-specific and non-obvious, keep it.
+
+### ✅ Use `@import` to delegate detail
+
+**Why it matters**: `@path/to/file` tells Claude to load that file into context when relevant. This keeps CLAUDE.md lean while making detailed guides available on demand — same progressive disclosure principle as skills.
+
+```markdown
+# ✅ Good — delegates without embedding
+See @README.md for project overview.
+
+# Git workflow
+@docs/git-instructions.md
+
+# Architecture decisions
+@.codemie/guides/architecture/architecture.md
+
+# ❌ Bad — all detail copy-pasted into CLAUDE.md
+## Architecture (500 words of inline architecture prose...)
+```
+
+**When to use `@import`**: Any time CLAUDE.md references a file ("see the architecture guide"), replace the pointer with an actual `@path` reference.
+
+### ✅ Choose one knowledge organisation pattern — and use it consistently
+
+**Why it matters**: There are two valid ways to organise deep project knowledge for Claude. Both work well. Using both at once creates confusion about where knowledge lives.
+
+---
+
+**Pattern A: Single CLAUDE.md + Guide Files**
+
+One lean root CLAUDE.md acts as an index with path references; all detail lives in separate guide files that Claude reads on demand.
+
+```
+# ✅ Good — Pattern A
+./CLAUDE.md                        ← lean index, references guides by path
+./.codemie/guides/architecture.md  ← architecture detail
+./.codemie/guides/testing.md       ← testing patterns
+./docs/git-instructions.md         ← git workflow
+```
+
+CLAUDE.md should reference these guides by actual path so Claude loads them when needed:
+```markdown
+# Architecture
+See .codemie/guides/architecture/architecture.md for layer patterns.
+
+# Testing
+See .codemie/guides/testing/testing-patterns.md for Vitest patterns.
+```
+
+**Best for**: Projects with rich domain knowledge (many guides), or teams wanting a single source of truth with CLAUDE.md as a navigator.
+
+---
+
+**Pattern B: Hierarchical CLAUDE.md**
+
+Multiple CLAUDE.md files at different directory depths, each scoped to its level. Claude automatically loads parent-directory CLAUDE.md files when working in subdirectories.
+
+```
+# ✅ Good — Pattern B
+./CLAUDE.md                    ← project-wide: Node 20+, git workflow, ESLint
+./packages/api/CLAUDE.md       ← api-only: Express patterns, OpenAPI conventions
+./packages/frontend/CLAUDE.md  ← frontend-only: React, CSS modules, Vite
+
+# ❌ Bad — Pattern B with duplication
+./CLAUDE.md              ← has Node.js conventions
+./packages/api/CLAUDE.md ← repeats the same Node.js conventions
+```
+
+**Best for**: Monorepos where different packages have genuinely different tech stacks or conventions.
+
+---
+
+**Detection commands** (run both to identify which pattern is in use):
+```bash
+# Find all CLAUDE.md files
+find . -name "CLAUDE.md" -o -name "CLAUDE.local.md" | grep -v node_modules | sort
+
+# Find guide directories (Pattern A signal)
+find . -type d \( -name 'guides' -o -name '.codemie' \) | grep -v node_modules
+
+# Check git tracking
+git ls-files CLAUDE.md
+
+# Check CLAUDE.local.md is gitignored
+grep CLAUDE.local.md .gitignore
+```
+
+### ✅ Use MANDATORY / NEVER / ALWAYS with trigger conditions
+
+**Why it matters**: Vague guidance ("try to follow…", "consider using…") is deprioritized when Claude is making decisions. Explicit directives with trigger conditions are followed consistently.
+
+```markdown
+# ✅ Good — directive + trigger + rationale
+🚨 MANDATORY: When user says "commit", NEVER use `git commit --no-verify`.
+   If a hook fails, fix the underlying issue first.
+
+# ❌ Bad — vague
+Try to avoid skipping git hooks when possible.
+```
+
+### ✅ Include a keyword/trigger table
+
+**Why it matters**: CLAUDE.md is read on every task. A task classifier table lets Claude quickly identify which rules apply to the current task, rather than re-reading everything every time.
+
+```markdown
+# ✅ Good
+| Keyword | Load Guide / Rule |
+|---------|------------------|
+| "commit", "push" | Follow Git Policy |
+| "test", "spec" | Follow Testing Policy (write tests ONLY if asked) |
+| TypeScript | Use strict mode, .js imports |
+```
+
+### ✅ Show ✅/❌ examples for critical rules
+
+**Why it matters**: Abstract rules ("use meaningful variable names") are interpreted differently. Concrete examples remove ambiguity.
+
+```markdown
+# ✅ Good
+## Import Style
+✅ `import { foo } from './utils.js'`
+❌ `import { foo } from './utils'`     ← missing .js extension
+❌ `const { foo } = require('./utils')` ← no CommonJS
+```
+
+### ✅ Never contradict yourself
+
+**Anti-pattern to avoid**: Having `Always use npm` in one section and `Use pnpm for dependencies` in another. Claude will pick one inconsistently, and behavior becomes unpredictable.
+
+**Prevention**: Search CLAUDE.md for tool names and compare all mentions before writing a new rule.
+
+---
+
+## Commands
+
+### ✅ `argument-hint` is mandatory when using `$ARGUMENTS`
+
+**Why it matters**: Without `argument-hint`, the slash-complete UI shows no hint. Users don't know what to type and the command appears broken.
+
+```yaml
+# ✅ Good
+argument-hint: "<ticket-id> [--dry-run] [--priority high|medium|low]"
+
+# ❌ Bad — uses $ARGUMENTS but no hint
+# (no argument-hint field, $ARGUMENTS appears in body)
+```
+
+### ✅ Phase-based workflow for auditability
+
+**Why it matters**: Numbered phases make command execution auditable ("it failed in Phase 3"). Users understand progress and can debug failures.
+
+```markdown
+# ✅ Good
+## Phase 1: Validate Input
+## Phase 2: Generate Content
+## Phase 3: Confirm and Execute
+
+# ❌ Bad — flat instructions
+Run git status. Then commit. Then push.
+```
+
+### ✅ Always handle the failure path
+
+**Why it matters**: Commands that don't handle failures leave users stranded with no error context and no path forward.
+
+```markdown
+# ✅ Good
+## Error Handling
+| Error | Action |
+|-------|--------|
+| API unreachable | Save draft to ./draft.md, print error |
+| Invalid input | Show usage hint, exit cleanly |
+
+# ❌ Bad — no failure cases mentioned at all
+```
+
+---
+
+## Hooks
+
+### ✅ Scope matchers to specific tools
+
+**Why it matters**: A wildcard matcher (`.*`) runs on every tool use, adding latency to every action Claude takes. Overly broad hooks also create unexpected side effects.
+
+```json
+// ✅ Good — targets specific tool
+{"matcher": "Bash", "hooks": [...]}
+{"matcher": "Write|Edit", "hooks": [...]}
+
+// ❌ Bad — matches everything
+{"matcher": ".*", "hooks": [...]}
+{"matcher": "", "hooks": [...]}
+```
+
+### ✅ Scripts must handle failures explicitly
+
+**Why it matters**: A hook script that crashes without a clean exit blocks the tool use it's attached to. Users see cryptic failures with no context.
+
+```bash
+#!/usr/bin/env bash
+# ✅ Good
+set -e
+trap 'echo "Hook failed on line $LINENO" >&2' ERR
+
+# ❌ Bad — no error handling
+curl https://api.example.com/log -d "$CLAUDE_TOOL_INPUT"
+```
+
+### ✅ Never hardcode credentials in hook commands
+
+**Why it matters**: `settings.json` is often committed to version control. Hardcoded tokens in hooks become exposed credentials in git history.
+
+```json
+// ✅ Good — env var reference
+"command": "bash -c 'curl $API_URL -H \"Authorization: Bearer $MY_TOKEN\"'"
+
+// ❌ Bad — literal token in config
+"command": "bash -c 'curl https://api.example.com -H \"Authorization: Bearer sk-abc123\"'"
+```
+
+---
+
+## MCP Config
+
+### ✅ Use env var references for all credentials
+
+**Why it matters**: `.mcp.json` is often committed to repositories and shared across teams. Literal credentials become a security incident.
+
+```json
+// ✅ Good
+"env": {
+  "API_KEY": "${MY_SERVICE_API_KEY}",
+  "DATABASE_URL": "${DATABASE_URL}"
+}
+
+// ❌ Bad
+"env": {
+  "API_KEY": "sk-prod-abc123",
+  "DATABASE_URL": "postgres://user:pass@prod-host/db"
+}
+```
+
+### ✅ Document required env vars
+
+**Why it matters**: New team members cloning the repo can't use your MCP servers if they don't know which env vars to configure. This creates a "works on my machine" problem.
+
+**Do this**: Add a `.env.example` file or a `## MCP Configuration` section to `CLAUDE.md` listing:
+- Server name
+- Required env var name
+- Where to get the value
+- Example value format (not real value)
+
+### ✅ Use descriptive server names
+
+**Why it matters**: `server1`, `mcp`, `test` give no information about what the server does. Descriptive names help Claude and team members understand the ecosystem at a glance.
+
+```json
+// ✅ Good
+"mcpServers": {
+  "jira": {...},
+  "github": {...},
+  "postgres-analytics": {...}
+}
+
+// ❌ Bad
+"mcpServers": {
+  "server1": {...},
+  "mcp": {...},
+  "test": {...}
+}
+```
+
+---
+
+## Common Anti-Patterns Quick Reference
+
+| Anti-Pattern | Component | Impact | Fix |
+|--------------|-----------|--------|-----|
+| Second-person in skill description ("Use this skill when you…") | Skill | Poor triggering | Rewrite as third-person: "This skill should be used when…" |
+| User-directed agent description ("Use this agent when you need to…") | Agent | Awkward routing | Use "Use this agent when the user requests…" or full third-person |
+| No negative cases in agent description | Agent | Over-invocation | Add "Do NOT invoke for: X, Y, Z" |
+| Missing `model:` field | Agent | Unpredictable cost/quality | Add explicit model; `model: inherit` is valid if intentional |
+| Powerful tools (Bash/Write/Edit) with no inline comment | Agent | Security risk, no audit trail | Add `# <Tool> required for: [reason]` within 3 lines of `tools:` |
+| Wall of text CLAUDE.md | CLAUDE.md | Rules ignored | Add H2 sections + tables |
+| No `argument-hint` | Command | Poor UX | Add `argument-hint: "<description>"` |
+| `.*` matcher in hook | Hook | Latency + side effects | Scope to specific tool name |
+| Hardcoded token in `.mcp.json` | MCP | Security incident | Use `${ENV_VAR_NAME}` pattern |
+| Multi-purpose skill ("does X AND Y AND Z") | Skill | Ambiguous triggers | Split into separate skills |
+| Vague guidance ("be careful") | CLAUDE.md | Rules ignored | Replace with explicit directives |
+| No usage examples in agent | Agent | Unpredictable invocation | Add `## Examples` with 3+ invocation cases |
+| "You are…" role statement missing or buried | Agent | Weak persona calibration | Add "You are a [role]…" as first line of body |
+| No anti-hallucination section | Agent | Accuracy issues | Add "Source Verification" section OR "FIRST STEP: Read [guide]" |
+| Agent references no guides or other components | Agent | Poor grounding | Reference project guides or related skills/agents |

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/references/component-checklists.md
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/references/component-checklists.md
@@ -1,0 +1,413 @@
+# Component Scoring Checklists
+
+Full scoring rubrics for all Claude Code components. Use during Phase 2 of the assessment.
+
+**Scoring logic per criterion:**
+- ✅ Pass → full points
+- ⚠️ Partial → half points (present but incomplete/weak — round down)
+- ❌ Fail → 0 points
+
+---
+
+## Skill Type Classification
+
+Run this check **before** applying any scoring rubric to a skill file.
+
+```bash
+grep -i "codemie.*assistant\|codemie.*chat\|assistants chat" SKILL.md
+```
+
+| Result | Skill Type | Rubric to Apply |
+|--------|-----------|----------------|
+| Match found | **Codemie-delegating** — thin API wrapper that routes to a Codemie assistant backend | Reduced rubric (21 pts max, see below) |
+| No match | **Standard skill** — executes locally via Claude tool calls | Full rubric (32 pts max) |
+
+### Codemie-Delegating Skill: Exemptions Table
+
+These criteria are **N/A** (skip, do not score, do not penalise):
+
+| Criterion | Why exempted |
+|-----------|-------------|
+| S1.4 `allowed-tools` | No local tool execution — the assistant handles it |
+| S2.1 Methodology/workflow | No local workflow steps — delegation is the entire "workflow" |
+| S2.2 Output format | Output is determined by the backend assistant |
+| S2.3 Examples | Usage pattern differs from standard skills; not applicable |
+| S2.4 Checklists | No step-by-step process to check off |
+
+**Applicable criteria for codemie-delegating skills** (21 pts max):
+- S1.1 (3), S1.2 (3), S1.3 (3) — identity always matters
+- S3.1 (1), S3.2 (1, **includes UUID check — see below**), S3.3 (1), S3.4 (1) — technical hygiene
+- S4.1 (2), S4.2 (2), S4.3 (2), S4.4 (2) — design quality
+
+**Scoring formula for codemie-delegating skills**:
+```
+Score = (points obtained from applicable criteria / 21) × 100
+```
+
+---
+
+## Skills (32 points max)
+
+### Structure (weight 3×) — 12 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| S1.1 | Valid SKILL.md filename or frontmatter | 3 | Filename == `SKILL.md` OR YAML frontmatter with `name:` field | File correctly identified as skill |
+| S1.2 | Name follows convention | 3 | Frontmatter `name:` matches `^[a-z0-9-]{1,64}$` | Lowercase, hyphens only, 1–64 chars |
+| S1.3 | Description non-empty | 3 | `description` field exists and length >20 chars | Not empty, not placeholder text |
+| S1.4 | `allowed-tools` specified | 3 | Frontmatter has `allowed-tools:` field | List or `all` value present |
+
+**Partial credit (⚠️)**:
+- S1.2: Name exists but uses underscores or has uppercase → 1.5 pts
+- S1.3: Description exists but <20 chars or is generic ("A skill for…") → 1.5 pts
+- S1.4: `allowed-tools` present but empty list `[]` → 1.5 pts
+
+### Content (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| S2.1 | Methodology or workflow described | 2 | Section titled `Methodology`, `Workflow`, `Process`, or numbered steps present | Structured process documented |
+| S2.2 | Output format specified | 2 | Section `Output`, `Format`, `Deliverables`, or explicit output type mentioned | Output shape defined |
+| S2.3 | Examples provided | 2 | Section `Examples`, `Usage`, `Scenarios` with code blocks or concrete instances | ≥1 concrete example |
+| S2.4 | Actionable checklists | 2 | Markdown checkboxes `- [ ]` or `- [x]` present | ≥3 checklist items |
+
+**Partial credit (⚠️)**:
+- S2.1: Steps exist but not organized (bullet list without numbering) → 1 pt
+- S2.3: Examples section exists but examples are abstract/vague → 1 pt
+- S2.4: Checkboxes present but <3 items → 1 pt
+
+### Technical (weight 1×) — 4 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| S3.1 | No hardcoded absolute paths | 1 | Grep for `/Users/`, `/home/[a-z]`, `C:\`, `D:\` | None found in SKILL.md or bundled scripts |
+| S3.2 | No plaintext secrets | 1 | Grep for `password\s*=`, `api_key\s*=`, `token\s*=` with literal values | None found (comments about avoiding secrets OK) |
+| S3.3 | Script error handling | 1 | If `.sh`/`.bash` files exist: grep for `set -e`, `trap`, `\|\| exit` | All scripts have error handling, or no scripts |
+| S3.4 | Dependencies documented | 1 | If external tools required: section `Requirements`, `Dependencies`, or `Prerequisites` | Prerequisites stated or no external deps |
+
+### Design (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| S4.1 | Single responsibility | 2 | Token count <5000 AND description avoids: `general`, `multi-purpose`, `various` | One focused domain |
+| S4.2 | Clear trigger conditions | 2 | Content has `When to use`, `Triggers`, `Activation`, or `Use cases` | User knows when to invoke |
+| S4.3 | No significant overlap | 2 | Jaccard similarity with other skills <0.5 | <50% keyword overlap with siblings |
+| S4.4 | Token budget respected | 2 | Total file size estimate (words × 1.3) <8000 tokens | Does not bloat context |
+
+---
+
+## Agents / Subagents (32 points max)
+
+### Identity (weight 3×) — 12 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| A1.1 | Descriptive name | 3 | `name:` not matching: `agent\d+`, `test`, `example`, `helper`, `assistant` | Meaningful, domain-specific name |
+| A1.2 | Description with trigger context | 3 | Description uses third-person ("This agent should be invoked when…") with `when`/`trigger` keywords; includes negative cases | User knows when AND when NOT to invoke |
+| A1.3 | Model specified | 3 | Frontmatter `model:` field is present with a value — `inherit`, `sonnet`, `opus`, `haiku` all count | Model explicitly declared (even `inherit` is valid) |
+| A1.4 | Tools appropriately restricted | 3 | All powerful/non-obvious tools justified: Bash AND any of Write/Edit/WebFetch/WebSearch need inline `# <tool> required for: <reason>` comment within 3 lines of `tools:` line | Least-privilege; intent clear |
+
+**Partial credit (⚠️)**:
+- A1.1: Name is generic but somewhat descriptive (e.g., "reviewer") → 1.5 pts
+- A1.2: Uses "Use this agent when the user…" (object-directed) with trigger phrases → 1.5 pts; uses "Use this agent when you…" (user-directed second person) with triggers → 1 pt
+- A1.4: Bash/powerful tools present with partial/non-proximate justification OR ≤3 tools total (minimal set) → 1.5 pts
+
+**A1.3 note**: `model: inherit` means the agent deliberately uses the calling context's model. This is an intentional architectural decision — score as full pass. Only penalise when `model:` field is entirely absent.
+
+### Prompt Quality (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| A2.1 | Role statement defined | 2 | First paragraph of body starts with `You are` OR contains `You are a/an [role]` within first 5 lines | Agent has clear, explicit persona at the top |
+| A2.2 | Output format specified | 2 | Section `Output`, `Format`, `Deliverables`, or inline `## Output Format` / `### Structure` present | Output structure defined |
+| A2.3 | Scope and limits defined | 2 | Section/content: `Scope`, `Limits`, `When NOT to use`, `What to AVOID`, `Do NOT`, `Triggers` | Boundaries explicit |
+| A2.4 | Anti-hallucination measures | 2 | Any of: `verify`, `cite`, `source`, `evidence`, `don't invent`, `hallucination`, `when uncertain`, `only use verified`, `based on`, `read.*first`, `check.*guide`, `FIRST STEP.*read` | Accuracy guardrails present |
+
+**Partial credit (⚠️)**:
+- A2.1: Role implied through purpose statement (`**Purpose**: You will…`) or `## Your Core Mission` with first-person instructions but no "You are…" opener → 1 pt
+- A2.3: Scope mentioned briefly but no negative cases defined → 1 pt
+- A2.4: Some accuracy guidance but not explicit (e.g., "be accurate", "reference docs") → 1 pt
+
+**A2.4 note**: Agents that instruct reading project guides before acting (`FIRST STEP: Read .codemie/guides/…`) provide implicit hallucination guardrails — count as partial pass (1 pt) if no explicit "when uncertain" language exists.
+
+### Validation (weight 1×) — 4 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| A3.1 | 3+ usage examples | 1 | `Examples`, `Usage`, `Scenarios` section with ≥3 distinct entries | Sufficient usage coverage |
+| A3.2 | Edge cases documented | 1 | Keywords: `edge case`, `corner case`, `error`, `failure`, `limitation` | Failure modes acknowledged |
+| A3.3 | Error handling described | 1 | Keywords: `fallback`, `recovery`, `error handling`, `failure mode`, `graceful` | Recovery strategy present |
+| A3.4 | Integration documented | 1 | References other agents, skills, or tools: `uses`, `integrates`, `works with`, `see also` | Ecosystem fit stated |
+
+### Design (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| A4.1 | Single responsibility | 2 | Token count <5000 AND description avoids: `general`, `multi-purpose`, `various`, `all` | One focused domain |
+| A4.2 | No duplication | 2 | Jaccard similarity with other agents <0.5 | <50% overlap with siblings |
+| A4.3 | Composable | 2 | References skills, agents, or project guides: `skill:`, `invoke`, `delegate`, `uses`, `see also`, or direct path refs (`guides/`, `.codemie/`, `SKILL.md`) | Leverages ecosystem — agents, skills, or project knowledge base |
+| A4.4 | Token budget | 2 | File size (words × 1.3) <8000 tokens | Context-efficient |
+
+**A4.3 partial credit (⚠️)**: Agent references project guide files (`.codemie/guides/`, `CLAUDE.md`) for grounding but does not explicitly reference other agents or skills → 1 pt.
+
+---
+
+## CLAUDE.md Rules (36 points max)
+
+### Coverage (weight 3×) — 9 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| R1.1 | Coding standards defined | 3 | Section on code style, language conventions, import patterns, or tooling | Style guidance present |
+| R1.2 | Workflow policies stated | 3 | Git, testing, deployment, or PR policies explicitly documented | Process guidance present |
+| R1.3 | Critical rules with triggers | 3 | Contains `MANDATORY`, `NEVER`, `ALWAYS`, `CRITICAL` with trigger conditions | Non-negotiables documented |
+
+**Partial credit (⚠️)**:
+- R1.1: Brief style mentions but no concrete rules → 1.5 pts
+- R1.3: "Always/Never" keywords present but no trigger context → 1.5 pts
+
+### Clarity (weight 3×) — 9 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| R2.1 | Actionable instructions | 3 | Instructions start with verbs; avoids vague words: `try`, `consider`, `be careful` | Commands are executable |
+| R2.2 | Trigger conditions stated | 3 | Rules specify when they apply: `when user says`, `if file is`, `for TypeScript` | Context is unambiguous |
+| R2.3 | Prohibitions explicit | 3 | `Never`, `Do not`, `Avoid` with concrete examples of what NOT to do | Forbidden actions are clear |
+
+**Partial credit (⚠️)**:
+- R2.1: Mix of actionable and vague instructions → 1.5 pts
+- R2.3: General warnings but no concrete examples → 1.5 pts
+
+### Structure (weight 2×) — 6 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| R3.1 | Section organization | 2 | ≥3 distinct H2 sections (not a wall of text) | Scannable and navigable |
+| R3.2 | Quick-reference tables | 2 | ≥1 markdown table summarizing rules or commands | Fast lookup exists |
+| R3.3 | Pattern examples | 2 | Shows ✅/❌ patterns or code blocks with correct vs incorrect | Good vs bad demonstrated |
+
+### Maintenance (weight 1×) — 6 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| R4.1 | No contradictions | 2 | Rules don't conflict (manual review) | Consistent guidance |
+| R4.2 | Technology versions noted | 2 | Stack versions mentioned: `Node >=20`, `Python 3.11+`, etc. | Version requirements clear |
+| R4.3 | Project context present | 2 | Project name, purpose, or team context stated | Reader understands the project |
+
+### Efficiency (weight 2×) — 6 points
+
+**Before scoring R5.3, detect the knowledge organisation pattern:**
+
+```bash
+find . -name 'CLAUDE.md' | grep -v node_modules | wc -l   # count
+find . -type d \( -name 'guides' -o -name '.codemie' \) | grep -v node_modules  # guide dirs
+```
+
+| Pattern | Detection | R5.3 scoring |
+|---------|-----------|-------------|
+| **A — Single CLAUDE.md + Guide Files** | 1 CLAUDE.md + guide/reference dirs present | Full credit if CLAUDE.md references guide paths |
+| **B — Hierarchical CLAUDE.md** | Multiple CLAUDE.md at different dir depths | **N/A** — hierarchy IS the delegation; auto-pass R5.3 |
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| R5.1 | Concise body | 2 | Non-code-block word count ≤400 words per file | Short enough that all rules are noticed |
+| R5.2 | No anti-pattern content | 2 | Does NOT contain: file-by-file descriptions, standard conventions Claude already knows, self-evident advice ("write clean code", "be careful") | Pruned of noise |
+| R5.3 | Delegates detail appropriately | 2 | **Pattern A**: CLAUDE.md references guide files by path; **Pattern B**: N/A (auto-pass) | Detail offloaded via the chosen pattern |
+
+**Partial credit (⚠️)**:
+- R5.1: 400–700 words → 1 pt; >700 words → 0 (applies to every CLAUDE.md file regardless of pattern)
+- R5.2: A few self-evident statements but critical rules still clear → 1 pt
+- R5.3 (Pattern A only): Guide files exist but CLAUDE.md describes them vaguely without path refs → 1 pt
+
+**R5.1 word count** (exclude code blocks):
+```python
+import re
+def non_code_words(text: str) -> int:
+    no_code = re.sub(r'```.*?```', '', text, flags=re.DOTALL)
+    return len(no_code.split())
+```
+
+**R5.2 anti-pattern detection**:
+```bash
+grep -n "\.md does\|\.ts does\|^- \`src/" CLAUDE.md       # file-by-file descriptions
+grep -ni "write clean\|be careful\|good code\|best practice" CLAUDE.md  # self-evident advice
+```
+
+---
+
+## CLAUDE.md Knowledge Organisation Check
+
+Apply this **after** per-file scoring. This is a **cross-component analysis** (Phase 3).
+
+### Two Valid Patterns — Detect First
+
+Both patterns are correct. Do NOT penalise a repo for not using the other pattern.
+
+**Pattern A: Single CLAUDE.md + Guide Files**
+One root CLAUDE.md acts as an index; domain knowledge lives in separate guide files that CLAUDE.md references by path.
+```
+./CLAUDE.md                       ← lean index, references guides by path
+./.codemie/guides/architecture.md ← detail here
+./.codemie/guides/testing.md
+```
+
+**Pattern B: Hierarchical CLAUDE.md**
+Multiple CLAUDE.md files at different directory levels, each scoped to its context level.
+```
+./CLAUDE.md                       ← project-wide rules
+./packages/api/CLAUDE.md          ← api-specific context only
+./packages/frontend/CLAUDE.md     ← frontend-specific context only
+```
+
+**Mixed pattern flag**: Having both subdir CLAUDE.md files AND a separate guides directory without clear ownership → 🔵 Minor inconsistency.
+
+### Pattern A Checks
+
+| Check | Severity | Detection |
+|-------|----------|-----------|
+| CLAUDE.md doesn't reference guide files by path | 🟡 Important | Guide dirs exist but no path refs to them in CLAUDE.md |
+| `CLAUDE.local.md` not gitignored | 🔴 Critical | `grep CLAUDE.local.md .gitignore` → empty |
+| Root not git-tracked | 🟡 Important | `git ls-files CLAUDE.md` → empty |
+
+### Pattern B Checks
+
+| Check | Severity | Detection |
+|-------|----------|-----------|
+| Root `CLAUDE.md` missing but subdir ones exist | 🟡 Important | No `./CLAUDE.md` but subdir files found |
+| Subdir duplicates root content | 🟡 Important | Jaccard similarity >0.3 between subdir and root |
+| Subdir contains project-wide rules | 🟡 Important | Subdir mentions stack/tooling that applies everywhere |
+| `CLAUDE.local.md` not gitignored | 🔴 Critical | `grep CLAUDE.local.md .gitignore` → empty |
+| Root not git-tracked | 🟡 Important | `git ls-files CLAUDE.md` → empty |
+| Monorepo missing per-package CLAUDE.md | 🔵 Minor | `packages/*/` dirs exist but none have CLAUDE.md |
+
+---
+
+## Commands (20 points max)
+
+### Structure (weight 3×) — 12 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| C1.1 | Valid frontmatter | 3 | YAML frontmatter with `name:` AND `description:` fields | Identity established |
+| C1.2 | Argument hint present | 3 | If `$ARGUMENTS` in body: frontmatter has `argument-hint:` | Usage hints visible in slash-complete |
+| C1.3 | Step-by-step workflow | 3 | Numbered phases (Phase 1…, 1., 2.) or clear H2 sections | Structured process |
+| C1.4 | Usage examples | 3 | Section `Usage`, `Examples` with invocation patterns | Invocation shown |
+
+**Partial credit (⚠️)**:
+- C1.2: Hint present but vague (e.g., `"[args]"`) → 1.5 pts
+- C1.3: Some structure but missing step numbers/phases → 1.5 pts
+
+### Quality (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| C2.1 | Error handling | 2 | Keywords: `error`, `failure`, `fallback`, `if fails`, `on failure` | Failure cases addressed |
+| C2.2 | Output format defined | 2 | Specifies what command produces (report, file, summary) | Output shape documented |
+| C2.3 | Validation gates | 2 | Keywords: `checkpoint`, `verify`, `validate`, `before proceeding`, `confirm` | Safety checks present |
+| C2.4 | Argument parsing shown | 2 | If `$ARGUMENTS` used: shows parsing (defaults, validation, conditional logic) | Arg handling demonstrated |
+
+---
+
+## Hooks (20 points max)
+
+### Validity (weight 3×) — 6 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| H1.1 | Valid JSON structure | 3 | File parses as valid JSON; hooks is an array | Syntactically correct |
+| H1.2 | Recognized event types | 3 | Event values in: `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreCompact`, `Notification` | Known lifecycle events only |
+
+### Security (weight 2×) — 8 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| H2.1 | No hardcoded credentials | 4 | Grep env/command values for: `password`, `secret`, `token`, `key` with literal values | Env var refs only, no literals |
+| H2.2 | Scripts use error handling | 4 | Bash commands in hooks use `set -e`, `trap`, or `\|\| exit` | Scripts exit cleanly on failure |
+
+### Quality (weight 2×) — 6 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| H3.1 | Scoped matchers | 3 | Matchers target specific tools or patterns, not `.*` or empty | Minimum necessary scope |
+| H3.2 | Purpose documented | 3 | `description` field in each hook OR adjacent README explains purpose | Intent is clear |
+
+---
+
+## MCP Config (20 points max)
+
+### Structure (weight 3×) — 9 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| M1.1 | Valid JSON | 3 | File parses as valid JSON | Syntactically correct |
+| M1.2 | `mcpServers` key present | 3 | Top-level key `mcpServers` exists as an object | Standard structure used |
+| M1.3 | Server definitions complete | 3 | Each server has `command` (stdio) or `url` (SSE/HTTP) | Required fields present |
+
+### Security (weight 2×) — 6 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| M2.1 | No hardcoded secrets | 3 | No literal values for `password`, `token`, `key`, `secret` in env sections | Credentials not in config file |
+| M2.2 | Env vars for credentials | 3 | Credentials use `${ENV_VAR}` pattern | Env var references used |
+
+### Documentation (weight 2×) — 5 points
+
+| ID | Criterion | Pts | Detection | Pass Condition |
+|----|-----------|-----|-----------|----------------|
+| M3.1 | Descriptive server names | 2 | Server keys are meaningful (not `server1`, `test`, `mcp`) | Names indicate purpose |
+| M3.2 | Required env vars documented | 3 | README.md, `.env.example`, or CLAUDE.md lists required vars | Setup is documented |
+
+---
+
+## Detection Utilities
+
+### Frontmatter Parser (Python)
+```python
+import re, yaml
+
+def parse_frontmatter(content: str) -> dict:
+    m = re.search(r'^---\n(.*?)\n---', content, re.DOTALL)
+    return yaml.safe_load(m.group(1)) if m else {}
+```
+
+### Token Estimate
+```python
+def estimate_tokens(text: str) -> int:
+    return int(len(text.split()) * 1.3)  # 1 token ≈ 0.75 words
+```
+
+### Jaccard Similarity (overlap detection)
+```python
+def jaccard(text1: str, text2: str) -> float:
+    s1 = set(text1.lower().split())
+    s2 = set(text2.lower().split())
+    return len(s1 & s2) / len(s1 | s2) if (s1 | s2) else 0.0
+# Flag if result > 0.5
+```
+
+### Security Grep
+```bash
+grep -rn \
+  -e '/Users/' \
+  -e '/home/[a-z]' \
+  -e 'password\s*=' \
+  -e 'api_key\s*=' \
+  -e 'token\s*=' \
+  .claude/ .mcp.json \
+  --include="*.md" --include="*.json" --include="*.sh" 2>/dev/null \
+  | grep -v "node_modules" \
+  | grep -v "# "   # skip comment lines
+```
+
+### Grade Calculator
+```python
+def grade(score: float) -> str:
+    if score >= 90: return "A"
+    if score >= 80: return "B"
+    if score >= 70: return "C"
+    if score >= 60: return "D"
+    return "F"
+
+def score(obtained: float, max_pts: float) -> float:
+    return round((obtained / max_pts) * 100, 1)
+```

--- a/src/agents/plugins/claude/plugin/skills/claude-setup-audit/scripts/scan-repo.sh
+++ b/src/agents/plugins/claude/plugin/skills/claude-setup-audit/scripts/scan-repo.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scan-repo.sh — Discover and inventory all Claude Code components in a repository
+# Usage: ./scan-repo.sh [path]
+# Output: Structured inventory of all Claude Code components found
+
+set -e
+
+ROOT="${1:-.}"
+SKILLS=()
+AGENTS=()
+COMMANDS=()
+CLAUDE_MD=""
+HOOKS=""
+MCP=""
+
+# ── Discovery ────────────────────────────────────────────────────────────────
+
+# Skills: SKILL.md files anywhere under .claude/skills/ or plugins/*/skills/
+while IFS= read -r file; do
+  SKILLS+=("$file")
+done < <(find "$ROOT" \( \
+  -path '*/.claude/skills/*/SKILL.md' -o \
+  -path '*/plugins/*/skills/*/SKILL.md' \
+\) -not -path '*/node_modules/*' 2>/dev/null | sort)
+
+# Agents: .md files in .claude/agents/ or plugins/*/agents/
+while IFS= read -r file; do
+  AGENTS+=("$file")
+done < <(find "$ROOT" \( \
+  -path '*/.claude/agents/*.md' -o \
+  -path '*/plugins/*/agents/*.md' \
+\) -not -path '*/node_modules/*' 2>/dev/null | sort)
+
+# Commands: .md files in .claude/commands/ (recursive) or plugins/*/commands/
+while IFS= read -r file; do
+  COMMANDS+=("$file")
+done < <(find "$ROOT" \( \
+  -path '*/.claude/commands/*.md' -o \
+  -path '*/.claude/commands/**/*.md' -o \
+  -path '*/plugins/*/commands/**/*.md' \
+\) -not -path '*/node_modules/*' 2>/dev/null | sort)
+
+# CLAUDE.md: root or .claude/
+if [ -f "$ROOT/CLAUDE.md" ]; then
+  CLAUDE_MD="$ROOT/CLAUDE.md"
+elif [ -f "$ROOT/.claude/CLAUDE.md" ]; then
+  CLAUDE_MD="$ROOT/.claude/CLAUDE.md"
+fi
+
+# Hooks: settings.json
+if [ -f "$ROOT/.claude/settings.json" ]; then
+  HOOKS="$ROOT/.claude/settings.json"
+fi
+
+# MCP config
+if [ -f "$ROOT/.mcp.json" ]; then
+  MCP="$ROOT/.mcp.json"
+elif [ -f "$ROOT/.claude/mcp.json" ]; then
+  MCP="$ROOT/.claude/mcp.json"
+fi
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Claude Code Repository Inventory"
+echo "  Path: $(realpath "$ROOT")"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+echo "📦 SKILLS (${#SKILLS[@]} found)"
+if [ ${#SKILLS[@]} -eq 0 ]; then
+  echo "   (none)"
+else
+  for f in "${SKILLS[@]}"; do
+    # Extract name from frontmatter if possible
+    name=$(grep -m1 '^name:' "$f" 2>/dev/null | sed 's/name: *//' || echo "?")
+    echo "   • $f  [name: $name]"
+  done
+fi
+echo ""
+
+echo "🤖 AGENTS (${#AGENTS[@]} found)"
+if [ ${#AGENTS[@]} -eq 0 ]; then
+  echo "   (none)"
+else
+  for f in "${AGENTS[@]}"; do
+    name=$(grep -m1 '^name:' "$f" 2>/dev/null | sed 's/name: *//' || echo "?")
+    model=$(grep -m1 '^model:' "$f" 2>/dev/null | sed 's/model: *//' || echo "not specified ⚠️")
+    echo "   • $f  [name: $name | model: $model]"
+  done
+fi
+echo ""
+
+echo "⚡ COMMANDS (${#COMMANDS[@]} found)"
+if [ ${#COMMANDS[@]} -eq 0 ]; then
+  echo "   (none)"
+else
+  for f in "${COMMANDS[@]}"; do
+    name=$(grep -m1 '^name:' "$f" 2>/dev/null | sed 's/name: *//' || echo "?")
+    echo "   • $f  [name: $name]"
+  done
+fi
+echo ""
+
+echo "📋 CLAUDE.md"
+if [ -n "$CLAUDE_MD" ]; then
+  lines=$(wc -l < "$CLAUDE_MD" | tr -d ' ')
+  echo "   ✓ $CLAUDE_MD  [$lines lines]"
+else
+  echo "   ✗ Not found"
+fi
+echo ""
+
+echo "🪝 HOOKS"
+if [ -n "$HOOKS" ]; then
+  hook_count=$(grep -c '"event"' "$HOOKS" 2>/dev/null || echo "0")
+  echo "   ✓ $HOOKS  [$hook_count hook(s)]"
+else
+  echo "   ✗ Not found (.claude/settings.json)"
+fi
+echo ""
+
+echo "🔌 MCP CONFIG"
+if [ -n "$MCP" ]; then
+  server_count=$(grep -c '"type"' "$MCP" 2>/dev/null || echo "?")
+  echo "   ✓ $MCP  [~$server_count server(s)]"
+else
+  echo "   ✗ Not found (.mcp.json)"
+fi
+echo ""
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+TOTAL=$(( ${#SKILLS[@]} + ${#AGENTS[@]} + ${#COMMANDS[@]} ))
+echo "  Total components: $TOTAL"
+echo "  Summary: ${#SKILLS[@]} skills | ${#AGENTS[@]} agents | ${#COMMANDS[@]} commands"
+EXTRAS=""
+[ -n "$CLAUDE_MD" ] && EXTRAS+="CLAUDE.md "
+[ -n "$HOOKS" ] && EXTRAS+="hooks "
+[ -n "$MCP" ] && EXTRAS+="MCP "
+echo "  Config files: ${EXTRAS:-none}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── Quick Security Sweep ─────────────────────────────────────────────────────
+echo ""
+echo "🔐 Security Sweep"
+SECURITY_HITS=$(grep -rn \
+  -e '/Users/' \
+  -e '/home/[a-z]' \
+  -e 'password\s*=' \
+  -e 'api_key\s*=' \
+  -e 'token\s*=' \
+  "$ROOT/.claude/" "$ROOT/.mcp.json" \
+  --include="*.md" --include="*.json" --include="*.sh" \
+  2>/dev/null | grep -v "node_modules" | grep -v "# " | head -20 || true)
+
+if [ -z "$SECURITY_HITS" ]; then
+  echo "   ✓ No obvious hardcoded credentials or paths found"
+else
+  echo "   ⚠️  Potential issues detected:"
+  echo "$SECURITY_HITS" | sed 's/^/   /'
+fi
+echo ""

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -280,7 +280,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.10');
+      expect(result.sourceVersion).toBe('1.0.11');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -293,8 +293,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.10');
-      expect(result2.installedVersion).toBe('1.0.10');
+      expect(result2.sourceVersion).toBe('1.0.11');
+      expect(result2.installedVersion).toBe('1.0.11');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -308,7 +308,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.10');
+      expect(json.version).toBe('1.0.11');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a new `claude-setup-audit` skill to the Claude plugin that provides comprehensive quality assessment of Claude Code configurations in a repository. The skill evaluates skills, agents, CLAUDE.md rules, commands, hooks, and MCP configurations against established best practices and produces a graded health report (A–F per component) with actionable recommendations.

## Changes

- **New skill**: `claude-setup-audit` — 5-phase workflow for auditing `.claude/` folder contents including discovery, component-by-component scoring, good/bad examples, prioritized recommendations, and final health report generation
- **Examples & references**: Bundled good/bad examples for skills, agents, commands, hooks, and CLAUDE.md snippets; best-practices and component-checklists reference docs
- **Scan script**: `scripts/scan-repo.sh` helper for component discovery
- **Version bump**: Claude plugin `plugin.json` bumped from 1.0.10 → 1.0.11
- **Tests**: Updated integration test version assertions to match new plugin version

## Impact

Users can now invoke `/claude-setup-audit` (or describe the need) to get a structured audit of their Claude Code setup quality, with letter grades per component and a prioritized fix list.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)