### PR TITLE
fix(agents): bump Claude Code supported version to 2.1.92, minimum to 2.1.82

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -30,17 +30,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_SUPPORTED_VERSION = '2.1.78';
+const CLAUDE_SUPPORTED_VERSION = '2.1.92';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.78 → minimum = 2.1.60
+ * e.g. supported = 2.1.92 → minimum = 2.1.82
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.60';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.82';
 
 /**
  * Claude Code installer URLs


### PR DESCRIPTION
## Summary

Updates Claude Code version constants to reflect the latest verified release. The latest supported version is bumped to 2.1.92 and the minimum required version is updated to 2.1.82 (10 patch versions below latest, per project convention).

## Changes

- `CLAUDE_SUPPORTED_VERSION`: `2.1.78` → `2.1.92`
- `CLAUDE_MINIMUM_SUPPORTED_VERSION`: `2.1.60` → `2.1.82`
- Updated inline comment to document the new version relationship

## Impact

Users running Claude Code below 2.1.82 will be blocked from starting. Users on 2.1.82–2.1.92 are fully supported.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)