### PR TITLE
Fix/settings json env override warning

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -247,9 +247,17 @@ export const ClaudePluginMetadata: AgentMetadata = {
               const conflicts = Object.keys(settingsEnv).filter(k => mappedVars.includes(k));
 
               if (conflicts.length > 0) {
+                // Detect sensitive keys that should have their values masked
+                const sensitiveKeyPatterns = ['TOKEN', 'KEY', 'SECRET', 'PASSWORD', 'AUTH'];
+                const isSensitive = (key: string) =>
+                  sensitiveKeyPatterns.some(pattern => key.toUpperCase().includes(pattern));
+
                 console.warn(chalk.yellow('\n⚠️  Warning: ~/.claude/settings.json contains env vars that will override CodeMie profile settings:'));
                 for (const key of conflicts) {
-                  console.warn(chalk.yellow(`   - ${key}: "${settingsEnv[key]}"`));
+                  const value = settingsEnv[key];
+                  // Mask sensitive values to prevent credential leakage
+                  const displayValue = isSensitive(key) ? '***REDACTED***' : `"${value}"`;
+                  console.warn(chalk.yellow(`   - ${key}: ${displayValue}`));
                 }
                 console.warn(chalk.yellow('   These settings.json values take precedence over your CodeMie profile.'));
                 console.warn(chalk.yellow('   Remove them from ~/.claude/settings.json to allow CodeMie to control these settings.\n'));

--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -227,6 +227,41 @@ export const ClaudePluginMetadata: AgentMetadata = {
         }
       }
 
+      // Warn if settings.json contains env vars that will override CodeMie's profile settings
+      {
+        const { readFile } = await import('fs/promises');
+        const { existsSync } = await import('fs');
+        const { join } = await import('path');
+
+        const settingsPath = join(resolveHomeDir('.claude'), 'settings.json');
+
+        if (existsSync(settingsPath)) {
+          try {
+            const raw = await readFile(settingsPath, 'utf-8');
+            const settings = JSON.parse(raw) as Record<string, unknown>;
+            const settingsEnv = settings.env as Record<string, string> | undefined;
+
+            if (settingsEnv && typeof settingsEnv === 'object') {
+              // Collect all env var names from envMapping
+              const mappedVars = Object.values(ClaudePluginMetadata.envMapping ?? {}).flat();
+              const conflicts = Object.keys(settingsEnv).filter(k => mappedVars.includes(k));
+
+              if (conflicts.length > 0) {
+                console.warn(chalk.yellow('\n⚠️  Warning: ~/.claude/settings.json contains env vars that will override CodeMie profile settings:'));
+                for (const key of conflicts) {
+                  console.warn(chalk.yellow(`   - ${key}: "${settingsEnv[key]}"`));
+                }
+                console.warn(chalk.yellow('   These settings.json values take precedence over your CodeMie profile.'));
+                console.warn(chalk.yellow('   Remove them from ~/.claude/settings.json to allow CodeMie to control these settings.\n'));
+                logger.warn('[Claude] settings.json env conflict detected', ...sanitizeLogArgs({ conflicts }));
+              }
+            }
+          } catch {
+            // Silently ignore parse errors - already handled in statusLine block if applicable
+          }
+        }
+      }
+
       return env;
     },
 


### PR DESCRIPTION

## Summary

Detects when `~/.claude/settings.json` contains env entries that silently override the environment variables CodeMie sets at spawn time (e.g. `ANTHROPIC_BASE_URL`,
`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`). When a conflict is found, a clear warning is printed before Claude launches so users understand why their CodeMie profile
settings are not taking effect.

## Changes

  - Added conflict-detection logic to the Claude plugin's beforeRun lifecycle hook that reads ~/.claude/settings.json and compares its env keys against all vars defined in ClaudePluginMetadata.envMapping
  - Emits a user-visible console.warn (yellow, emoji-prefixed) listing each conflicting variable with its value (or ***REDACTED*** for sensitive keys), with actionable guidance to remove them
  - Sensitive values are automatically masked for env vars containing: TOKEN, KEY, SECRET, PASSWORD, or AUTH (case-insensitive)
  - Logs the conflict via logger.warn with sanitized args for debug traceability
  - No changes to settings.json are made — the fix is purely informational and non-destructive

## Impact

**Before**: If ~/.claude/settings.json contained "env": { "ANTHROPIC_BASE_URL": "..." }, CodeMie would silently report the correct profile/model while Claude actually
connected to the wrong endpoint — no indication anything was wrong.

**After**: The user sees this warning before Claude starts:

```
 ⚠️  Warning: ~/.claude/settings.json contains env vars that will override CodeMie profile settings:
     - ANTHROPIC_AUTH_TOKEN: ***REDACTED***
     - ANTHROPIC_BASE_URL: "https://some-custom-endpoint.example.com"
     These settings.json values take precedence over your CodeMie profile.
     Remove them from ~/.claude/settings.json to allow CodeMie to control these settings.
```

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
