### PR TITLE
fix(proxy): transform thinking params for claude-opus-4-7 adaptive API

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -30,17 +30,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_SUPPORTED_VERSION = '2.1.92';
+const CLAUDE_SUPPORTED_VERSION = '2.1.114';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.92 → minimum = 2.1.82
+ * e.g. supported = 2.1.114 → minimum = 2.1.104
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.82';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.104';
 
 /**
  * Claude Code installer URLs

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/claude-thinking-transformer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/claude-thinking-transformer.plugin.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Claude Thinking Transformer Plugin Tests
+ *
+ * Tests proxy-level transformation of thinking params for claude-opus-4-7:
+ *   - thinking.type "enabled"  → thinking.type "adaptive" + output_config.effort
+ *   - thinking.type "disabled" → field removed entirely
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ClaudeThinkingTransformerPlugin } from '../claude-thinking-transformer.plugin.js';
+import { PluginContext, ProxyInterceptor } from '../types.js';
+import { ProxyContext } from '../../proxy-types.js';
+import { logger } from '../../../../../../utils/logger.js';
+
+/** Helper: create a minimal PluginContext */
+function createPluginContext(clientType?: string, model?: string): PluginContext {
+  return {
+    config: {
+      targetApiUrl: 'https://api.anthropic.com',
+      provider: 'test',
+      sessionId: 'test-session',
+      clientType,
+      model,
+    },
+    logger,
+  };
+}
+
+/** Helper: create a ProxyContext with JSON body */
+function createProxyContext(body: Record<string, unknown> | null, contentType = 'application/json'): ProxyContext {
+  const requestBody = body ? Buffer.from(JSON.stringify(body), 'utf-8') : null;
+  return {
+    requestId: 'test-req',
+    sessionId: 'test-session',
+    agentName: 'test-agent',
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {
+      'content-type': contentType,
+      ...(requestBody && { 'content-length': String(requestBody.length) }),
+    },
+    requestBody,
+    requestStartTime: Date.now(),
+    metadata: {},
+  };
+}
+
+describe('ClaudeThinkingTransformerPlugin', () => {
+  let plugin: ClaudeThinkingTransformerPlugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new ClaudeThinkingTransformerPlugin();
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('Plugin Metadata', () => {
+    it('has correct id', () => {
+      expect(plugin.id).toBe('@codemie/proxy-claude-thinking-transformer');
+    });
+
+    it('has correct name', () => {
+      expect(plugin.name).toBe('Claude Thinking Transformer');
+    });
+
+    it('has correct version', () => {
+      expect(plugin.version).toBe('1.0.0');
+    });
+
+    it('has priority 16 (after RequestSanitizer at 15)', () => {
+      expect(plugin.priority).toBe(16);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('createInterceptor — Agent Scoping', () => {
+    it('creates interceptor for codemie-claude', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+      expect(interceptor).toBeDefined();
+      expect(interceptor.name).toBe('claude-thinking-transformer');
+    });
+
+    it('throws for codemie-code agent', async () => {
+      await expect(plugin.createInterceptor(createPluginContext('codemie-code')))
+        .rejects.toThrow('Plugin disabled for agent: codemie-code');
+    });
+
+    it('throws for codemie-opencode agent', async () => {
+      await expect(plugin.createInterceptor(createPluginContext('codemie-opencode')))
+        .rejects.toThrow('Plugin disabled for agent: codemie-opencode');
+    });
+
+    it('throws for undefined clientType', async () => {
+      await expect(plugin.createInterceptor(createPluginContext(undefined)))
+        .rejects.toThrow('Plugin disabled');
+    });
+
+    it('throws for empty string clientType', async () => {
+      await expect(plugin.createInterceptor(createPluginContext('')))
+        .rejects.toThrow('Plugin disabled');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('thinking.type "enabled" → adaptive transformation', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+    });
+
+    it('sets thinking.type to adaptive for claude-opus-4-7', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+    });
+
+    it('removes budget_tokens from thinking object', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 5000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking.budget_tokens).toBeUndefined();
+    });
+
+    it('sets output_config.effort based on budget_tokens (high for >8192)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config).toEqual({ effort: 'high' });
+    });
+
+    it('sets output_config.effort to medium for budget_tokens <= 8192', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 4000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config).toEqual({ effort: 'medium' });
+    });
+
+    it('sets output_config.effort to low for budget_tokens <= 2048', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 1024 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('sets effort to low when budget_tokens is absent', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('low');
+    });
+
+    it('does not overwrite an existing output_config.effort', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 20000 },
+        output_config: { effort: 'medium' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('medium'); // caller's value preserved
+    });
+
+    it('preserves existing output_config fields other than effort', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+        output_config: { some_other_field: 'value' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('high');
+      expect(body.output_config.some_other_field).toBe('value');
+    });
+
+    it('transforms for versioned model id (claude-opus-4-7-20250514)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7-20250514',
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+      expect(body.output_config.effort).toBeDefined();
+    });
+
+    it('sets effort to low for budget_tokens exactly at boundary (2048)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 2048 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('low');
+    });
+
+    it('sets effort to medium for budget_tokens just above low boundary (2049)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 2049 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('medium');
+    });
+
+    it('sets effort to medium for budget_tokens exactly at boundary (8192)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 8192 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('medium');
+    });
+
+    it('sets effort to high for budget_tokens just above medium boundary (8193)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 8193 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.output_config.effort).toBe('high');
+    });
+
+    it('uses configModel fallback when body.model is absent', async () => {
+      const interceptorWithConfig = await plugin.createInterceptor(
+        createPluginContext('codemie-claude', 'claude-opus-4-7')
+      );
+      const context = createProxyContext({
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'enabled', budget_tokens: 2000 },
+      });
+
+      await interceptorWithConfig.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+      expect(body.output_config.effort).toBeDefined();
+    });
+
+    it('preserves all other body fields', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'test' }],
+        max_tokens: 4096,
+        thinking: { type: 'enabled', budget_tokens: 2000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.model).toBe('claude-opus-4-7');
+      expect(body.messages).toHaveLength(1);
+      expect(body.max_tokens).toBe(4096);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('thinking.type "disabled" → field removal', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+    });
+
+    it('removes thinking field entirely for claude-opus-4-7', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'disabled' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toBeUndefined();
+    });
+
+    it('does not touch output_config when removing disabled thinking', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'disabled' },
+        output_config: { effort: 'low' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toBeUndefined();
+      expect(body.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('does not remove disabled thinking for non-matching model', async () => {
+      const context = createProxyContext({
+        model: 'claude-sonnet-4-5',
+        thinking: { type: 'disabled' },
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('No-op Cases', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+    });
+
+    it('does not modify thinking for non-matching model', async () => {
+      const context = createProxyContext({
+        model: 'claude-sonnet-4-5',
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+
+    it('does not transform for two-digit sub-minor model (claude-opus-4-70)', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-70',
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+
+    it('does not modify when thinking.type is already adaptive', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'adaptive' },
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+
+    it('does not modify when no thinking field present', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+
+    it('passes through when request body is null', async () => {
+      const context = createProxyContext(null);
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody).toBeNull();
+    });
+
+    it('passes through for non-JSON content-type', async () => {
+      const context = createProxyContext(
+        { model: 'claude-opus-4-7', thinking: { type: 'enabled', budget_tokens: 1000 } },
+        'text/plain',
+      );
+      const originalBody = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBody);
+    });
+
+    it('processes application/json; charset=utf-8 content-type', async () => {
+      const context = createProxyContext(
+        { model: 'claude-opus-4-7', thinking: { type: 'enabled', budget_tokens: 10000 } },
+        'application/json; charset=utf-8',
+      );
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toEqual({ type: 'adaptive' });
+    });
+
+    it('passes through malformed JSON without error', async () => {
+      const context: ProxyContext = {
+        requestId: 'test-req',
+        sessionId: 'test-session',
+        agentName: 'test-agent',
+        method: 'POST',
+        url: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+        requestBody: Buffer.from('not valid json{{{', 'utf-8'),
+        requestStartTime: Date.now(),
+        metadata: {},
+      };
+
+      await expect(interceptor.onRequest!(context)).resolves.toBeUndefined();
+      expect(context.requestBody!.toString('utf-8')).toBe('not valid json{{{');
+    });
+
+    it('does nothing when model is absent and no configModel', async () => {
+      const context = createProxyContext({
+        thinking: { type: 'enabled', budget_tokens: 1000 },
+      });
+      const originalBodyStr = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBodyStr);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('Content-Length Update', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+    });
+
+    it('updates content-length header to match new body size after enabled→adaptive', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      expect(Number(context.headers['content-length'])).toBe(context.requestBody!.length);
+    });
+
+    it('updates content-length header to match new body size after disabled removal', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        thinking: { type: 'disabled' },
+      });
+
+      await interceptor.onRequest!(context);
+
+      expect(Number(context.headers['content-length'])).toBe(context.requestBody!.length);
+    });
+
+    it('does not change content-length when no transformation needed', async () => {
+      const context = createProxyContext({
+        model: 'claude-opus-4-7',
+        messages: [],
+      });
+      const originalLength = context.headers['content-length'];
+
+      await interceptor.onRequest!(context);
+
+      expect(context.headers['content-length']).toBe(originalLength);
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/claude-thinking-transformer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/claude-thinking-transformer.plugin.ts
@@ -1,0 +1,128 @@
+/**
+ * Claude Thinking Transformer Plugin
+ * Priority: 16 (runs after Request Sanitizer at 15, before header injection at 20)
+ *
+ * Transforms thinking parameters for Claude models that require the new adaptive
+ * thinking API (e.g. claude-opus-4-7).
+ *
+ * Problem: Claude Code sends `thinking: { type: "enabled", budget_tokens: N }`
+ * for Opus models. claude-opus-4-7 rejects this with HTTP 400:
+ *   "thinking.type.enabled" is not supported for this model. Use
+ *   "thinking.type.adaptive" and "output_config.effort" instead.
+ *
+ * Fix: When the request model matches a Claude 4.7+ pattern:
+ *   - "enabled"  → thinking: { type: "adaptive" } + output_config.effort (derived
+ *                  from budget_tokens; only written if not already present)
+ *   - "disabled" → delete the thinking field entirely (model does not accept this value)
+ *
+ * Scope: Only enabled for codemie-claude agent (Claude Code via SSO proxy).
+ *
+ * To add support for a new model: append a pattern to ADAPTIVE_THINKING_MODEL_PATTERNS.
+ */
+
+import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+
+/**
+ * Model name patterns that require the adaptive thinking API.
+ * Matches claude-opus-4-7, claude-opus-4-7-20250514, and future date-tagged variants.
+ * Extend this list as Anthropic migrates additional models — see EPMCDME-11821.
+ */
+const ADAPTIVE_THINKING_MODEL_PATTERNS: RegExp[] = [
+  /claude-opus-4-[7-9](?:[^0-9]|$)/i,  // claude-opus-4-7/8/9 and date-tagged variants (e.g. claude-opus-4-7-20250514); excludes claude-opus-4-70+
+];
+
+function modelRequiresAdaptiveThinking(modelName: string): boolean {
+  return ADAPTIVE_THINKING_MODEL_PATTERNS.some(p => p.test(modelName));
+}
+
+/**
+ * Map legacy budget_tokens to the closest output_config.effort level.
+ *
+ * budget_tokens was the maximum token budget for thinking in the old API.
+ * effort is a coarser control in the new API: low / medium / high.
+ */
+function budgetTokensToEffort(budgetTokens: unknown): 'low' | 'medium' | 'high' {
+  const tokens = typeof budgetTokens === 'number' ? budgetTokens : 0;
+  if (tokens <= 2048) return 'low';
+  if (tokens <= 8192) return 'medium';
+  return 'high';
+}
+
+/** Agent that sends Claude API requests through the codemie proxy */
+const ALLOWED_AGENT = 'codemie-claude';
+
+export class ClaudeThinkingTransformerPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-claude-thinking-transformer';
+  name = 'Claude Thinking Transformer';
+  version = '1.0.0';
+  priority = 16; // After RequestSanitizer (15), before HeaderInjection (20)
+
+  async createInterceptor(context: PluginContext): Promise<ProxyInterceptor> {
+    const clientType = context.config.clientType;
+    if (!clientType || clientType !== ALLOWED_AGENT) {
+      throw new Error(`Plugin disabled for agent: ${clientType}`);
+    }
+    // Pass the configured model as a fallback for requests that omit body.model
+    const configModel = context.config.model;
+    return new ClaudeThinkingTransformerInterceptor(configModel);
+  }
+}
+
+class ClaudeThinkingTransformerInterceptor implements ProxyInterceptor {
+  name = 'claude-thinking-transformer';
+
+  constructor(private readonly configModel?: string) {}
+
+  async onRequest(context: ProxyContext): Promise<void> {
+    if (!context.requestBody || !context.headers['content-type']?.includes('application/json')) {
+      return;
+    }
+
+    try {
+      const bodyStr = context.requestBody.toString('utf-8');
+      const body = JSON.parse(bodyStr);
+
+      const thinkingType = body.thinking?.type;
+      if (thinkingType !== 'enabled' && thinkingType !== 'disabled') {
+        return;
+      }
+
+      // Resolve model: prefer request body, fall back to proxy config
+      const model = (typeof body.model === 'string' && body.model) || this.configModel || '';
+      if (!model || !modelRequiresAdaptiveThinking(model)) {
+        return;
+      }
+
+      if (thinkingType === 'enabled') {
+        const effort = budgetTokensToEffort(body.thinking.budget_tokens);
+
+        // Replace old thinking object with new adaptive format
+        body.thinking = { type: 'adaptive' };
+
+        // Set output_config.effort only if the caller hasn't already specified it
+        if (!body.output_config?.effort) {
+          body.output_config = { ...(body.output_config ?? {}), effort };
+        }
+
+        logger.debug(
+          `[${this.name}] Transformed thinking: "enabled" → "adaptive", effort="${effort}" for model: ${model}`
+        );
+      } else {
+        // thinking.type === 'disabled': model does not accept this value — remove the field
+        delete body.thinking;
+
+        logger.debug(
+          `[${this.name}] Removed unsupported thinking.type="disabled" for model: ${model}`
+        );
+      }
+
+      const newBodyStr = JSON.stringify(body);
+      context.requestBody = Buffer.from(newBodyStr, 'utf-8');
+      context.headers['content-length'] = String(context.requestBody.length);
+    } catch {
+      // Not valid JSON or unexpected structure — pass through unchanged
+    }
+  }
+}

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -12,6 +12,7 @@ import { SSOAuthPlugin } from './sso-auth.plugin.js';
 import { JWTAuthPlugin } from './jwt-auth.plugin.js';
 import { HeaderInjectionPlugin } from './header-injection.plugin.js';
 import { RequestSanitizerPlugin } from './request-sanitizer.plugin.js';
+import { ClaudeThinkingTransformerPlugin } from './claude-thinking-transformer.plugin.js';
 import { LoggingPlugin } from './logging.plugin.js';
 import { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 
@@ -28,6 +29,7 @@ export function registerCorePlugins(): void {
   registry.register(new SSOAuthPlugin());
   registry.register(new JWTAuthPlugin());
   registry.register(new RequestSanitizerPlugin()); // Priority 15 - strips unsupported reasoning params
+  registry.register(new ClaudeThinkingTransformerPlugin()); // Priority 16 - transforms thinking params for Claude 4.7+ models
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
   registry.register(new SSOSessionSyncPlugin()); // Priority 100 - syncs sessions via multiple processors
@@ -37,7 +39,16 @@ export function registerCorePlugins(): void {
 registerCorePlugins();
 
 // Re-export for convenience
-export { MCPAuthPlugin, EndpointBlockerPlugin, SSOAuthPlugin, JWTAuthPlugin, HeaderInjectionPlugin, RequestSanitizerPlugin, LoggingPlugin };
+export {
+  MCPAuthPlugin,
+  EndpointBlockerPlugin,
+  SSOAuthPlugin,
+  JWTAuthPlugin,
+  HeaderInjectionPlugin,
+  RequestSanitizerPlugin,
+  ClaudeThinkingTransformerPlugin,
+  LoggingPlugin,
+};
 export { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 export { getPluginRegistry, resetPluginRegistry } from './registry.js';
 export * from './types.js';


### PR DESCRIPTION
## Summary
- Adds `ClaudeThinkingTransformerPlugin` (priority 16) to the SSO proxy plugin chain
- Converts `thinking.type=enabled` → `thinking.type=adaptive` + `output_config.effort` for models matching `claude-opus-4-[7-9]*`
- Strips `thinking.type=disabled` entirely (model rejects this value)
- Only activates for `codemie-claude` agent to prevent unintended side effects

Closes EPMCDME-11821

## Test plan
- [ ] Unit tests added in `claude-thinking-transformer.plugin.test.ts` covering enabled → adaptive conversion, disabled removal, non-matching models, and missing content-type passthrough
- [ ] Verify no regression for other Claude model integrations (claude-3.x, claude-opus-4-5, etc.)
- [ ] Manual smoke test with `claude-opus-4-7` to confirm no 400 errors