### PR TITLE
feat(agents): add OneNote support to msgraph skill

### DIFF
--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.14"
+  "version": "1.0.15"
 }

--- a/src/agents/plugins/claude/plugin/skills/msgraph/README.md
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/README.md
@@ -9,7 +9,7 @@ Work with your Microsoft 365 account from Claude Code — emails, calendar, Shar
 ### 1. Log in (first time only)
 
 ```bash
-node .codemie/claude-plugin/skills/msgraph/scripts/msgraph.js login
+node ~/.codemie/claude-plugin/skills/msgraph/scripts/msgraph.js login
 ```
 
 You'll see a message like:

--- a/src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md
@@ -2,12 +2,13 @@
 name: msgraph
 description: >
   Work with Microsoft 365 services via the Graph API — emails, calendar events, SharePoint sites,
-  Teams chats, OneDrive files, contacts, and org chart. Use this skill whenever the user asks
-  about their emails, inbox, unread messages, meetings, calendar, Teams messages or chats,
-  SharePoint documents, OneDrive files, colleagues, manager, direct reports, or any personal/
-  organizational Microsoft data. Invoke proactively any time the user mentions Outlook, Teams,
-  SharePoint, OneDrive, or wants to interact with their Microsoft 365 account. The skill uses
-  a local Node.js CLI (msgraph.js) that handles authentication, token caching, and all API calls.
+  Teams chats, OneDrive files, OneNote notebooks, contacts, and org chart. Use this skill whenever
+  the user asks about their emails, inbox, unread messages, meetings, calendar, Teams messages or
+  chats, SharePoint documents, OneDrive files, OneNote notes or notebooks, colleagues, manager,
+  direct reports, or any personal/organizational Microsoft data. Invoke proactively any time the
+  user mentions Outlook, Teams, SharePoint, OneDrive, OneNote, or wants to interact with their
+  Microsoft 365 account. The skill uses a local Node.js CLI (msgraph.js) that handles
+  authentication, token caching, and all API calls.
 ---
 
 # Microsoft Graph API Skill
@@ -169,6 +170,32 @@ node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onedrive --download
 node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onedrive --info ITEM_ID
 ```
 
+### OneNote
+
+```bash
+# List all notebooks
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --notebooks
+
+# List sections in a notebook (use ID from --notebooks output)
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --sections NOTEBOOK_ID
+
+# List pages in a section (use ID from --sections output)
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --pages SECTION_ID
+
+# Read a page's content (use ID from --pages output)
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --read PAGE_ID
+
+# Search pages across all notebooks
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --search "meeting notes"
+
+# Create a new page in a section
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --create "My Note" \
+  --section SECTION_ID --body "Note content here"
+
+# Machine-readable JSON output
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js onenote --notebooks --json
+```
+
 ### People & Contacts
 
 ```bash
@@ -204,6 +231,12 @@ node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js people --contacts
 ### "Check my Teams messages"
 1. Run `teams --chats` → list chats
 2. User picks a chat → run `teams --messages CHAT_ID`
+
+### "Show me my OneNote notes" / "Find a note about X"
+1. Run `onenote --notebooks` → list notebooks
+2. Run `onenote --sections NOTEBOOK_ID` → list sections
+3. Run `onenote --pages SECTION_ID` → list pages, or use `onenote --search "keyword"` to search directly
+4. Run `onenote --read PAGE_ID` → display page content
 
 ### "Who's my manager?" / "Who reports to me?"
 - Run `org --manager` or `org --reports`

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -25,7 +25,9 @@ const SCOPES     = [
   'Calendars.Read', 'Calendars.ReadWrite',
   'Files.Read', 'Files.ReadWrite',
   'Sites.Read.All', 'Chat.Read', 'Chat.ReadWrite',
-  'People.Read', 'Contacts.Read', 'offline_access',
+  'People.Read', 'Contacts.Read',
+  'Notes.Read', 'Notes.ReadWrite',
+  'offline_access',
 ].join(' ');
 const CACHE_FILE = path.join(os.homedir(), '.ms_graph_token_cache.json');
 const GRAPH_BASE = 'https://graph.microsoft.com/v1.0';
@@ -676,11 +678,98 @@ async function cmdOrg(args) {
   for (const p of colleagues) console.log(`  ${p.displayName}`);
 }
 
+async function cmdOnenote(args) {
+  const token = await getValidToken();
+  const limit = parseInt(args.limit) || 20;
+
+  if (args.notebooks) {
+    const data      = await graphGet('/me/onenote/notebooks', token, { $top: limit, $select: 'id,displayName,lastModifiedDateTime' });
+    const notebooks = data.value || [];
+    if (args.json) { console.log(JSON.stringify(notebooks, null, 2)); return; }
+    if (!notebooks.length) { console.log('No notebooks found.'); return; }
+    console.log(`\n${'ID'.padEnd(36)}  ${'Modified'.padEnd(18)}  Name`);
+    console.log('─'.repeat(80));
+    for (const nb of notebooks)
+      console.log(`${(nb.id || '').padEnd(36)}  ${fmtDt(nb.lastModifiedDateTime).padEnd(18)}  ${nb.displayName || 'N/A'}`);
+    return;
+  }
+
+  if (args.sections) {
+    const data     = await graphGet(`/me/onenote/notebooks/${args.sections}/sections`, token, { $top: limit, $select: 'id,displayName,lastModifiedDateTime' });
+    const sections = data.value || [];
+    if (args.json) { console.log(JSON.stringify(sections, null, 2)); return; }
+    if (!sections.length) { console.log('No sections found.'); return; }
+    console.log(`\nSections in notebook ${args.sections.slice(0, 20)}...:`);
+    console.log(`${'ID'.padEnd(36)}  Name`);
+    console.log('─'.repeat(70));
+    for (const s of sections)
+      console.log(`${(s.id || '').padEnd(36)}  ${s.displayName || 'N/A'}`);
+    return;
+  }
+
+  if (args.pages) {
+    const data  = await graphGet(`/me/onenote/sections/${args.pages}/pages`, token, { $top: limit, $select: 'id,title,lastModifiedDateTime' });
+    const pages = data.value || [];
+    if (args.json) { console.log(JSON.stringify(pages, null, 2)); return; }
+    if (!pages.length) { console.log('No pages found.'); return; }
+    console.log(`\nPages in section ${args.pages.slice(0, 20)}...:`);
+    console.log(`${'ID'.padEnd(36)}  ${'Modified'.padEnd(18)}  Title`);
+    console.log('─'.repeat(80));
+    for (const p of pages)
+      console.log(`${(p.id || '').padEnd(36)}  ${fmtDt(p.lastModifiedDateTime).padEnd(18)}  ${p.title || '(untitled)'}`);
+    return;
+  }
+
+  if (args.read) {
+    const res  = await httpsRequest(`${GRAPH_BASE}/me/onenote/pages/${args.read}/content`, { headers: { Authorization: `Bearer ${token}` } });
+    if (args.json) { console.log(JSON.stringify({ id: args.read, content: res.body })); return; }
+    console.log(stripHtml(res.body));
+    return;
+  }
+
+  if (args.search) {
+    const data  = await graphGet('/me/onenote/pages', token, { $search: `"${args.search}"`, $top: limit, $select: 'id,title,createdDateTime' });
+    const pages = data.value || [];
+    if (args.json) { console.log(JSON.stringify(pages, null, 2)); return; }
+    if (!pages.length) { console.log(`No pages found matching "${args.search}".`); return; }
+    console.log(`\nSearch results for "${args.search}" (${pages.length}):`);
+    console.log(`${'ID'.padEnd(36)}  Title`);
+    console.log('─'.repeat(70));
+    for (const p of pages)
+      console.log(`${(p.id || '').padEnd(36)}  ${p.title || '(untitled)'}`);
+    return;
+  }
+
+  if (args.create) {
+    if (!args.section) {
+      console.error('Error: --create requires --section SECTION_ID');
+      process.exit(1);
+    }
+    const htmlBody = `<!DOCTYPE html><html><head><title>${args.create}</title></head><body>${args.body || ''}</body></html>`;
+    const res = await httpsRequest(`${GRAPH_BASE}/me/onenote/sections/${args.section}/pages`, {
+      method:  'POST',
+      headers: {
+        Authorization:    `Bearer ${token}`,
+        'Content-Type':   'text/html',
+        'Content-Length': Buffer.byteLength(htmlBody),
+      },
+    }, htmlBody);
+    const page = JSON.parse(res.body);
+    console.log(`Page created: ${page.title || args.create}`);
+    console.log(`ID: ${page.id}`);
+    return;
+  }
+
+  console.log('OneNote: --notebooks | --sections NOTEBOOK_ID | --pages SECTION_ID');
+  console.log('         --read PAGE_ID | --search QUERY');
+  console.log('         --create TITLE --section SECTION_ID [--body CONTENT]');
+}
+
 // ── CLI Parser ────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
   // Flags that take no value (boolean)
   const BOOL = new Set(['json','unread','sites','chats','teamsList','contacts',
-                        'manager','reports','availability','help']);
+                        'manager','reports','availability','notebooks','help']);
   const args = { _: [] };
   let i = 0;
   while (i < argv.length) {
@@ -724,6 +813,9 @@ Data:
            [--info ID] [--json]
   people [--contacts] [--search NAME] [--limit N] [--json]
   org [--manager] [--reports] [--json]
+  onenote [--notebooks] [--sections NOTEBOOK_ID] [--pages SECTION_ID]
+          [--read PAGE_ID] [--search QUERY] [--limit N] [--json]
+          [--create TITLE --section SECTION_ID [--body CONTENT]]
 
 Add --json to any command for machine-readable output.
 
@@ -734,6 +826,12 @@ Examples:
   node ${name} calendar --create "Standup" --start 2024-03-15T09:00 --end 2024-03-15T09:30
   node ${name} teams --chats
   node ${name} onedrive --upload report.pdf --dest "Documents/report.pdf"
+  node ${name} onenote --notebooks
+  node ${name} onenote --sections NOTEBOOK_ID
+  node ${name} onenote --pages SECTION_ID
+  node ${name} onenote --read PAGE_ID
+  node ${name} onenote --search "meeting notes"
+  node ${name} onenote --create "My Note" --section SECTION_ID --body "Content here"
 `);
 }
 
@@ -757,6 +855,7 @@ async function main() {
     onedrive:   () => cmdOnedrive(args),
     people:     () => cmdPeople(args),
     org:        () => cmdOrg(args),
+    onenote:    () => cmdOnenote(args),
     help:       () => { printHelp(); process.exit(0); },
   };
 

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -280,7 +280,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.14');
+      expect(result.sourceVersion).toBe('1.0.15');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -293,8 +293,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.14');
-      expect(result2.installedVersion).toBe('1.0.14');
+      expect(result2.sourceVersion).toBe('1.0.15');
+      expect(result2.installedVersion).toBe('1.0.15');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -308,7 +308,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.14');
+      expect(json.version).toBe('1.0.15');
     });
   });
 });


### PR DESCRIPTION
## Summary

Extends the Microsoft Graph API skill (`msgraph`) with full OneNote support — users can now browse notebooks, sections, and pages, read note content, search across all notebooks, and create new pages, all from within Claude.

## Changes

- Added `Notes.Read` and `Notes.ReadWrite` OAuth scopes to the SCOPES array so the token request includes OneNote permissions
- Implemented `cmdOnenote()` command supporting: `--notebooks`, `--sections NOTEBOOK_ID`, `--pages SECTION_ID`, `--read PAGE_ID`, `--search QUERY`, `--create TITLE --section SECTION_ID [--body CONTENT]`
- Registered `onenote` in the CLI parser COMMANDS map and added `notebooks` to the boolean flags set
- Updated `SKILL.md` skill description to mention OneNote and added a full `### OneNote` section with command examples and a workflow pattern
- Fixed integration test version expectations (`1.0.14` → `1.0.15`) to match the pre-existing `plugin.json` version bump

## Impact

Before: msgraph skill had no OneNote support — users could not access notes via Claude.  
After: Full read/write access to OneNote — list notebooks → drill into sections → browse/read pages → search → create notes.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)