### PR TITLE
fix(agents): bump Claude version to 2.1.63 and add ENABLE_TOOL_SEARCH=0 workaround

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -30,17 +30,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_SUPPORTED_VERSION = '2.1.56';
+const CLAUDE_SUPPORTED_VERSION = '2.1.63';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.56 → minimum = 2.1.41
+ * e.g. supported = 2.1.63 → minimum = 2.1.53
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.41';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.53';
 
 /**
  * Claude Code installer URLs
@@ -155,6 +155,12 @@ export const ClaudePluginMetadata: AgentMetadata = {
       // https://code.claude.com/docs/en/settings
       if (!env.DISABLE_AUTOUPDATER) {
         env.DISABLE_AUTOUPDATER = '1';
+      }
+
+      // WORKAROUND: Disable tool search feature introduced in 2.1.69+
+      // Claude Code 2.1.69+ fails to start without this flag when using CodeMie proxy
+      if (!env.ENABLE_TOOL_SEARCH) {
+        env.ENABLE_TOOL_SEARCH = '0';
       }
 
       // Statusline setup: when --status flag is passed, configure Claude Code


### PR DESCRIPTION
## Summary

Bumps the default Claude Code version to 2.1.63 and adds a `ENABLE_TOOL_SEARCH=0` environment variable workaround required for Claude Code 2.1.69+ compatibility.

## Changes

- Updated `CLAUDE_SUPPORTED_VERSION` from `2.1.56` to `2.1.63`
- Updated `CLAUDE_MINIMUM_SUPPORTED_VERSION` from `2.1.41` to `2.1.53` (10 patch versions below supported)
- Added `ENABLE_TOOL_SEARCH=0` to `beforeRun` lifecycle hook — Claude Code 2.1.69+ fails to start without this flag when using the CodeMie proxy

## Impact

- `codemie-claude` sessions will now have `ENABLE_TOOL_SEARCH=0` set automatically, restoring compatibility with Claude Code >=2.1.69
- Users can still override by setting `ENABLE_TOOL_SEARCH` in their environment before launching

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)