### PR TITLE
fix(proxy): add selected user project to proxy request headers

### DIFF
--- a/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
@@ -89,7 +89,8 @@ class MetricsApiClient {
       'X-CodeMie-CLI': `codemie-cli/${this.config.version}`,
       'X-CodeMie-Client': this.config.clientType,
       'X-CodeMie-Repository': metric.attributes.repository,
-      'X-CodeMie-Branch': metric.attributes.branch
+      'X-CodeMie-Branch': metric.attributes.branch,
+      ...(metric.attributes.project && { 'X-CodeMie-Project': metric.attributes.project })
     };
 
     if (this.config.apiKey) {


### PR DESCRIPTION
## Summary

Fixes missing project context in proxy request headers by conditionally including the X-CodeMie-Project header when a user project is selected.

## Changes

- Added X-CodeMie-Project header to metrics API client requests, populated from metric.attributes.project when available

## Impact

 Before: Proxy requests did not carry project information, making it impossible to associate metrics with a specific user project on the server side.

 After: When a user has a project selected, the X-CodeMie-Project header is included in outgoing proxy requests, enabling correct project-level attribution.

## Checklist

- [ ] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
