### PR TITLE
docs: fix outdated `codemie auth` references in AUTHENTICATION.md

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -35,16 +35,16 @@ If you need to authenticate separately or refresh your credentials:
 
 ```bash
 # Authenticate with AI/Run CodeMie SSO
-codemie auth login --url https://your-airun-codemie-instance.com
+codemie profile login --url https://your-airun-codemie-instance.com
 
 # Check authentication status
-codemie auth status
+codemie profile status
 
 # Refresh expired tokens
-codemie auth refresh
+codemie profile refresh
 
 # Logout and clear credentials
-codemie auth logout
+codemie profile logout
 ```
 
 ## Token Management
@@ -57,7 +57,7 @@ AI/Run CodeMie CLI automatically refreshes tokens when they expire. For manual r
 
 ```bash
 # Refresh SSO credentials (extends session)
-codemie auth refresh
+codemie profile refresh
 ```
 
 **When to refresh manually:**
@@ -71,7 +71,7 @@ codemie auth refresh
 Check your current authentication state:
 
 ```bash
-codemie auth status
+codemie profile status
 ```
 
 **Status information includes:**
@@ -86,15 +86,15 @@ Common authentication issues and solutions:
 
 ```bash
 # Token expired
-codemie auth refresh
+codemie profile refresh
 
 # Connection issues
 codemie doctor                    # Full system diagnostics
-codemie auth status              # Check auth-specific issues
+codemie profile status              # Check auth-specific issues
 
 # Complete re-authentication
-codemie auth logout
-codemie auth login --url https://your-airun-codemie-instance.com
+codemie profile logout
+codemie profile login --url https://your-airun-codemie-instance.com
 
 # Reset all configuration
 codemie config reset


### PR DESCRIPTION
## Summary

- `docs/AUTHENTICATION.md` references the non-existent `codemie auth` command (10 occurrences)
- The `codemie auth` command was consolidated into `codemie profile` in PR #51, but this doc file was missed during that update
- This PR replaces all `codemie auth` → `codemie profile` to match the actual CLI

## Context

The auth-to-profile migration happened in Dec 2025:
- **PR #51** (`dd1902e`) — moved code from `src/cli/commands/auth.ts` to `src/cli/commands/profile/auth.ts`
- **PR #55** (`f17c82a`) — updated `README.md` and `docs/COMMANDS.md`, but `docs/AUTHENTICATION.md` was missed

## Test plan

- [x] Verify all commands referenced in the doc (`codemie profile login`, `status`, `refresh`, `logout`) exist in the CLI