### PR TITLE
chore(providers): update recommended model to claude-sonnet-4-6

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,7 +2,7 @@
   "provider": "ai-run",
   "baseUrl": "https://litellm.codemie.example.com",
   "apiKey": "your-litellm-api-key-here",
-  "model": "claude-4-5-sonnet",
+  "model": "claude-sonnet-4-6",
   "timeout": 300,
   "debug": false,
   "allowedDirs": ["/home/user/projects"],

--- a/docs/CLAUDE_MODEL_TIER_AUTO_SELECTION.md
+++ b/docs/CLAUDE_MODEL_TIER_AUTO_SELECTION.md
@@ -42,7 +42,7 @@ If environment variables are not set, auto-select from available models:
 2. **Sonnet Tier**: User's selected model
    - Use the model the user selected during setup
    - This is the default/main model for the profile
-   - Example: `claude-4-5-sonnet`
+   - Example: `claude-sonnet-4-6`
 
 3. **Opus Tier**: Latest opus model
    - Filter models containing "opus" (case-insensitive)
@@ -112,13 +112,13 @@ Result: `claude-opus-4-6-20260205` is selected as the latest opus model.
 
 Available models:
 - `claude-haiku-4-5-20251001`
-- `claude-4-5-sonnet` (user selects this)
+- `claude-sonnet-4-6` (user selects this)
 - `claude-opus-4-5-20251101`
 - `claude-opus-4-6-20260205`
 
 Result:
 - Haiku: `claude-haiku-4-5-20251001` (only haiku available)
-- Sonnet: `claude-4-5-sonnet` (user's selection)
+- Sonnet: `claude-sonnet-4-6` (user's selection)
 - Opus: `claude-opus-4-6-20260205` (latest opus: 4.6 > 4.5)
 
 ### Scenario 2: Environment Variables Set

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -61,7 +61,7 @@ codemie-code --help              # Show help with all options
 
 # With configuration overrides
 codemie-code --profile work-litellm "analyze codebase"
-codemie-code --model claude-4-5-sonnet "review code"
+codemie-code --model claude-sonnet-4-6 "review code"
 codemie-code --provider ollama --model codellama "generate tests"
 ```
 
@@ -83,7 +83,7 @@ codemie-gemini health
 # It's designed to be invoked by IDEs via ACP protocol
 
 # With configuration overrides
-codemie-claude --model claude-4-5-sonnet --api-key sk-... "review code"
+codemie-claude --model claude-sonnet-4-6 --api-key sk-... "review code"
 codemie-gemini -m gemini-2.5-flash --api-key key "optimize performance"
 # With profile selection
 codemie-claude --profile personal-openai "review PR"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,9 +59,9 @@ codemie setup
 # List all profiles (shows active profile with ●)
 codemie profile
 # Output:
-# ● work-litellm (litellm) - claude-4-5-sonnet
+# ● work-litellm (litellm) - claude-sonnet-4-6
 # ○ personal-openai (openai) - gpt-4.1
-# ○ enterprise-sso (ai-run-sso) - claude-4-5-sonnet
+# ○ enterprise-sso (ai-run-sso) - claude-sonnet-4-6
 
 # Switch active profile
 codemie profile switch personal-openai
@@ -91,7 +91,7 @@ Profiles are stored in `~/.codemie/codemie-cli.config.json`:
       "provider": "litellm",
       "baseUrl": "https://litellm.company.com",
       "apiKey": "sk-***",
-      "model": "claude-4-5-sonnet",
+      "model": "claude-sonnet-4-6",
       "timeout": 300
     },
     "personal-openai": {
@@ -259,7 +259,7 @@ Location: `~/.codemie/codemie-cli.config.json`
 ```json
 {
   "provider": "litellm",
-  "model": "claude-sonnet-4-5",
+  "model": "claude-sonnet-4-6",
   "baseUrl": "https://litellm.codemie.example.com",
   "apiKey": "your-api-key",
   "timeout": 300

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -32,7 +32,7 @@ codemie config test
 codemie config init
 
 # Temporary model override
-codemie-claude --model claude-4-5-sonnet "Explain this algorithm"
+codemie-claude --model claude-sonnet-4-6 "Explain this algorithm"
 ```
 
 ## Multi-Provider Workflow Examples
@@ -45,7 +45,7 @@ codemie setup
 # → Name: "work"
 # → Provider: LiteLLM
 # → URL: https://litellm.company.com
-# → Model: claude-4-5-sonnet
+# → Model: claude-sonnet-4-6
 
 # Setup personal profile with OpenAI
 codemie setup
@@ -55,7 +55,7 @@ codemie setup
 
 # List profiles to verify
 codemie profile
-# ● work (litellm) - claude-4-5-sonnet
+# ● work (litellm) - claude-sonnet-4-6
 # ○ personal (openai) - gpt-4.1
 
 # Use work profile during work hours
@@ -132,7 +132,7 @@ codemie analytics show \
 codemie-claude \
   --base-url "${CODEMIE_BASE_URL}" \
   --api-key "${CODEMIE_API_KEY}" \
-  --model "${CODEMIE_MODEL:-claude-4-5-sonnet}" \
+  --model "${CODEMIE_MODEL:-claude-sonnet-4-6}" \
   --provider "litellm" \
   -p "$(cat /tmp/review-prompt.txt)" \
   --max-turns "${CODEMIE_MAX_TURNS:-50}" \

--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -86,7 +86,7 @@ export const ClaudePluginMetadata: AgentMetadata = {
 
   supportedProviders: ['litellm', 'ai-run-sso', 'bedrock', 'bearer-auth'],
   blockedModelPatterns: [],
-  recommendedModels: ['claude-4-5-sonnet', 'claude-4-opus', 'gpt-4.1'],
+  recommendedModels: ['claude-sonnet-4-6', 'claude-4-opus', 'gpt-4.1'],
 
   ssoConfig: {
     enabled: true,

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -444,7 +444,7 @@ async function promptForModelSelection(
         type: 'input',
         name: 'manualModel',
         message: 'No models found. Enter model name manually:',
-        default: 'claude-4-5-sonnet',
+        default: 'claude-sonnet-4-6',
         validate: (input: string) => input.trim() !== '' || 'Model name is required'
       }
     ]);

--- a/src/providers/plugins/bedrock/bedrock.template.ts
+++ b/src/providers/plugins/bedrock/bedrock.template.ts
@@ -20,7 +20,7 @@ export const BedrockTemplate = registerProvider<ProviderTemplate>({
   priority: 15,
   defaultProfileName: 'bedrock',
   recommendedModels: [
-    'claude-sonnet-4-5',      // Latest Claude Sonnet 4.5
+    'claude-sonnet-4-6',      // Latest Claude Sonnet 4.6
   ],
 
   capabilities: ['streaming', 'tools', 'function-calling', 'vision'],

--- a/src/providers/plugins/jwt/jwt.setup-steps.ts
+++ b/src/providers/plugins/jwt/jwt.setup-steps.ts
@@ -112,7 +112,7 @@ export const JWTBearerSetupSteps: ProviderSetupSteps = {
     // Return default models - actual model list will be fetched at runtime with JWT token
     // User can override model selection via CLI or config
     return [
-      'claude-4-5-sonnet',
+      'claude-sonnet-4-6',
       'claude-opus-4-6',
       'claude-4-5-haiku',
       'gpt-4-turbo',

--- a/src/providers/plugins/jwt/jwt.template.ts
+++ b/src/providers/plugins/jwt/jwt.template.ts
@@ -22,7 +22,7 @@ export const JWTTemplate = registerProvider<ProviderTemplate>({
   hidden: true, // Not shown in interactive setup - used only for script/auto-configuration
   defaultProfileName: 'jwt-bearer',
   recommendedModels: [
-    'claude-4-5-sonnet',
+    'claude-sonnet-4-6',
     'claude-opus-4-6',
     'gpt-4-turbo',
   ],

--- a/src/providers/plugins/litellm/litellm.template.ts
+++ b/src/providers/plugins/litellm/litellm.template.ts
@@ -20,7 +20,7 @@ export const LiteLLMTemplate = registerProvider<ProviderTemplate>({
   priority: 14,
   defaultProfileName: 'litellm',
   recommendedModels: [
-    'claude-4-5-sonnet'
+    'claude-sonnet-4-6'
   ],
   capabilities: ['streaming', 'tools', 'function-calling'],
   supportsModelInstallation: false,

--- a/src/providers/plugins/sso/sso.template.ts
+++ b/src/providers/plugins/sso/sso.template.ts
@@ -21,7 +21,7 @@ export const SSOTemplate = registerProvider<ProviderTemplate>({
   priority: 0, // Highest priority (shown first)
   defaultProfileName: 'codemie-sso',
   recommendedModels: [
-    'claude-4-5-sonnet',
+    'claude-sonnet-4-6',
   ],
   capabilities: ['streaming', 'tools', 'sso-auth', 'function-calling', 'embeddings'],
   supportsModelInstallation: false,


### PR DESCRIPTION
## Summary

Updates the recommended model across all providers and documentation from `claude-4-5-sonnet` to `claude-sonnet-4-6`.

## Changes

- Updated `recommendedModels` in all provider templates: LiteLLM, SSO, Bedrock, JWT
- Updated `recommendedModels` in Claude agent plugin
- Updated default fallback model in `setup.ts` manual entry prompt
- Updated default model list in `jwt.setup-steps.ts`
- Updated `config.example.json` example model value
- Updated all doc examples in `COMMANDS.md`, `EXAMPLES.md`, `CONFIGURATION.md`, `CLAUDE_MODEL_TIER_AUTO_SELECTION.md`

## Impact

Before: `claude-4-5-sonnet` shown as recommended during setup and in docs
After: `claude-sonnet-4-6` shown as recommended during setup and in docs

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)