### PR TITLE
feat(agents): add opencode provider merge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,26 @@ codemie opencode-metrics --discover --verbose
 
 Metrics are automatically extracted at session end and synced to the analytics system. Use `codemie analytics` to view comprehensive usage statistics across all agents.
 
+### OpenCode Multi-Provider Mode (`--merge-providers`)
+
+By default, `codemie-opencode` launches `opencode` with only CodeMie-managed providers visible. This ensures a consistent, up-to-date CodeMie SSO model catalogue on every launch, but hides any providers the user has configured in `~/.config/opencode/config.json`.
+
+Pass `--merge-providers` to keep the user's existing providers available alongside CodeMie SSO:
+
+```bash
+codemie-opencode --merge-providers
+```
+
+**What this does:**
+- Reads the user's `~/.config/opencode/config.json` (never modified)
+- Merges the user's providers (anthropic, github-copilot, openrouter, …) with the CodeMie-generated config
+- Removes the injected `enabled_providers` whitelist so authenticated opencode-native providers like GitHub Copilot remain visible
+- The `codemie-proxy` provider is always the fresh, CodeMie-owned entry — stale user entries cannot override proxy wiring
+- The user's top-level `model` field is preserved if set; otherwise CodeMie's default is used
+- Safe fall-back: if the user has no config (or it is malformed), the launch proceeds with the CodeMie-only config
+
+See [OpenCode Merge Providers Guide](.codemie/guides/usage/opencode-merge-providers.md) for the full merge-rules reference.
+
 ## Commands
 
 The CodeMie CLI has a rich set of commands for managing agents, configuration, and more.

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -69,6 +69,7 @@ export class AgentCLI {
       .option('--timeout <seconds>', 'Override timeout (in seconds)', parseInt)
       .option('--jwt-token <token>', 'JWT token for authentication (overrides config)')
       .option('--task <prompt>', 'Execute a single task (agent-specific flag mapping)')
+      .option('--merge-providers', 'Merge CodeMie SSO provider with user\'s existing ~/.config/opencode/config.json so user-defined providers remain available (opencode only)')
       .allowUnknownOption()
       .argument('[args...]', `Arguments to pass to ${this.adapter.displayName}`)
       .action(async (args, options) => {
@@ -259,6 +260,13 @@ export class AgentCLI {
         providerEnv.CODEMIE_STATUS = '1';
       }
 
+      // Pass --merge-providers flag to lifecycle hooks. Scoped to opencode today
+      // (OpenCode plugin reads env.CODEMIE_MERGE_PROVIDERS in beforeRun). Silently
+      // ignored by other agents.
+      if (options.mergeProviders) {
+        providerEnv.CODEMIE_MERGE_PROVIDERS = 'true';
+      }
+
       // Serialize full profile config for proxy plugins (read once at CLI level)
       providerEnv.CODEMIE_PROFILE_CONFIG = JSON.stringify(config);
 
@@ -404,7 +412,7 @@ export class AgentCLI {
   ): string[] {
     const agentArgs = [...args];
     // Config-only options (not passed to agent, handled by CodeMie CLI)
-    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout', 'model', 'silent', 'status', 'jwtToken'];
+    const configOnlyOptions = ['profile', 'provider', 'apiKey', 'baseUrl', 'timeout', 'model', 'silent', 'status', 'jwtToken', 'mergeProviders'];
 
     for (const [key, value] of Object.entries(options)) {
       // Skip config-only options (handled by CodeMie CLI layer)

--- a/src/agents/plugins/opencode/__tests__/opencode-config-merger.test.ts
+++ b/src/agents/plugins/opencode/__tests__/opencode-config-merger.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Unit tests for opencode-config-merger
+ *
+ * Covers:
+ * - readUserOpenCodeConfig: file reading / parsing / error handling
+ * - mergeProviderMaps: CodeMie-owned vs user-owned provider keys
+ * - mergeEnabledProviders: union + dedup + order preservation
+ * - mergePluginArrays: union + dedup
+ * - mergeOpenCodeProviders: end-to-end merge rules
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Logger mock (shared)
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    setAgentName: vi.fn(),
+    setSessionId: vi.fn(),
+    setProfileName: vi.fn(),
+  },
+}));
+
+// We import dynamically to let the mocks apply.
+const {
+  readUserOpenCodeConfig,
+  mergeProviderMaps,
+  mergeEnabledProviders,
+  mergePluginArrays,
+  mergeOpenCodeProviders,
+  CODEMIE_OWNED_PROVIDER_KEYS,
+} = await import('../opencode-config-merger.js');
+
+/* ------------------------------------------------------------------ */
+/* readUserOpenCodeConfig                                             */
+/* ------------------------------------------------------------------ */
+
+describe('readUserOpenCodeConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'codemie-merge-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when file does not exist', async () => {
+    const path = join(tmpDir, 'no-such-file.json');
+    const result = await readUserOpenCodeConfig(path);
+    expect(result).toBeNull();
+  });
+
+  it('returns parsed object when file is valid JSON', async () => {
+    const path = join(tmpDir, 'config.json');
+    writeFileSync(path, JSON.stringify({ model: 'anthropic/claude-sonnet-4-5' }));
+    const result = await readUserOpenCodeConfig(path);
+    expect(result).toEqual({ model: 'anthropic/claude-sonnet-4-5' });
+  });
+
+  it('returns null on malformed JSON and does not throw', async () => {
+    const path = join(tmpDir, 'config.json');
+    writeFileSync(path, '{ not valid json ');
+    const result = await readUserOpenCodeConfig(path);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when JSON root is a primitive', async () => {
+    const path = join(tmpDir, 'config.json');
+    writeFileSync(path, '"just a string"');
+    const result = await readUserOpenCodeConfig(path);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when JSON root is an array', async () => {
+    const path = join(tmpDir, 'config.json');
+    writeFileSync(path, '[1, 2, 3]');
+    const result = await readUserOpenCodeConfig(path);
+    expect(result).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* mergeProviderMaps                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('mergeProviderMaps', () => {
+  it('passes through user-only providers unchanged', () => {
+    const codeMie = {};
+    const user = {
+      anthropic: { options: { apiKey: 'user-key' } },
+      'github-copilot': { name: 'Copilot' },
+    };
+    const result = mergeProviderMaps(codeMie, user);
+    expect(result.anthropic).toEqual({ options: { apiKey: 'user-key' } });
+    expect(result['github-copilot']).toEqual({ name: 'Copilot' });
+  });
+
+  it('CodeMie-owned keys win when present in CodeMie config', () => {
+    const codeMie = {
+      'codemie-proxy': { name: 'CodeMie SSO', models: { 'fresh-model': {} } },
+    };
+    const user = {
+      'codemie-proxy': { name: 'Stale', models: { 'stale-model': {} } },
+      anthropic: { name: 'Anthropic' },
+    };
+    const result = mergeProviderMaps(codeMie, user);
+    expect(result['codemie-proxy']).toEqual({
+      name: 'CodeMie SSO',
+      models: { 'fresh-model': {} },
+    });
+    expect(result.anthropic).toEqual({ name: 'Anthropic' });
+  });
+
+  it('preserves user entry for owned key when CodeMie did not emit it', () => {
+    // E.g. no Responses-API models → CodeMie does not emit `openai` entry;
+    // user's existing openai provider should survive.
+    const codeMie = {
+      'codemie-proxy': { name: 'CodeMie SSO' },
+    };
+    const user = {
+      openai: { options: { apiKey: 'user-openai-key' } },
+    };
+    const result = mergeProviderMaps(codeMie, user);
+    expect(result.openai).toEqual({ options: { apiKey: 'user-openai-key' } });
+    expect(result['codemie-proxy']).toEqual({ name: 'CodeMie SSO' });
+  });
+
+  it('returns only CodeMie providers when user map is empty', () => {
+    const codeMie = { 'codemie-proxy': { name: 'X' }, ollama: { name: 'O' } };
+    const result = mergeProviderMaps(codeMie, {});
+    expect(result).toEqual(codeMie);
+  });
+
+  it('exposes CODEMIE_OWNED_PROVIDER_KEYS containing expected keys', () => {
+    expect(CODEMIE_OWNED_PROVIDER_KEYS).toEqual(
+      expect.arrayContaining(['codemie-proxy', 'openai', 'ollama', 'amazon-bedrock']),
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* mergeEnabledProviders                                              */
+/* ------------------------------------------------------------------ */
+
+describe('mergeEnabledProviders', () => {
+  it('returns union without duplicates, CodeMie order first', () => {
+    const result = mergeEnabledProviders(
+      ['codemie-proxy', 'openai', 'ollama', 'amazon-bedrock'],
+      ['anthropic', 'codemie-proxy', 'github-copilot'],
+    );
+    expect(result).toEqual([
+      'codemie-proxy',
+      'openai',
+      'ollama',
+      'amazon-bedrock',
+      'anthropic',
+      'github-copilot',
+    ]);
+  });
+
+  it('handles missing user list', () => {
+    const result = mergeEnabledProviders(['codemie-proxy'], undefined);
+    expect(result).toEqual(['codemie-proxy']);
+  });
+
+  it('handles missing CodeMie list', () => {
+    const result = mergeEnabledProviders(undefined, ['anthropic']);
+    expect(result).toEqual(['anthropic']);
+  });
+
+  it('ignores non-string entries', () => {
+    const result = mergeEnabledProviders(
+      ['codemie-proxy', 42, null],
+      ['anthropic', { bad: 'shape' }],
+    );
+    expect(result).toEqual(['codemie-proxy', 'anthropic']);
+  });
+
+  it('returns empty array when both inputs missing / invalid', () => {
+    expect(mergeEnabledProviders(null, null)).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* mergePluginArrays                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('mergePluginArrays', () => {
+  it('returns union without duplicates', () => {
+    const result = mergePluginArrays(
+      ['file:///codemie/hooks.js'],
+      ['file:///user/plugin.js', 'file:///codemie/hooks.js'],
+    );
+    expect(result).toEqual(['file:///codemie/hooks.js', 'file:///user/plugin.js']);
+  });
+
+  it('returns undefined when both inputs are absent', () => {
+    expect(mergePluginArrays(undefined, undefined)).toBeUndefined();
+  });
+
+  it('handles only user plugins', () => {
+    const result = mergePluginArrays(undefined, ['file:///u.js']);
+    expect(result).toEqual(['file:///u.js']);
+  });
+
+  it('handles only CodeMie plugins', () => {
+    const result = mergePluginArrays(['file:///c.js'], undefined);
+    expect(result).toEqual(['file:///c.js']);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* mergeOpenCodeProviders (end-to-end)                                */
+/* ------------------------------------------------------------------ */
+
+describe('mergeOpenCodeProviders', () => {
+  let tmpDir: string;
+  let userConfigPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'codemie-merge-test-'));
+    userConfigPath = join(tmpDir, 'config.json');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildCodeMieConfig(): Record<string, unknown> {
+    // Mirrors the shape produced in opencode.plugin.ts beforeRun()
+    return {
+      enabled_providers: ['codemie-proxy', 'openai', 'ollama', 'amazon-bedrock'],
+      share: 'disabled',
+      provider: {
+        'codemie-proxy': {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'CodeMie SSO',
+          options: { baseURL: 'http://localhost:9999/', apiKey: 'proxy-handled' },
+          models: { 'gpt-5-2-2025-12-11': { id: 'gpt-5-2-2025-12-11' } },
+        },
+        ollama: {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'Ollama',
+          options: { baseURL: 'http://localhost:11434/v1/', apiKey: 'ollama' },
+        },
+      },
+      model: 'codemie-proxy/gpt-5-2-2025-12-11',
+    };
+  }
+
+  it('no-op when user config is missing', async () => {
+    const cfg = buildCodeMieConfig();
+    const snapshot = JSON.stringify(cfg);
+    // point to a non-existent file
+    await mergeOpenCodeProviders(cfg, join(tmpDir, 'missing.json'));
+    expect(JSON.stringify(cfg)).toBe(snapshot);
+  });
+
+  it('no-op on corrupt user config, does not throw', async () => {
+    writeFileSync(userConfigPath, '{ not: valid json');
+    const cfg = buildCodeMieConfig();
+    const snapshot = JSON.stringify(cfg);
+    await expect(mergeOpenCodeProviders(cfg, userConfigPath)).resolves.toBeUndefined();
+    expect(JSON.stringify(cfg)).toBe(snapshot);
+  });
+
+  it('passes through user extras (anthropic, github-copilot) while keeping codemie-proxy fresh', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: {
+        anthropic: { options: { apiKey: 'user-anthropic' } },
+        'github-copilot': { name: 'Copilot' },
+        // stale codemie-proxy must be replaced
+        'codemie-proxy': { options: { baseURL: 'http://stale:1/' }, models: { stale: {} } },
+      },
+      enabled_providers: ['anthropic', 'github-copilot'],
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    const providers = cfg.provider as Record<string, unknown>;
+    expect(providers.anthropic).toEqual({ options: { apiKey: 'user-anthropic' } });
+    expect(providers['github-copilot']).toEqual({ name: 'Copilot' });
+    // codemie-proxy is the fresh one, not stale
+    expect((providers['codemie-proxy'] as { options: { baseURL: string } }).options.baseURL)
+      .toBe('http://localhost:9999/');
+    expect((providers['codemie-proxy'] as { models: Record<string, unknown> }).models)
+      .toHaveProperty('gpt-5-2-2025-12-11');
+  });
+
+  it('removes enabled_providers so authenticated opencode providers are not hidden', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      enabled_providers: ['anthropic', 'codemie-proxy'],
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    // Upstream opencode treats enabled_providers as a hard whitelist. Removing
+    // it entirely is what allows providers authenticated via opencode's auth
+    // store (e.g. GitHub Copilot) to remain visible in the UI.
+    expect('enabled_providers' in cfg).toBe(false);
+  });
+
+  it("preserves user's top-level model field when set", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      model: 'anthropic/claude-sonnet-4-5',
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect(cfg.model).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it("uses CodeMie's computed model when user has no model field", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: { anthropic: {} },
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect(cfg.model).toBe('codemie-proxy/gpt-5-2-2025-12-11');
+  });
+
+  it('merges plugin arrays without duplicates', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      plugin: ['file:///user/plugin.js'],
+    }));
+
+    const cfg = buildCodeMieConfig();
+    (cfg as Record<string, unknown>).plugin = ['file:///codemie/hooks.js'];
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect(cfg.plugin).toEqual([
+      'file:///codemie/hooks.js',
+      'file:///user/plugin.js',
+    ]);
+  });
+
+  it('passes through extra top-level user keys that CodeMie does not set (mcp, mode)', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      mcp: { foo: { command: 'foo-server' } },
+      mode: 'plan',
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect(cfg.mcp).toEqual({ foo: { command: 'foo-server' } });
+    expect(cfg.mode).toBe('plan');
+  });
+
+  it('removes the whitelist even when user config does not define enabled_providers', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: { anthropic: {} },
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect('enabled_providers' in cfg).toBe(false);
+  });
+
+  it("does not let user override codemie-owned top-level keys (e.g. share)", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      share: 'enabled', // user tries to re-enable share
+    }));
+
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    expect(cfg.share).toBe('disabled'); // CodeMie value preserved
+  });
+
+  it("preserves user's openai provider when CodeMie did NOT emit one (no Responses-API models)", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: {
+        openai: { options: { apiKey: 'user-openai-key' } },
+      },
+    }));
+
+    const cfg = buildCodeMieConfig(); // no `openai` key in codemie config
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    const providers = cfg.provider as Record<string, unknown>;
+    expect(providers.openai).toEqual({ options: { apiKey: 'user-openai-key' } });
+  });
+
+  it("replaces user's openai provider when CodeMie DID emit one (Responses-API models present)", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: {
+        openai: { options: { apiKey: 'user-openai-key' } },
+      },
+    }));
+
+    const cfg = buildCodeMieConfig();
+    // Simulate CodeMie emitting its own openai entry (Responses-API path)
+    (cfg.provider as Record<string, unknown>).openai = {
+      name: 'CodeMie SSO',
+      options: { baseURL: 'http://localhost:9999/' },
+      models: { 'o3-2025': {} },
+    };
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+
+    const providers = cfg.provider as Record<string, unknown>;
+    // CodeMie wins → user's openai entry is replaced
+    expect((providers.openai as { name: string }).name).toBe('CodeMie SSO');
+    expect((providers.openai as { options: { baseURL: string } }).options.baseURL)
+      .toBe('http://localhost:9999/');
+  });
+
+  it('empty user config object still removes the provider whitelist', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({}));
+    const cfg = buildCodeMieConfig();
+    await mergeOpenCodeProviders(cfg, userConfigPath);
+    expect('enabled_providers' in cfg).toBe(false);
+    expect(cfg.model).toBe('codemie-proxy/gpt-5-2-2025-12-11');
+  });
+});

--- a/src/agents/plugins/opencode/__tests__/opencode-plugin-merge.test.ts
+++ b/src/agents/plugins/opencode/__tests__/opencode-plugin-merge.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration tests for the `--merge-providers` flag path in the
+ * OpenCode plugin's `beforeRun` lifecycle hook.
+ *
+ * These tests validate that:
+ * - When CODEMIE_MERGE_PROVIDERS is unset, behaviour is identical to today
+ *   (CodeMie-only config in OPENCODE_CONFIG_CONTENT).
+ * - When CODEMIE_MERGE_PROVIDERS=true and a user opencode config exists,
+ *   the final config contains both CodeMie providers and user extras.
+ * - A failure to read/parse user config never breaks the launch — the plugin
+ *   falls back to the CodeMie-only config.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// --- Mocks -----------------------------------------------------------
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    setAgentName: vi.fn(),
+    setSessionId: vi.fn(),
+    setProfileName: vi.fn(),
+  },
+}));
+
+vi.mock('../../../core/BaseAgentAdapter.js', () => ({
+  BaseAgentAdapter: class {
+    metadata: unknown;
+    constructor(metadata: unknown) {
+      this.metadata = metadata;
+    }
+  },
+}));
+
+vi.mock('../opencode-model-configs.js', () => ({
+  getModelConfig: vi.fn(() => ({
+    id: 'gpt-5-2-2025-12-11',
+    name: 'gpt-5-2-2025-12-11',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+  })),
+  getChatCompletionsModelConfigs: vi.fn(() => ({
+    'gpt-5-2-2025-12-11': { id: 'gpt-5-2-2025-12-11' },
+  })),
+  getResponsesApiModelConfigs: vi.fn(() => ({})),
+}));
+
+vi.mock('../opencode-dynamic-models.js', () => ({
+  fetchDynamicModelConfigs: vi.fn(() =>
+    Promise.resolve({
+      'gpt-5-2-2025-12-11': {
+        id: 'gpt-5-2-2025-12-11',
+        name: 'gpt-5-2-2025-12-11',
+        family: 'gpt-5',
+        tool_call: true,
+      },
+    }),
+  ),
+}));
+
+vi.mock('../../../core/session/ensure-session.js', () => ({
+  ensureSessionFile: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../../codemie-code-hooks/index.js', () => ({
+  getHooksPluginFileUrl: vi.fn(() => 'file:///mock/codemie-hooks.js'),
+  cleanupHooksPlugin: vi.fn(),
+}));
+
+vi.mock('../opencode.session.js', () => ({
+  OpenCodeSessionAdapter: vi.fn(function () {
+    return { discoverSessions: vi.fn().mockResolvedValue([]) };
+  }),
+}));
+
+vi.mock('../../../../providers/plugins/bedrock/bedrock.utils.js', () => ({
+  toBedrockModelId: vi.fn((id: string) => id),
+}));
+
+// --- Dynamic import after mocks are registered ----------------------
+const { OpenCodePluginMetadata } = await import('../opencode.plugin.js');
+
+// --- Helpers ---------------------------------------------------------
+
+function baseEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    CODEMIE_BASE_URL: 'http://localhost:9999',
+    CODEMIE_MODEL: 'gpt-5-2-2025-12-11',
+    CODEMIE_PROVIDER: 'ai-run-sso',
+    ...overrides,
+  } as NodeJS.ProcessEnv;
+}
+
+function parseGeneratedConfig(env: NodeJS.ProcessEnv): Record<string, unknown> {
+  expect(env.OPENCODE_CONFIG_CONTENT).toBeDefined();
+  return JSON.parse(env.OPENCODE_CONFIG_CONTENT!);
+}
+
+// --- Tests -----------------------------------------------------------
+
+describe('OpenCode plugin — --merge-providers integration', () => {
+  const beforeRun = OpenCodePluginMetadata.lifecycle!.beforeRun!;
+
+  let tmpDir: string;
+  let userConfigPath: string;
+  let originalXdg: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), 'codemie-merge-int-'));
+    // Point getOpenCodeConfigDir() at our tmp dir via XDG_CONFIG_HOME
+    // NOTE: opencode.paths.ts uses join(XDG_CONFIG_HOME, 'opencode')
+    const xdgRoot = join(tmpDir, 'xdg');
+    const opencodeDir = join(xdgRoot, 'opencode');
+    mkdirSync(opencodeDir, { recursive: true });
+    userConfigPath = join(opencodeDir, 'config.json');
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = xdgRoot;
+  });
+
+  afterEach(() => {
+    if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdg;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('unset CODEMIE_MERGE_PROVIDERS → CodeMie-only config (regression)', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: { anthropic: { options: { apiKey: 'should-not-appear' } } },
+    }));
+
+    const env = baseEnv();
+    await beforeRun(env, {} as never);
+
+    const cfg = parseGeneratedConfig(env);
+    const providers = cfg.provider as Record<string, unknown>;
+    expect(providers['codemie-proxy']).toBeDefined();
+    expect(cfg.enabled_providers).toEqual(['codemie-proxy', 'openai', 'ollama', 'amazon-bedrock']);
+    // anthropic must NOT leak in when flag is off
+    expect(providers.anthropic).toBeUndefined();
+  });
+
+  it('CODEMIE_MERGE_PROVIDERS=true + user config with anthropic → merged result', async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: {
+        anthropic: { options: { apiKey: 'user-anthropic-key' } },
+      },
+      enabled_providers: ['anthropic'],
+    }));
+
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await beforeRun(env, {} as never);
+
+    const cfg = parseGeneratedConfig(env);
+    const providers = cfg.provider as Record<string, unknown>;
+    expect(providers['codemie-proxy']).toBeDefined();
+    expect(providers.anthropic).toEqual({ options: { apiKey: 'user-anthropic-key' } });
+    expect('enabled_providers' in cfg).toBe(false);
+  });
+
+  it("CODEMIE_MERGE_PROVIDERS=true but no user config file → falls back to CodeMie-only config", async () => {
+    // Don't create any user config file
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await beforeRun(env, {} as never);
+
+    const cfg = parseGeneratedConfig(env);
+    const providers = cfg.provider as Record<string, unknown>;
+    expect(providers['codemie-proxy']).toBeDefined();
+    expect(Object.keys(providers)).toEqual(
+      expect.arrayContaining(['codemie-proxy', 'ollama']),
+    );
+    // No user config means no merge occurred, so the original whitelist remains.
+    expect(cfg.enabled_providers).toEqual(['codemie-proxy', 'openai', 'ollama', 'amazon-bedrock']);
+  });
+
+  it("CODEMIE_MERGE_PROVIDERS=true with corrupt user config → falls back, does not throw", async () => {
+    writeFileSync(userConfigPath, '{ not valid json');
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await expect(beforeRun(env, {} as never)).resolves.toBeDefined();
+
+    const cfg = parseGeneratedConfig(env);
+    expect((cfg.provider as Record<string, unknown>)['codemie-proxy']).toBeDefined();
+  });
+
+  it("user's top-level model preserved on merge", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      model: 'anthropic/claude-sonnet-4-5',
+      provider: { anthropic: {} },
+    }));
+
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await beforeRun(env, {} as never);
+
+    const cfg = parseGeneratedConfig(env);
+    expect(cfg.model).toBe('anthropic/claude-sonnet-4-5');
+    expect('enabled_providers' in cfg).toBe(false);
+  });
+
+  it("user's stale codemie-proxy models replaced with fresh CodeMie models", async () => {
+    writeFileSync(userConfigPath, JSON.stringify({
+      provider: {
+        'codemie-proxy': {
+          options: { baseURL: 'http://stale:1/', apiKey: 'stale' },
+          models: { 'stale-model': {} },
+        },
+      },
+    }));
+
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await beforeRun(env, {} as never);
+
+    const cfg = parseGeneratedConfig(env);
+    const proxy = (cfg.provider as Record<string, { options: { baseURL: string }; models: Record<string, unknown> }>)['codemie-proxy'];
+    // Must be the fresh CodeMie proxy (local proxy URL), not the stale user value
+    expect(proxy.options.baseURL).toBe('http://localhost:9999/');
+    // Must have freshly-fetched models only
+    expect(proxy.models).toHaveProperty('gpt-5-2-2025-12-11');
+    expect(proxy.models).not.toHaveProperty('stale-model');
+    expect('enabled_providers' in cfg).toBe(false);
+  });
+
+  it('merge does not break the OPENCODE_CONFIG temp-file fallback for oversized configs', async () => {
+    // Write a sizeable user config with many extra providers
+    const hugeProviders: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) {
+      hugeProviders[`provider-${i}`] = {
+        name: `P${i}`,
+        options: { apiKey: 'x'.repeat(2000), baseURL: 'http://p/' },
+      };
+    }
+    writeFileSync(userConfigPath, JSON.stringify({ provider: hugeProviders }));
+
+    const env = baseEnv({ CODEMIE_MERGE_PROVIDERS: 'true' });
+    await beforeRun(env, {} as never);
+
+    // Either inline config or temp-file path env must be set; never both unset.
+    const usedTempFile = !!env.OPENCODE_CONFIG && !env.OPENCODE_CONFIG_CONTENT;
+    const usedInline = !!env.OPENCODE_CONFIG_CONTENT;
+    expect(usedTempFile || usedInline).toBe(true);
+  });
+});

--- a/src/agents/plugins/opencode/index.ts
+++ b/src/agents/plugins/opencode/index.ts
@@ -6,6 +6,16 @@ export {
   type OpenCodeModelConfig
 } from './opencode-model-configs.js';
 
+// Provider-merge helper for `--merge-providers` flag
+export {
+  mergeOpenCodeProviders,
+  readUserOpenCodeConfig,
+  mergeProviderMaps,
+  mergeEnabledProviders,
+  mergePluginArrays,
+  CODEMIE_OWNED_PROVIDER_KEYS
+} from './opencode-config-merger.js';
+
 // Phase 2 exports (Session Analytics)
 export { OpenCodeSessionAdapter } from './opencode.session.js';
 // FIXED (GPT-5.10/5.11): Export canonical function names, not deprecated alias

--- a/src/agents/plugins/opencode/opencode-config-merger.ts
+++ b/src/agents/plugins/opencode/opencode-config-merger.ts
@@ -1,0 +1,273 @@
+/**
+ * OpenCode Config Merger
+ * ======================
+ *
+ * Optional merging of CodeMie-generated OpenCode config with the user's
+ * existing `~/.config/opencode/config.json`.
+ *
+ * Activated by the `--merge-providers` CLI flag on `codemie-opencode`
+ * (see AgentCLI.setupProgram). When enabled, the user retains access to their
+ * own opencode providers (e.g. anthropic, github-copilot, openrouter, etc.)
+ * while also getting the freshly-fetched CodeMie SSO model catalogue.
+ *
+ * ## Merge Rules
+ *
+ * Fields in CodeMie-generated config always win for the keys CodeMie owns,
+ * because those keys are wired to the local SSO proxy and are refreshed on
+ * every launch. The user's other providers are passed through untouched.
+ *
+ * | Field                          | Winner                                           |
+ * |--------------------------------|--------------------------------------------------|
+ * | provider.codemie-proxy         | CodeMie (always replaced – fresh models)         |
+ * | provider.openai                | CodeMie if Responses-API models exist, else user |
+ * | provider.ollama                | CodeMie (CodeMie owns the baseURL/timeout)       |
+ * | provider.amazon-bedrock        | CodeMie when provider='bedrock', else user       |
+ * | provider.<other-key>           | User (pass-through)                              |
+ * | enabled_providers              | Removed entirely                                  |
+ * | model                          | User's value preserved if set, else CodeMie's    |
+ * | plugin                         | Union, deduplicated                              |
+ * | share / other top-level fields | CodeMie (preserves existing behaviour)           |
+ *
+ * ## Safety
+ *
+ * - Function is failure-isolated: any IO or parse error logs a warning and
+ *   returns without mutating the CodeMie config. Opencode still launches.
+ * - The user's config file is never written. Read-only operation.
+ * - Proxy/SSO plumbing is not altered: the `codemie-proxy` entry is always
+ *   the CodeMie-generated one, keeping baseURL pointing at the local proxy.
+ * - `enabled_providers` is removed when merging. In upstream opencode this
+ *   field is a hard whitelist, and leaving it in place would hide providers
+ *   authenticated outside config.json (for example GitHub Copilot credentials
+ *   stored in opencode's auth.json).
+ */
+
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getOpenCodeConfigDir } from './opencode.paths.js';
+import { logger } from '../../../utils/logger.js';
+
+/**
+ * Provider keys whose entries are owned by CodeMie when present in the
+ * CodeMie-generated config. Overriding these would break the proxy wiring
+ * (baseURL, apiKey, freshly-fetched model list).
+ *
+ * Note: `openai` is in this list only because OpenCode's built-in `openai`
+ * CUSTOM_LOADER shares the provider key with the Responses API wiring.
+ * When CodeMie emits an `openai` entry, it is tied to the local proxy URL
+ * and must win; otherwise the user's `openai` entry is preserved.
+ */
+const CODEMIE_OWNED_PROVIDER_KEYS = [
+  'codemie-proxy',
+  'openai',
+  'ollama',
+  'amazon-bedrock',
+] as const;
+
+/**
+ * Top-level keys that come from CodeMie and should always win when set.
+ * Intentionally excludes `model` (user's model preserved if set) and
+ * `provider` / `enabled_providers` / `plugin` (handled by merge rules).
+ */
+const CODEMIE_OWNED_TOPLEVEL_KEYS = new Set(['share']);
+
+type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Read the user's opencode config from the standard XDG path.
+ *
+ * Returns `null` if:
+ * - The file does not exist (not an error — user just hasn't created one)
+ * - The file is unreadable or contains invalid JSON (warns + returns null)
+ *
+ * @param filePath Optional override, primarily for tests. Defaults to
+ *                 `getOpenCodeConfigDir()/config.json`.
+ */
+export async function readUserOpenCodeConfig(
+  filePath?: string,
+): Promise<UnknownRecord | null> {
+  const path = filePath ?? join(getOpenCodeConfigDir(), 'config.json');
+
+  if (!existsSync(path)) {
+    logger.debug(`[opencode-merge] No user opencode config found at ${path}; merge is a no-op`);
+    return null;
+  }
+
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      logger.warn(`[opencode-merge] User opencode config at ${path} is not a JSON object; skipping merge`);
+      return null;
+    }
+    return parsed as UnknownRecord;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(`[opencode-merge] Failed to read/parse user opencode config at ${path}: ${message}`);
+    return null;
+  }
+}
+
+/**
+ * Merge two provider maps. CodeMie-owned keys win when present in the
+ * CodeMie map; all other keys from the user map are passed through.
+ *
+ * @param codeMieProviders - Provider map from CodeMie-generated config
+ * @param userProviders    - Provider map from the user's config (may be empty)
+ * @param ownedKeys        - Keys CodeMie owns unconditionally when it has them
+ */
+export function mergeProviderMaps(
+  codeMieProviders: UnknownRecord,
+  userProviders: UnknownRecord,
+  ownedKeys: readonly string[] = CODEMIE_OWNED_PROVIDER_KEYS,
+): UnknownRecord {
+  const result: UnknownRecord = {};
+  const ownedSet = new Set(ownedKeys);
+
+  // Start with user's providers — these are the "extras" the user wants to keep
+  for (const [key, value] of Object.entries(userProviders)) {
+    if (ownedSet.has(key) && key in codeMieProviders) {
+      // CodeMie owns this key and has emitted it → CodeMie wins, skip user's entry
+      continue;
+    }
+    result[key] = value;
+  }
+
+  // Overlay CodeMie providers (always win when CodeMie emitted them)
+  for (const [key, value] of Object.entries(codeMieProviders)) {
+    result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Merge two `enabled_providers` arrays.
+ *
+ * Legacy helper retained for explicit unit coverage and possible future use.
+ *
+ * IMPORTANT: `mergeOpenCodeProviders()` intentionally does NOT use this result
+ * in the final merged config. In upstream opencode, `enabled_providers` is a
+ * hard whitelist. Keeping any whitelist in the injected config would hide
+ * authenticated providers that come from opencode's auth store rather than
+ * from config.json (for example GitHub Copilot).
+ */
+export function mergeEnabledProviders(
+  codeMieList: unknown,
+  userList: unknown,
+): string[] {
+  const codeMieArr = Array.isArray(codeMieList)
+    ? codeMieList.filter((x): x is string => typeof x === 'string')
+    : [];
+  const userArr = Array.isArray(userList)
+    ? userList.filter((x): x is string => typeof x === 'string')
+    : [];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const name of [...codeMieArr, ...userArr]) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Merge two `plugin` arrays (file:// URLs to opencode plugins).
+ * Order: CodeMie's plugins first (hooks plugin, etc.), user's appended.
+ * Duplicates removed.
+ */
+export function mergePluginArrays(
+  codeMieList: unknown,
+  userList: unknown,
+): string[] | undefined {
+  const codeMieArr = Array.isArray(codeMieList)
+    ? codeMieList.filter((x): x is string => typeof x === 'string')
+    : [];
+  const userArr = Array.isArray(userList)
+    ? userList.filter((x): x is string => typeof x === 'string')
+    : [];
+
+  if (codeMieArr.length === 0 && userArr.length === 0) return undefined;
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of [...codeMieArr, ...userArr]) {
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Merge the user's opencode config into the CodeMie-generated config **in place**.
+ *
+ * This is the primary entry point invoked from `OpenCodePlugin.beforeRun` when
+ * `--merge-providers` is active.
+ *
+ * If there is no user config, or the file is unreadable/invalid, the CodeMie
+ * config is returned untouched and a debug/warn is logged. The caller should
+ * always proceed with `codeMieConfig` regardless of merge outcome.
+ *
+ * @param codeMieConfig - The CodeMie-generated config object (mutated in place)
+ * @param filePath      - Optional override for the user config path (tests only)
+ */
+export async function mergeOpenCodeProviders(
+  codeMieConfig: UnknownRecord,
+  filePath?: string,
+): Promise<void> {
+  const userConfig = await readUserOpenCodeConfig(filePath);
+  if (!userConfig) return;
+
+  // --- providers ---
+  const codeMieProviders = isRecord(codeMieConfig.provider) ? codeMieConfig.provider : {};
+  const userProviders = isRecord(userConfig.provider) ? userConfig.provider : {};
+  codeMieConfig.provider = mergeProviderMaps(codeMieProviders, userProviders);
+
+  // Upstream opencode treats `enabled_providers` as a hard whitelist. That is
+  // correct for CodeMie-only launches, but it breaks `--merge-providers`
+  // because providers authenticated outside config.json (for example Copilot in
+  // opencode's auth.json) are loaded by opencode and then filtered out by the
+  // whitelist. Remove the field entirely so all authenticated providers remain
+  // visible while still merging our provider definitions.
+  delete codeMieConfig.enabled_providers;
+
+  // --- model: preserve user's value if set ---
+  if (typeof userConfig.model === 'string' && userConfig.model.length > 0) {
+    logger.debug(
+      `[opencode-merge] Preserving user's top-level model: "${userConfig.model}" ` +
+      `(CodeMie's computed model "${String(codeMieConfig.model)}" is still available via the codemie-proxy provider)`,
+    );
+    codeMieConfig.model = userConfig.model;
+  }
+
+  // --- plugin: union, deduplicated ---
+  const mergedPlugins = mergePluginArrays(codeMieConfig.plugin, userConfig.plugin);
+  if (mergedPlugins) {
+    codeMieConfig.plugin = mergedPlugins;
+  }
+
+  // --- pass through any extra top-level keys from user config that CodeMie
+  //     does not set (e.g. mcp servers, mode, autoshare overrides). CodeMie's
+  //     top-level values always win for the keys it emits. ---
+  for (const [key, value] of Object.entries(userConfig)) {
+    if (key === 'provider' || key === 'enabled_providers' || key === 'model' || key === 'plugin') continue;
+    if (CODEMIE_OWNED_TOPLEVEL_KEYS.has(key)) continue; // CodeMie wins
+    if (key in codeMieConfig) continue;                 // CodeMie already set it
+    codeMieConfig[key] = value;
+  }
+
+  const mergedProviderCount = Object.keys(codeMieConfig.provider as UnknownRecord).length;
+  logger.info(
+    `[opencode-merge] Merged user opencode config: ${mergedProviderCount} providers total in final config`,
+  );
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+// Export owned key list so tests can assert against a single source of truth
+export { CODEMIE_OWNED_PROVIDER_KEYS };

--- a/src/agents/plugins/opencode/opencode.plugin.ts
+++ b/src/agents/plugins/opencode/opencode.plugin.ts
@@ -2,6 +2,7 @@ import type { AgentMetadata, AgentConfig } from '../../core/types.js';
 import { logger } from '../../../utils/logger.js';
 import { getModelConfig, getChatCompletionsModelConfigs, getResponsesApiModelConfigs } from './opencode-model-configs.js';
 import { fetchDynamicModelConfigs } from './opencode-dynamic-models.js';
+import { mergeOpenCodeProviders } from './opencode-config-merger.js';
 import { BaseAgentAdapter } from '../../core/BaseAgentAdapter.js';
 import type { SessionAdapter } from '../../core/session/BaseSessionAdapter.js';
 import type { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
@@ -172,6 +173,29 @@ export const OpenCodePluginMetadata: AgentMetadata = {
         openCodeConfig.plugin = (openCodeConfig.plugin as string[] | undefined) || [];
         (openCodeConfig.plugin as string[]).push(pluginUrl);
         logger.debug(`[opencode] Injected hooks plugin: ${pluginUrl}`);
+      }
+
+      // --- Optional: merge with user's ~/.config/opencode/config.json ---
+      // Activated by `codemie-opencode --merge-providers`. Keeps the user's
+      // additional providers (anthropic, github-copilot, openrouter, ...) so
+      // they can switch between providers inside opencode while still using
+      // CodeMie SSO by default.
+      //
+      // Merge is failure-isolated: on any IO/parse error we log a warning and
+      // fall back to the CodeMie-only config. The user's file is never written.
+      //
+      // Safety: the `codemie-proxy` provider entry is always the freshly
+      // generated one, so the proxy baseURL, auth wiring, and model catalogue
+      // can never be overridden by a stale user-side entry.
+      if (env.CODEMIE_MERGE_PROVIDERS === 'true') {
+        try {
+          await mergeOpenCodeProviders(openCodeConfig);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(
+            `[opencode] --merge-providers failed, continuing with CodeMie-only config: ${message}`,
+          );
+        }
       }
 
       env.OPENCODE_DISABLE_SHARE = 'true';


### PR DESCRIPTION
## Summary

Add `--merge-providers` to `codemie-opencode` so the launcher can merge
CodeMie's generated OpenCode provider config with the user's existing
OpenCode setup instead of replacing it outright.

This also removes the injected `enabled_providers` whitelist in merge
mode, which lets OpenCode keep showing authenticated native providers
such as corporate GitHub Copilot alongside CodeMie SSO models.

## Changes

- add the `--merge-providers` flag to `codemie-opencode`
- merge CodeMie-owned OpenCode providers with the user's config without
  duplicating providers or stale CodeMie model lists
- preserve CodeMie proxy and SSO behavior by keeping `codemie-proxy`
  authoritative while still allowing other providers to remain visible
- remove the merge-mode provider whitelist so authenticated OpenCode
  providers like corporate Copilot are not filtered out
- add unit and integration coverage for merge behavior and whitelist
  removal
- document the new launch mode in the README

## Impact

Before this change, launching with `codemie-opencode` replaced the
visible OpenCode providers with a CodeMie-only set. That prevented users
from switching to already-authenticated corporate Copilot models inside
OpenCode.

With `codemie-opencode --merge-providers`, users can launch OpenCode with
CodeMie SSO models and corporate Copilot models in the same session.
This improves usage management because teams can keep CodeMie-governed
model access available while still using approved corporate Copilot
capacity when it makes sense.

<img width="480" height="220" alt="image" src="https://github.com/user-attachments/assets/e4b9399e-cb6c-4a38-9d3b-1f4d210e7f3b" />

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)