### PR TITLE
fix(proxy): add selected user project to proxy request headers

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -773,7 +773,8 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       authMethod: (env.CODEMIE_AUTH_METHOD as 'sso' | 'jwt') || undefined,
       jwtToken: env.CODEMIE_JWT_TOKEN || undefined,
       repository,
-      branch: branch || undefined
+      branch: branch || undefined,
+      project: env.CODEMIE_PROJECT || undefined
     };
   }
 

--- a/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
@@ -62,12 +62,15 @@ class HeaderInjectionInterceptor implements ProxyInterceptor {
       context.headers['X-CodeMie-Client'] = config.clientType;
     }
 
-    // Add repository and branch headers
+    // Add repository, branch and project headers
     if (config.repository) {
       context.headers['X-CodeMie-Repository'] = config.repository;
     }
     if (config.branch) {
       context.headers['X-CodeMie-Branch'] = config.branch;
+    }
+    if (config.project) {
+      context.headers['X-CodeMie-Project'] = config.project;
     }
 
     logger.debug(`[${this.name}] Injected CodeMie headers`);

--- a/src/providers/plugins/sso/proxy/proxy-types.ts
+++ b/src/providers/plugins/sso/proxy/proxy-types.ts
@@ -27,6 +27,7 @@ export interface ProxyConfig {
   jwtToken?: string;             // JWT token (from CLI arg or env var)
   repository?: string;           // Repository name (parent/current format) for header injection
   branch?: string;               // Git branch at startup for header injection
+  project?: string;              // CodeMie project name for header injection
 }
 
 /**


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                              
Fixes missing project context in proxy request headers by conditionally including the X-CodeMie-Project header when a user project is selected.

Changes

- Added X-CodeMie-Project header to metrics API client requests, populated from metric.attributes.project when available

Impact

Before: Proxy requests did not carry project information, making it impossible to associate metrics with a specific user project on the server side.

After: When a user has a project selected, the X-CodeMie-Project header is included in outgoing proxy requests, enabling correct project-level attribution.

Checklist

- Self-reviewed
- Manual testing performed
- Documentation updated (if needed)
- No breaking changes (or clearly documented)
