### PR TITLE
fix(agents): bypass SSO auth when --jwt-token is provided

### DIFF
--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -192,11 +192,11 @@ export class AgentCLI {
       }
 
       // NEW: Auth validation via provider plugin
+      // Skip when --jwt-token is explicitly provided: it overrides any configured provider auth
       try {
-        // Check if provider implements auth validation
         const setupSteps = provider ? ProviderRegistry.getSetupSteps(config.provider || '') : null;
 
-        if (setupSteps?.validateAuth) {
+        if (setupSteps?.validateAuth && !options.jwtToken) {
           const validationResult = await setupSteps.validateAuth(config);
 
           if (!validationResult.valid) {
@@ -221,6 +221,15 @@ export class AgentCLI {
       }
 
       const providerEnv = ConfigLoader.exportProviderEnvVars(config);
+
+      // JWT token from CLI overrides the profile's auth method in envOverrides.
+      // Without this, exportProviderEnvVars would emit CODEMIE_AUTH_METHOD='sso'
+      // which gets spread after process.env in BaseAgentAdapter.run(), erasing the
+      // 'jwt' value we set in process.env above and causing the proxy to use the SSO path.
+      if (options.jwtToken) {
+        providerEnv.CODEMIE_AUTH_METHOD = 'jwt';
+        providerEnv.CODEMIE_JWT_TOKEN = options.jwtToken as string;
+      }
 
       // Pass config info for welcome message display
       providerEnv.CODEMIE_PROFILE_NAME = config.name || 'default';


### PR DESCRIPTION
## Summary

When using `--jwt-token` with an SSO-configured profile (`ai-run-sso`), the agent was ignoring the token and falling through to the interactive SSO re-authentication flow (or failing with `Proxy setup failed: SSO credentials not found`).

## Changes

- **Auth validation bypass**: `setupSteps.validateAuth` is now skipped when `--jwt-token` is explicitly provided. The SSO validator was checking for stored browser-session cookies, finding none, and prompting for re-auth.
- **Proxy auth method fix**: `ConfigLoader.exportProviderEnvVars(config)` emits `CODEMIE_AUTH_METHOD='sso'` for SSO profiles. This was being spread as `envOverrides` in `BaseAgentAdapter.run()` — after `process.env` — silently overwriting the `CODEMIE_AUTH_METHOD='jwt'` set by the CLI flag. The JWT token and auth method are now also written into `providerEnv` so they survive the merge.

## Impact

Before: `codemie-claude --jwt-token "${CODEMIE_JWT_TOKEN}" --task "hi"` triggered interactive SSO login or proxy error.

After: command runs non-interactively using the provided JWT token, as documented.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)