### PR TITLE
fix(cli): exit silently when CODEMIE_AGENT env var is absent in hook handler

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -129,19 +129,18 @@ function getConfigValue(envKey: string, config?: HookProcessingConfig): string |
 function initializeLoggerContext(): string {
   const agentName = process.env.CODEMIE_AGENT;
   if (!agentName) {
-    // Debug: Log all environment variables that start with CODEMIE_
-    const codemieEnvVars = Object.keys(process.env)
-      .filter(key => key.startsWith('CODEMIE_'))
-      .map(key => `${key}=${process.env[key]}`)
-      .join(', ');
-    console.error(`[hook:debug] CODEMIE_AGENT missing. Available CODEMIE_* vars: ${codemieEnvVars || 'none'}`);
-    throw new Error('CODEMIE_AGENT environment variable is required');
+    // Not running inside a codemie-managed session — exit silently.
+    // This happens when the plugin is loaded via --plugin-dir but CODEMIE_AGENT
+    // was never set (e.g. bare `claude` invocation for a personal account).
+    // Throwing here causes Claude Code to display "Hook cancelled" to the user.
+    process.exit(0);
   }
 
   // Use CODEMIE_SESSION_ID from environment
   const sessionId = process.env.CODEMIE_SESSION_ID;
   if (!sessionId) {
-    throw new Error('CODEMIE_SESSION_ID environment variable is required');
+    // Same rationale: exit silently rather than surfacing an error to the user.
+    process.exit(0);
   }
 
   // Set logger context
@@ -1253,7 +1252,9 @@ export function createHookCommand(): Command {
           process.exit(2); // Blocking error
         }
 
-        if (!event.transcript_path) {
+        // transcript_path is optional for SessionStart/SessionEnd (consistent with validateHookEvent)
+        const transcriptOptionalEvents = ['SessionStart', 'SessionEnd'];
+        if (!event.transcript_path && !transcriptOptionalEvents.includes(event.hook_event_name)) {
           logger.error('[hook] Missing required field: transcript_path');
           logger.debug(`[hook] Received event: ${JSON.stringify(event)}`);
           process.exit(2); // Blocking error


### PR DESCRIPTION
## Summary

- Fixes "SessionEnd hook failed: Hook cancelled" shown on every session exit when the codemie plugin is loaded via `--plugin-dir` but the session is not managed by codemie (e.g. a bare `claude` invocation).
- Aligns `createHookCommand()` transcript_path validation with `validateHookEvent()` — `SessionStart`/`SessionEnd` do not require `transcript_path`.

## Root cause

`codemie hook` calls `initializeLoggerContext()`, which throws when `CODEMIE_AGENT` or `CODEMIE_SESSION_ID` are absent. Missing env vars in this context is not an error — it means the hook is running outside a codemie-managed session and should simply no-op. The thrown error propagates as exit code 1, which Claude Code surfaces as "Hook cancelled".

## Changes

**Fix 1 — `initializeLoggerContext()`**: Replace `throw new Error(...)` with `process.exit(0)` when `CODEMIE_AGENT` / `CODEMIE_SESSION_ID` are not set. Removed the debug logging added during investigation since the exit is now intentional and expected.

**Fix 2 — `createHookCommand()`**: `transcript_path` is marked optional for `SessionStart`/`SessionEnd` in `validateHookEvent()`, but the CLI handler was unconditionally requiring it for all events and exiting with code 2. Added a `transcriptOptionalEvents` check to match the validator's behavior.

## Test plan

- [ ] Run `claude` directly (not via `codemie-claude`) with the codemie plugin active — session should exit cleanly with no "Hook cancelled" message
- [ ] Run via `codemie-claude` — `SessionEnd` hook should execute normally (CODEMIE_AGENT is set by BaseAgentAdapter)
- [ ] Verify `SessionStart`/`SessionEnd` events without `transcript_path` no longer cause exit code 2

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)