### PR TITLE
feat(ci): add native bootstrap installers for Windows and macOS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
     name: Publish Package
     runs-on: ubuntu-latest
     environment: prod
+    env:
+      ARTIFACTORY_INSTALL_URL: ${{ secrets.ARTIFACTORY_INSTALL_URL }}
+      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
 
     steps:
       - name: Confirm publish
@@ -50,3 +53,26 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Prepare installer artifacts
+        run: npm run prepare:install-artifacts
+
+      - name: Upload installer artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: codemie-installers
+          path: artifacts/install
+
+      - name: Publish installer artifacts to Artifactory
+        if: ${{ env.ARTIFACTORY_INSTALL_URL != '' && env.ARTIFACTORY_TOKEN != '' }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          for file in artifacts/install/*; do
+            name=$(basename "$file")
+            curl -fsS -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
+              -T "$file" \
+              "${ARTIFACTORY_INSTALL_URL}/${VERSION}/${name}"
+            curl -fsS -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
+              -T "$file" \
+              "${ARTIFACTORY_INSTALL_URL}/stable/${name}"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Build output
 dist/
+artifacts/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -38,29 +38,15 @@ Perfect for developers seeking a powerful alternative to GitHub Copilot or Curso
 
 ## Quick Start
 
+Install CodeMie using the instructions for your shell, then run:
+
 ```bash
-# Install globally for best experience
-npm install -g @codemieai/code
-
-# 1. Setup (interactive wizard)
 codemie setup
-
-# 2. Check system health
 codemie doctor
-
-# 3. Install an external agent (e.g., Claude Code - latest supported version)
 codemie install claude --supported
-
-# 4. Use the installed agent
 codemie-claude "Review my API code"
-
-# 5. Use the built-in agent
 codemie-code "Analyze this codebase"
-
-# 6. Execute a single task and exit
 codemie --task "Generate unit tests"
-
-# 7. Connect to a remote MCP server (with automatic OAuth)
 claude mcp add my-server -- codemie-mcp-proxy "https://mcp-server.example.com/sse"
 ```
 
@@ -75,16 +61,76 @@ npx @codemieai/code install claude --supported
 
 ## Installation
 
-### Global Installation (Recommended)
+### Native Bootstrap Installers
 
-For the best experience with all features and agent shortcuts:
+For Windows and macOS, use the CodeMie bootstrap installers instead of installing directly with npm. The bootstrap installers are plain scripts stored in this public GitHub repo, so they do not require a Windows-built `.exe` or a private Artifactory mirror.
+
+The bootstrap path is recommended for non-technical users and managed enterprise machines because it:
+
+- avoids PowerShell `npm.ps1` execution-policy failures on Windows,
+- avoids global npm permission errors such as macOS `EACCES`,
+- installs into a user-writable location where possible,
+- checks Node.js, npm, registry access, and CodeMie package visibility before installing,
+- prints actionable remediation when the enterprise npm registry is not configured correctly.
+
+The examples below use GitHub raw URLs from the `main` branch. For reproducible installs, replace `main` with a release tag such as `v0.0.57`. Enterprise teams can mirror the same scripts to Artifactory later by setting `CODEMIE_INSTALL_URL` to the mirrored script directory.
+
+Channel selection is not implemented in the bootstrap scripts yet. To pin a version on Windows PowerShell, pass `-Version 0.0.57`. To pin a version on macOS, Linux, or WSL, set `CODEMIE_PACKAGE_VERSION=0.0.57` before running the install command.
+
+### Windows PowerShell
+
+The Windows bootstrapper installs CodeMie in user-local portable mode by default and calls `npm.cmd` directly, so it does not permanently change PowerShell execution policy.
+
+```powershell
+irm https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.ps1 | iex
+```
+
+To pass explicit options:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.ps1))) -RegistryUrl https://registry.npmjs.org/
+```
+
+### Windows CMD
+
+Use this fallback when PowerShell copy-paste guidance is not practical:
+
+```cmd
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+### macOS
+
+The macOS bootstrapper uses npm global installation only when it is user-writable. If global npm is not writable, it configures a user-local npm prefix instead.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/macos/install.sh | bash
+```
+
+To install a specific package version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/macos/install.sh | env CODEMIE_PACKAGE_VERSION=0.0.57 bash
+```
+
+### Linux and WSL
+
+Use the same shell bootstrapper for Linux and WSL:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/macos/install.sh | bash
+```
+
+### npm Fallback
+
+Use npm fallback only when Node.js 20+ and npm global installs are already configured correctly:
 
 ```bash
 npm install -g @codemieai/code
 codemie --help
 ```
 
-### Local/Project Installation
+### Local/Project npm Installation
 
 For project-specific usage:
 
@@ -96,6 +142,16 @@ npx @codemieai/code --help
 ```
 
 **Note:** Agent shortcuts (`codemie-claude`, `codemie-code`, `codemie-opencode`, etc.) require global installation.
+
+### Installation Troubleshooting
+
+If PowerShell reports that `npm.ps1` cannot be loaded, use the CodeMie bootstrap installer. It calls `npm.cmd` directly and does not permanently change your execution policy.
+
+If npm reports `EACCES` on macOS, use the bootstrap installer or configure npm to use a user-local prefix.
+
+If npm reports `404 Not Found`, verify that you are installing `@codemieai/code`, not `codemie`, and that your enterprise npm virtual registry exposes the `@codemieai` scope.
+
+If the installer says `@codemieai/code` is not visible in the registry, ask IT to expose the package through the approved virtual npm repository.
 
 ### From Source
 

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,75 @@
+# CodeMie Bootstrap Installers
+
+This directory contains source files for the lightweight CodeMie bootstrap installers.
+
+The first supported distribution model is hosted scripts:
+
+- Windows PowerShell: `install/windows/install.ps1`
+- Windows CMD: `install/windows/install.cmd`
+- macOS/Linux/WSL: `install/macos/install.sh`
+
+The scripts can be run directly from GitHub raw URLs or mirrored to Artifactory later. They do not require a Windows-built `.exe`.
+
+Set `CODEMIE_INSTALL_URL` only when you want to override the public GitHub raw location, for example with an enterprise Artifactory mirror. If it is unset, `install/windows/install.cmd` downloads the PowerShell installer from this public repository.
+
+Channel selection is not implemented in the bootstrap scripts yet. Install the default npm package version, or pass an explicit version with PowerShell `-Version` or shell `CODEMIE_PACKAGE_VERSION`.
+
+## GitHub Raw URLs
+
+Use `main` for the latest installer source.
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.ps1 | iex
+```
+
+Windows CMD:
+
+```cmd
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+macOS, Linux, and WSL:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/macos/install.sh | bash
+```
+
+Direct file URLs:
+
+```text
+https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.ps1
+https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows/install.cmd
+https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/macos/install.sh
+```
+
+For reproducible installs, replace `main` with a release tag such as `v0.0.57`.
+
+## Windows Defaults
+
+Windows installs into the current user's local profile by default:
+
+```text
+%LOCALAPPDATA%\CodeMie
+```
+
+The installer calls `npm.cmd` directly to avoid PowerShell resolving `npm` to `npm.ps1`.
+
+Known limitation: `install/windows/install.cmd` forwards arguments to PowerShell through `%*`. Use the PowerShell installer directly when passing arguments that contain spaces, such as `-InstallRoot "C:\My Folder"`.
+
+## macOS/Linux Defaults
+
+macOS, Linux, and WSL prefer npm global installation when global npm is user-writable. If global npm is not writable, the script configures a user-local npm prefix.
+
+## Release Artifacts
+
+Run this command to prepare publishable artifacts:
+
+```bash
+npm run prepare:install-artifacts
+```
+
+Generated files are written to `artifacts/install/` and are not committed.
+
+Generated artifacts include a version header and their checksums are computed from the generated artifact content, not from the source files under `install/`.

--- a/install/macos/install.sh
+++ b/install/macos/install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_NAME="@codemieai/code"
+MINIMUM_NODE_MAJOR="20"
+REGISTRY_URL="${CODEMIE_REGISTRY_URL:-https://registry.npmjs.org/}"
+SCOPE_REGISTRY_URL="${CODEMIE_SCOPE_REGISTRY_URL:-}"
+INSTALL_MODE="${CODEMIE_INSTALL_MODE:-auto}"
+USER_PREFIX="${CODEMIE_NPM_PREFIX:-$HOME/.codemie/npm-prefix}"
+PACKAGE_VERSION="${CODEMIE_PACKAGE_VERSION:-}"
+
+status() {
+  printf '%-18s %s\n' "$1:" "$2"
+}
+
+command_path() {
+  command -v "$1" 2>/dev/null || true
+}
+
+node_major() {
+  local version
+  version="$(node --version 2>/dev/null || true)"
+  case "$version" in
+    v[0-9]*)
+      echo "$version" | sed -E 's/^v([0-9]+).*/\1/'
+      ;;
+    *)
+      echo "0"
+      ;;
+  esac
+}
+
+NODE_PATH="$(command_path node)"
+NPM_PATH="$(command_path npm)"
+NODE_MAJOR="$(node_major)"
+
+echo "CodeMie installer diagnostics"
+status "OS" "$(uname -s)-$(uname -m)"
+status "Shell" "POSIX"
+status "Node" "${NODE_PATH:-not found} major $NODE_MAJOR"
+status "npm" "${NPM_PATH:-not found}"
+status "Registry" "$REGISTRY_URL"
+
+if [ -z "$NODE_PATH" ] || [ "$NODE_MAJOR" -lt "$MINIMUM_NODE_MAJOR" ]; then
+  echo "Node.js $MINIMUM_NODE_MAJOR or newer is required. Install Node.js using the approved enterprise method, then rerun this installer." >&2
+  exit 1
+fi
+
+if [ -z "$NPM_PATH" ]; then
+  echo "npm was not found. Reinstall Node.js with npm enabled, then rerun this installer." >&2
+  exit 1
+fi
+
+if [ -n "$SCOPE_REGISTRY_URL" ]; then
+  npm config set '@codemieai:registry' "$SCOPE_REGISTRY_URL" --location user
+fi
+
+if [ "$INSTALL_MODE" = "auto" ]; then
+  NPM_PREFIX="$(npm config get prefix)"
+  if [ -w "$NPM_PREFIX" ]; then
+    INSTALL_MODE="npm-global"
+  else
+    INSTALL_MODE="user-prefix"
+  fi
+fi
+
+status "Install mode" "$INSTALL_MODE"
+
+if [ "$INSTALL_MODE" = "user-prefix" ]; then
+  mkdir -p "$USER_PREFIX/bin"
+  npm config set prefix "$USER_PREFIX" --location user
+  case ":$PATH:" in
+    *":$USER_PREFIX/bin:"*)
+      status "PATH update" "already present"
+      ;;
+    *)
+      status "PATH update" "add $USER_PREFIX/bin to PATH in your shell profile"
+      ;;
+  esac
+fi
+
+PACKAGE_SPEC="$PACKAGE_NAME"
+if [ -n "$PACKAGE_VERSION" ]; then
+  PACKAGE_SPEC="$PACKAGE_NAME@$PACKAGE_VERSION"
+fi
+
+if ! RESOLVED_PACKAGE_VERSION="$(npm view "$PACKAGE_SPEC" version --registry "$REGISTRY_URL" 2>&1)"; then
+  echo "Package $PACKAGE_SPEC was not found in registry $REGISTRY_URL." >&2
+  echo "Ask IT to expose @codemieai/code through the approved virtual npm repository, or rerun with CODEMIE_SCOPE_REGISTRY_URL pointing to the approved registry." >&2
+  echo "npm output: $RESOLVED_PACKAGE_VERSION" >&2
+  exit 1
+fi
+
+RESOLVED_PACKAGE_VERSION="$(printf '%s\n' "$RESOLVED_PACKAGE_VERSION" | head -n 1)"
+status "Package" "$PACKAGE_SPEC found ($RESOLVED_PACKAGE_VERSION)"
+
+if ! npm install -g "$PACKAGE_SPEC" --registry "$REGISTRY_URL"; then
+  echo "Failed to install $PACKAGE_SPEC from registry $REGISTRY_URL." >&2
+  exit 1
+fi
+
+status "CodeMie" "installed $RESOLVED_PACKAGE_VERSION"
+echo "Run `codemie doctor` in a new terminal to verify the installation."

--- a/install/windows/install.cmd
+++ b/install/windows/install.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+set "CODEMIE_INSTALL_URL=%CODEMIE_INSTALL_URL%"
+if "%CODEMIE_INSTALL_URL%"=="" (
+  set "CODEMIE_INSTALL_URL=https://raw.githubusercontent.com/codemie-ai/codemie-code/main/install/windows"
+)
+
+set "INSTALL_PS1=%TEMP%\codemie-install.ps1"
+
+curl -fsSL "%CODEMIE_INSTALL_URL%/install.ps1" -o "%INSTALL_PS1%"
+if errorlevel 1 (
+  echo Failed to download CodeMie PowerShell installer from %CODEMIE_INSTALL_URL%/install.ps1
+  exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%INSTALL_PS1%" %*
+set "INSTALL_EXIT=%ERRORLEVEL%"
+
+del "%INSTALL_PS1%" >nul 2>nul
+exit /b %INSTALL_EXIT%

--- a/install/windows/install.ps1
+++ b/install/windows/install.ps1
@@ -1,0 +1,201 @@
+[CmdletBinding()]
+param(
+  [ValidateSet('portable', 'npm-global')]
+  [string]$Mode = 'portable',
+  [string]$Version = '',
+  [string]$RegistryUrl = 'https://registry.npmjs.org/',
+  [string]$ScopeRegistryUrl = '',
+  [string]$InstallRoot = '',
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$PackageName = '@codemieai/code'
+$MinimumNodeMajor = 20
+$Commands = @(
+  'codemie',
+  'codemie-code',
+  'codemie-claude',
+  'codemie-claude-acp',
+  'codemie-gemini',
+  'codemie-opencode',
+  'codemie-mcp-proxy'
+)
+
+function Write-Status {
+  param([string]$Name, [string]$Value)
+  Write-Host ('{0,-18} {1}' -f "${Name}:", $Value)
+}
+
+function Get-CommandPath {
+  param([string]$Name)
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if ($null -eq $command) {
+    return ''
+  }
+  return $command.Source
+}
+
+function Get-NodeMajor {
+  param([string]$NodePath)
+  if ([string]::IsNullOrWhiteSpace($NodePath)) {
+    return 0
+  }
+
+  $version = & $NodePath --version
+  if ($version -match '^v(\d+)\.') {
+    return [int]$Matches[1]
+  }
+
+  return 0
+}
+
+function Invoke-Checked {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [string]$FailureMessage
+  )
+
+  if ($DryRun) {
+    Write-Host "DRY RUN: $FilePath $($Arguments -join ' ')"
+    return
+  }
+
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw $FailureMessage
+  }
+}
+
+function Get-PackageVersion {
+  param(
+    [string]$NpmPath,
+    [string]$PackageSpec,
+    [string]$RegistryUrl
+  )
+
+  if ($DryRun) {
+    Write-Host "DRY RUN: $NpmPath view $PackageSpec version --registry $RegistryUrl"
+    return 'dry-run'
+  }
+
+  $output = & $NpmPath @('view', $PackageSpec, 'version', '--registry', $RegistryUrl) 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $message = @(
+      "Package $PackageSpec was not found in registry $RegistryUrl.",
+      'Ask IT to expose @codemieai/code through the approved virtual npm repository, or rerun with -ScopeRegistryUrl pointing to the approved registry.',
+      "npm output: $($output -join ' ')"
+    ) -join ' '
+    throw $message
+  }
+
+  return ($output | Select-Object -First 1).ToString().Trim()
+}
+
+function Add-UserPath {
+  param([string]$PathToAdd)
+
+  $currentUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  if ([string]::IsNullOrWhiteSpace($currentUserPath)) {
+    $currentUserPath = ''
+  }
+
+  $pathEntries = $currentUserPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($pathEntries -icontains $PathToAdd) {
+    Write-Status 'PATH update' 'already present'
+    return
+  }
+
+  if ($DryRun) {
+    Write-Status 'PATH update' "DRY RUN: would add $PathToAdd to user PATH"
+    return
+  }
+
+  $newPath = if ($currentUserPath) { "$currentUserPath;$PathToAdd" } else { $PathToAdd }
+  [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+  Write-Status 'PATH update' 'user PATH updated; open a new terminal'
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
+  $InstallRoot = Join-Path $env:LOCALAPPDATA 'CodeMie'
+}
+
+$BinDir = Join-Path $InstallRoot 'bin'
+$PrefixDir = Join-Path $InstallRoot 'npm-prefix'
+$NpmPath = Get-CommandPath 'npm.cmd'
+$NodePath = Get-CommandPath 'node.exe'
+$GitPath = Get-CommandPath 'git.exe'
+$NodeMajor = Get-NodeMajor $NodePath
+
+Write-Host 'CodeMie installer diagnostics'
+Write-Status 'OS' ([System.Environment]::OSVersion.VersionString)
+Write-Status 'Shell' 'PowerShell'
+Write-Status 'Install mode' $Mode
+Write-Status 'Install root' $InstallRoot
+Write-Status 'Node' $(if ($NodePath) { "$NodePath (major $NodeMajor)" } else { 'not found' })
+Write-Status 'npm' $(if ($NpmPath) { $NpmPath } else { 'not found' })
+Write-Status 'Git' $(if ($GitPath) { $GitPath } else { 'not found' })
+Write-Status 'Registry' $RegistryUrl
+
+if (-not $NodePath -or $NodeMajor -lt $MinimumNodeMajor) {
+  throw "Node.js $MinimumNodeMajor or newer is required. Install the corporate-approved Node.js package, then rerun this installer."
+}
+
+if (-not $NpmPath) {
+  throw 'npm.cmd was not found. Reinstall Node.js with npm enabled, then rerun this installer.'
+}
+
+if ($Mode -eq 'portable') {
+  if ($DryRun) {
+    Write-Host "DRY RUN: would create $BinDir and $PrefixDir"
+  } else {
+    New-Item -ItemType Directory -Force -Path $BinDir, $PrefixDir | Out-Null
+  }
+  Invoke-Checked $NpmPath @('config', 'set', 'prefix', $PrefixDir, '--location', 'user') 'Failed to configure npm prefix.'
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ScopeRegistryUrl)) {
+  Invoke-Checked $NpmPath @('config', 'set', '@codemieai:registry', $ScopeRegistryUrl, '--location', 'user') 'Failed to configure @codemieai registry.'
+}
+
+$PackageSpec = $PackageName
+if (-not [string]::IsNullOrWhiteSpace($Version)) {
+  $PackageSpec = "$PackageName@$Version"
+}
+
+$ResolvedPackageVersion = Get-PackageVersion $NpmPath $PackageSpec $RegistryUrl
+Write-Status 'Package' "$PackageSpec found ($ResolvedPackageVersion)"
+Invoke-Checked $NpmPath @('install', '-g', $PackageSpec, '--registry', $RegistryUrl) "Failed to install $PackageSpec."
+
+if ($Mode -eq 'portable') {
+  foreach ($CommandName in $Commands) {
+    $shimPath = Join-Path $BinDir "$CommandName.cmd"
+    $targetPath = Join-Path $PrefixDir "$CommandName.cmd"
+    $fallbackTargetPath = Join-Path $PrefixDir "node_modules\.bin\$CommandName.cmd"
+    $shim = @(
+      '@echo off',
+      "if exist `"$targetPath`" (",
+      "  call `"$targetPath`" %*",
+      '  exit /b %ERRORLEVEL%',
+      ')',
+      "if exist `"$fallbackTargetPath`" (",
+      "  call `"$fallbackTargetPath`" %*",
+      '  exit /b %ERRORLEVEL%',
+      ')',
+      "echo CodeMie command shim could not find $CommandName.cmd in $PrefixDir",
+      'exit /b 1'
+    ) -join "`r`n"
+
+    if ($DryRun) {
+      Write-Host "DRY RUN: would write $shimPath"
+    } else {
+      $shim | Set-Content -Path $shimPath -Encoding ASCII
+    }
+  }
+
+  Add-UserPath $BinDir
+}
+
+Write-Status 'CodeMie' "installed $ResolvedPackageVersion"
+Write-Host 'Run `codemie doctor` in a new terminal to verify the installation.'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc && tsc-alias && npm run copy-plugin",
     "copy-plugin": "node scripts/copy-plugins.js",
+    "prepare:install-artifacts": "node scripts/prepare-install-artifacts.mjs",
     "dev": "tsc --watch",
     "test": "vitest",
     "test:unit": "vitest run src",

--- a/scripts/prepare-install-artifacts.mjs
+++ b/scripts/prepare-install-artifacts.mjs
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const packageJson = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+const outDir = path.join(root, 'artifacts', 'install');
+
+const files = [
+  ['install/windows/install.ps1', 'install.ps1'],
+  ['install/windows/install.cmd', 'install.cmd'],
+  ['install/macos/install.sh', 'install.sh']
+];
+
+// Checksums intentionally cover the generated artifacts, including version headers.
+// They are for release artifact verification, not source-file verification.
+
+await mkdir(outDir, { recursive: true });
+
+const checksums = [];
+
+for (const [source, target] of files) {
+  const sourcePath = path.join(root, source);
+  const targetPath = path.join(outDir, target);
+  await copyFile(sourcePath, targetPath);
+
+  const originalContent = await readFile(targetPath, 'utf8');
+  const content = addArtifactHeader(target, originalContent, packageJson);
+  await writeFile(targetPath, content, 'utf8');
+
+  const sha256 = createHash('sha256').update(content).digest('hex');
+  checksums.push(`${sha256}  ${target}`);
+}
+
+const manifest = {
+  packageName: packageJson.name,
+  packageVersion: packageJson.version,
+  generatedAt: new Date().toISOString(),
+  artifacts: checksums.map((line) => {
+    const [sha256, fileName] = line.split(/\s+/);
+    return { fileName, sha256 };
+  })
+};
+
+await writeFile(path.join(outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+await writeFile(path.join(outDir, 'checksums.txt'), `${checksums.join('\n')}\n`, 'utf8');
+
+console.log(`Prepared installer artifacts for ${packageJson.name}@${packageJson.version}`);
+console.log(`Output: ${path.relative(root, outDir)}`);
+
+function addArtifactHeader(fileName, content, packageJson) {
+  const versionLine = `CodeMie installer artifact for ${packageJson.name}@${packageJson.version}`;
+
+  if (fileName.endsWith('.cmd')) {
+    return `rem ${versionLine}\r\n${content}`;
+  }
+
+  if (fileName.endsWith('.sh') && content.startsWith('#!')) {
+    const firstNewline = content.indexOf('\n');
+    if (firstNewline !== -1) {
+      return `${content.slice(0, firstNewline + 1)}# ${versionLine}\n${content.slice(firstNewline + 1)}`;
+    }
+  }
+
+  return `# ${versionLine}\n${content}`;
+}

--- a/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
+++ b/src/agents/plugins/claude/plugin/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI/Run CodeMie",
     "email": "support@codemieai.com"
   },
-  "version": "1.0.19"
+  "version": "1.0.20"
 }

--- a/src/cli/commands/proxy/__tests__/index.test.ts
+++ b/src/cli/commands/proxy/__tests__/index.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Proxy command tests
+ * @group unit
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../utils/config.js', () => ({
+  ConfigLoader: {
+    load: vi.fn(),
+    listProfiles: vi.fn(),
+    getActiveProfileName: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../providers/index.js', () => ({
+  ProviderRegistry: {
+    getProvider: vi.fn(),
+  },
+}));
+
+vi.mock('../daemon-manager.js', () => ({
+  checkStatus: vi.fn(),
+  readState: vi.fn(),
+  spawnDaemon: vi.fn(),
+  stopDaemon: vi.fn(),
+}));
+
+vi.mock('../connectors/desktop.js', () => ({
+  writeDesktopConfig: vi.fn(),
+}));
+
+vi.mock('../inspect-desktop.js', () => ({
+  printDesktopInspection: vi.fn(),
+}));
+
+vi.mock('../../../../providers/plugins/sso/sso.auth.js', () => ({
+  CodeMieSSO: vi.fn(),
+}));
+
+describe('proxy connect desktop', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit:${code}`);
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('does not spawn the daemon when selected SSO profile has no stored credentials', async () => {
+    const { ConfigLoader } = await import('../../../../utils/config.js');
+    const { ProviderRegistry } = await import('../../../../providers/index.js');
+    const { CodeMieSSO } = await import('../../../../providers/plugins/sso/sso.auth.js');
+    const { checkStatus, spawnDaemon } = await import('../daemon-manager.js');
+    const { createProxyCommand } = await import('../index.js');
+
+    vi.mocked(checkStatus).mockResolvedValue({ running: false, state: null });
+    vi.mocked(ConfigLoader.load).mockResolvedValue({
+      name: 'codemie-new',
+      provider: 'ai-run-sso',
+      baseUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+      codeMieUrl: 'https://codemie.lab.epam.com',
+    } as Awaited<ReturnType<typeof ConfigLoader.load>>);
+    vi.mocked(ProviderRegistry.getProvider).mockReturnValue({
+      name: 'ai-run-sso',
+      authType: 'sso',
+    } as ReturnType<typeof ProviderRegistry.getProvider>);
+    vi.mocked(CodeMieSSO).mockImplementation(function MockCodeMieSSO() {
+      return {
+      getStoredCredentials: vi.fn().mockResolvedValue(null),
+      };
+    } as unknown as typeof CodeMieSSO);
+
+    const command = createProxyCommand();
+    await expect(
+      command.parseAsync(['connect', 'desktop', '--profile', 'codemie-new'], { from: 'user' })
+    ).rejects.toThrow('process.exit:1');
+
+    expect(spawnDaemon).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No SSO credentials found for profile 'codemie-new'.")
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '  Run: codemie profile login --url https://codemie.lab.epam.com/code-assistant-api'
+    );
+  });
+});

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -87,6 +87,22 @@ async function resolveDesktopProxyConfig(profileName?: string): Promise<{
   );
 }
 
+async function verifySsoCredentials(baseUrl: string, profileName: string): Promise<void> {
+  try {
+    const { CodeMieSSO } = await import('../../../providers/plugins/sso/sso.auth.js');
+    const sso = new CodeMieSSO();
+    const creds = await sso.getStoredCredentials(baseUrl);
+    if (!creds) {
+      console.error(chalk.red(`✗ No SSO credentials found for profile '${profileName}'.`));
+      console.error(`  Run: codemie profile login --url ${baseUrl}`);
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(chalk.red(`✗ Failed to verify credentials: ${(err as Error).message}`));
+    process.exit(1);
+  }
+}
+
 export function createProxyCommand(): Command {
   const proxy = new Command('proxy');
   proxy.description('Manage the CodeMie local gateway proxy daemon');
@@ -115,20 +131,7 @@ export function createProxyCommand(): Command {
         process.exit(1);
       }
 
-      // Verify SSO credentials exist before spawning
-      try {
-        const { CodeMieSSO } = await import('../../../providers/plugins/sso/sso.auth.js');
-        const sso = new CodeMieSSO();
-        const creds = await sso.getStoredCredentials(config.baseUrl);
-        if (!creds) {
-          console.error(chalk.red(`✗ No SSO credentials found for profile '${config.name ?? 'default'}'.`));
-          console.error(`  Run: codemie profile login --url ${config.baseUrl}`);
-          process.exit(1);
-        }
-      } catch (err) {
-        console.error(chalk.red(`✗ Failed to verify credentials: ${(err as Error).message}`));
-        process.exit(1);
-      }
+      await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
 
       console.log('Starting proxy daemon...');
       const daemonState = await spawnDaemon({
@@ -224,6 +227,7 @@ export function createProxyCommand(): Command {
             `(source: ${profileSource === 'explicit' ? '--profile' : 'active profile'})`
           )
         );
+        await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
         state = await spawnDaemon({
           targetUrl: config.baseUrl,
           provider: config.provider ?? 'ai-run-sso',

--- a/tests/integration/sso-claude-plugin.test.ts
+++ b/tests/integration/sso-claude-plugin.test.ts
@@ -280,7 +280,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBeDefined();
-      expect(result.sourceVersion).toBe('1.0.19');
+      expect(result.sourceVersion).toBe('1.0.20');
       expect(result.installedVersion).toBeUndefined(); // First install
     });
 
@@ -293,8 +293,8 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const result2 = await installer.install();
       expect(result2.success).toBe(true);
       expect(result2.action).toBe('already_exists');
-      expect(result2.sourceVersion).toBe('1.0.19');
-      expect(result2.installedVersion).toBe('1.0.19');
+      expect(result2.sourceVersion).toBe('1.0.20');
+      expect(result2.installedVersion).toBe('1.0.20');
     });
 
     it('should detect version in installed plugin', async () => {
@@ -308,7 +308,7 @@ describe('SSO Provider - Claude Plugin Auto-Install', () => {
       const json = JSON.parse(content);
 
       expect(json.version).toBeDefined();
-      expect(json.version).toBe('1.0.19');
+      expect(json.version).toBe('1.0.20');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds lightweight bootstrap installer scripts for Windows (PowerShell + CMD) and macOS/Linux/WSL (bash), along with publish workflow integration to build and distribute them as release artifacts.

## Changes

- **`install/windows/install.ps1`** — PowerShell bootstrapper; installs in portable user-local mode by default, calls `npm.cmd` directly to avoid execution-policy issues
- **`install/windows/install.cmd`** — CMD wrapper that downloads and executes the PowerShell installer, for environments where PowerShell pipe-invocation is impractical
- **`install/macos/install.sh`** — POSIX bash installer; falls back to user-local npm prefix when global npm is not writable
- **`scripts/prepare-install-artifacts.mjs`** — Generates versioned artifacts with checksums in `artifacts/install/` for release publishing
- **`publish.yml`** — Extended to prepare, upload, and publish installers to Artifactory under versioned and `stable` paths
- **`README.md`** — New installation section covering all three platforms with troubleshooting guidance

## Impact

Users on Windows and macOS can now install CodeMie without npm global-install permissions or execution-policy changes. Enterprise teams can mirror the scripts to Artifactory by setting `CODEMIE_INSTALL_URL`.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)