### PR TITLE
fix(providers): support haiku and opus aliases for claude

### DIFF
--- a/src/providers/plugins/anthropic-subscription/__tests__/anthropic-subscription.template.test.ts
+++ b/src/providers/plugins/anthropic-subscription/__tests__/anthropic-subscription.template.test.ts
@@ -30,6 +30,10 @@ describe('AnthropicSubscriptionTemplate', () => {
 
   it('includes recommended Claude models', () => {
     expect(AnthropicSubscriptionTemplate.recommendedModels).toContain('claude-sonnet-4-6');
+    expect(AnthropicSubscriptionTemplate.recommendedModels).toContain('claude-opus-4-7');
+    expect(AnthropicSubscriptionTemplate.recommendedModels).not.toContain('claude-opus-4-6');
+    expect(AnthropicSubscriptionTemplate.recommendedModels).toContain('claude-haiku-4-5-20251001');
+    expect(AnthropicSubscriptionTemplate.recommendedModels).not.toContain('claude-4-5-haiku');
     expect(AnthropicSubscriptionTemplate.recommendedModels.length).toBeGreaterThan(0);
   });
 
@@ -170,6 +174,38 @@ describe('AnthropicSubscriptionTemplate', () => {
     it('always exports CODEMIE_API_KEY as empty string', () => {
       const env = AnthropicSubscriptionTemplate.exportEnvVars!({} as any);
       expect(env.CODEMIE_API_KEY).toBe('');
+    });
+
+    it('normalizes gateway Haiku aliases to Anthropic-native Haiku for Claude Code', () => {
+      const env = AnthropicSubscriptionTemplate.exportEnvVars!({
+        model: 'claude-4-5-haiku',
+        haikuModel: 'claude-haiku-4-5-20251001',
+      } as any);
+
+      expect(env.CODEMIE_MODEL).toBe('claude-haiku-4-5-20251001');
+      expect(env.CODEMIE_HAIKU_MODEL).toBeUndefined();
+    });
+
+    it('normalizes stale Opus defaults to Claude Code subscription Opus 4.7', () => {
+      const env = AnthropicSubscriptionTemplate.exportEnvVars!({
+        model: 'claude-opus-4-6',
+        opusModel: 'claude-opus-4-6[1m]',
+      } as any);
+
+      expect(env.CODEMIE_MODEL).toBe('claude-opus-4-7');
+      expect(env.CODEMIE_OPUS_MODEL).toBe('claude-opus-4-7[1m]');
+    });
+
+    it('does not rewrite non-Haiku Anthropic subscription models', () => {
+      const env = AnthropicSubscriptionTemplate.exportEnvVars!({
+        model: 'claude-sonnet-4-6',
+        haikuModel: 'claude-haiku-4-5-20251001',
+        opusModel: 'claude-opus-4-7',
+      } as any);
+
+      expect(env.CODEMIE_MODEL).toBeUndefined();
+      expect(env.CODEMIE_HAIKU_MODEL).toBeUndefined();
+      expect(env.CODEMIE_OPUS_MODEL).toBeUndefined();
     });
 
     it('exports CODEMIE_URL and CODEMIE_SYNC_API_URL when codeMieUrl is set', () => {

--- a/src/providers/plugins/anthropic-subscription/anthropic-subscription.template.ts
+++ b/src/providers/plugins/anthropic-subscription/anthropic-subscription.template.ts
@@ -12,6 +12,19 @@ import type { AgentConfig } from '../../../agents/core/types.js';
 import { registerProvider } from '../../core/decorators.js';
 import { ensureApiBase } from '../../core/codemie-auth-helpers.js';
 
+const ANTHROPIC_SUBSCRIPTION_DEFAULT_HAIKU_MODEL = 'claude-haiku-4-5-20251001';
+const ANTHROPIC_SUBSCRIPTION_DEFAULT_OPUS_MODEL = 'claude-opus-4-7';
+
+const ANTHROPIC_SUBSCRIPTION_MODEL_ALIASES: Record<string, string> = {
+  'claude-4-5-haiku': ANTHROPIC_SUBSCRIPTION_DEFAULT_HAIKU_MODEL,
+  'claude-opus-4-6': ANTHROPIC_SUBSCRIPTION_DEFAULT_OPUS_MODEL,
+  'claude-opus-4-6[1m]': `${ANTHROPIC_SUBSCRIPTION_DEFAULT_OPUS_MODEL}[1m]`,
+};
+
+function normalizeAnthropicSubscriptionModel(model: string | undefined): string | undefined {
+  return model ? ANTHROPIC_SUBSCRIPTION_MODEL_ALIASES[model] ?? model : undefined;
+}
+
 export const AnthropicSubscriptionTemplate = registerProvider<ProviderTemplate>({
   name: 'anthropic-subscription',
   displayName: 'Anthropic Subscription',
@@ -23,8 +36,8 @@ export const AnthropicSubscriptionTemplate = registerProvider<ProviderTemplate>(
   defaultProfileName: 'anthropic-subscription',
   recommendedModels: [
     'claude-sonnet-4-6',
-    'claude-opus-4-6',
-    'claude-4-5-haiku',
+    ANTHROPIC_SUBSCRIPTION_DEFAULT_OPUS_MODEL,
+    ANTHROPIC_SUBSCRIPTION_DEFAULT_HAIKU_MODEL,
   ],
   capabilities: ['streaming', 'tools', 'function-calling', 'vision'],
   supportsModelInstallation: false,
@@ -98,6 +111,22 @@ export const AnthropicSubscriptionTemplate = registerProvider<ProviderTemplate>(
       // for native Claude auth before the Claude process is spawned.
       CODEMIE_API_KEY: '',
     };
+
+    // SSO/JWT use CodeMie gateway model names, but this provider talks directly to
+    // Anthropic via Claude Code's native subscription session.
+    const model = normalizeAnthropicSubscriptionModel(config.model);
+    const haikuModel = normalizeAnthropicSubscriptionModel(config.haikuModel);
+    const opusModel = normalizeAnthropicSubscriptionModel(config.opusModel);
+
+    if (model && model !== config.model) {
+      env.CODEMIE_MODEL = model;
+    }
+    if (haikuModel && haikuModel !== config.haikuModel) {
+      env.CODEMIE_HAIKU_MODEL = haikuModel;
+    }
+    if (opusModel && opusModel !== config.opusModel) {
+      env.CODEMIE_OPUS_MODEL = opusModel;
+    }
 
     if (config.codeMieUrl) {
       env.CODEMIE_URL = config.codeMieUrl;

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/claude-non-thinking-model-sanitizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/claude-non-thinking-model-sanitizer.plugin.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Claude Non-Thinking Model Sanitizer Plugin Tests
+ *
+ * Verifies Claude Desktop requests are sanitized when the selected Claude model
+ * does not support extended thinking, such as Claude Haiku.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ClaudeNonThinkingModelSanitizerPlugin } from '../claude-non-thinking-model-sanitizer.plugin.js';
+import { PluginContext, ProxyInterceptor } from '../types.js';
+import { ProxyContext } from '../../proxy-types.js';
+import { logger } from '../../../../../../utils/logger.js';
+
+function createPluginContext(clientType?: string, model?: string): PluginContext {
+  return {
+    config: {
+      targetApiUrl: 'https://api.anthropic.com',
+      provider: 'test',
+      sessionId: 'test-session',
+      clientType,
+      model,
+    },
+    logger,
+  };
+}
+
+function createProxyContext(
+  body: Record<string, unknown> | null,
+  contentType = 'application/json',
+  headers: Record<string, string> = {},
+): ProxyContext {
+  const requestBody = body ? Buffer.from(JSON.stringify(body), 'utf-8') : null;
+  return {
+    requestId: 'test-req',
+    sessionId: 'test-session',
+    agentName: 'claude-desktop',
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {
+      'content-type': contentType,
+      ...headers,
+      ...(requestBody && { 'content-length': String(requestBody.length) }),
+    },
+    requestBody,
+    requestStartTime: Date.now(),
+    metadata: {},
+  };
+}
+
+describe('ClaudeNonThinkingModelSanitizerPlugin', () => {
+  let plugin: ClaudeNonThinkingModelSanitizerPlugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new ClaudeNonThinkingModelSanitizerPlugin();
+  });
+
+  describe('Plugin Metadata', () => {
+    it('has correct id', () => {
+      expect(plugin.id).toBe('@codemie/proxy-claude-non-thinking-model-sanitizer');
+    });
+
+    it('has priority 17', () => {
+      expect(plugin.priority).toBe(17);
+    });
+  });
+
+  describe('createInterceptor — Agent Scoping', () => {
+    it('creates interceptor for claude-desktop', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('claude-desktop'));
+
+      expect(interceptor).toBeDefined();
+      expect(interceptor.name).toBe('claude-non-thinking-model-sanitizer');
+    });
+
+    it('throws for codemie-claude', async () => {
+      await expect(plugin.createInterceptor(createPluginContext('codemie-claude')))
+        .rejects.toThrow('Plugin disabled for agent: codemie-claude');
+    });
+  });
+
+  describe('Non-Thinking Claude Model Sanitization', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('claude-desktop'));
+    });
+
+    it('removes top-level thinking and thinking history blocks for Claude Haiku', async () => {
+      const context = createProxyContext({
+        model: 'claude-haiku-4-5-20251001',
+        thinking: { type: 'enabled', budget_tokens: 1024 },
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'internal reasoning', signature: 'sig' },
+              { type: 'text', text: 'Visible answer' },
+              { type: 'tool_use', id: 'tool-1', name: 'read', input: {} },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'redacted_thinking', data: 'encrypted' },
+              { type: 'text', text: 'More visible text' },
+            ],
+          },
+        ],
+      });
+      const originalLength = context.headers['content-length'];
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toBeUndefined();
+      expect(body.messages[0].content).toEqual([
+        { type: 'text', text: 'Visible answer' },
+        { type: 'tool_use', id: 'tool-1', name: 'read', input: {} },
+      ]);
+      expect(body.messages[1].content).toEqual([
+        { type: 'text', text: 'More visible text' },
+      ]);
+      expect(Number(context.headers['content-length'])).toBeLessThan(Number(originalLength));
+      expect(Number(context.headers['content-length'])).toBe(context.requestBody!.length);
+    });
+
+    it('replaces thinking-only content arrays with an empty text block', async () => {
+      const context = createProxyContext({
+        model: 'claude-haiku-4-5-20251001',
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'thinking', thinking: 'internal reasoning' }],
+          },
+        ],
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.messages[0].content).toEqual([{ type: 'text', text: '' }]);
+    });
+
+    it('removes only interleaved thinking from anthropic-beta header', async () => {
+      const context = createProxyContext(
+        {
+          model: 'claude-haiku-4-5-20251001',
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+        'application/json',
+        { 'anthropic-beta': 'files-api-beta, interleaved-thinking-beta' },
+      );
+
+      await interceptor.onRequest!(context);
+
+      expect(context.headers['anthropic-beta']).toBe('files-api-beta');
+    });
+
+    it('deletes anthropic-beta header when it only contains interleaved thinking', async () => {
+      const context = createProxyContext(
+        {
+          model: 'claude-haiku-4-5-20251001',
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+        'application/json',
+        { 'anthropic-beta': 'interleaved-thinking-beta' },
+      );
+
+      await interceptor.onRequest!(context);
+
+      expect(context.headers['anthropic-beta']).toBeUndefined();
+    });
+
+    it('does not change Sonnet 4 requests that support extended thinking', async () => {
+      const original = {
+        model: 'claude-sonnet-4-6',
+        thinking: { type: 'enabled', budget_tokens: 1024 },
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'internal reasoning', signature: 'sig' },
+              { type: 'text', text: 'Visible answer' },
+            ],
+          },
+        ],
+      };
+      const context = createProxyContext(original);
+      const originalBody = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBody);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('claude-desktop'));
+    });
+
+    it('passes through non-Claude models', async () => {
+      const context = createProxyContext({
+        model: 'gpt-5',
+        thinking: { type: 'enabled' },
+      });
+      const originalBody = context.requestBody!.toString('utf-8');
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalBody);
+    });
+
+    it('uses configured model when request body omits model', async () => {
+      const configuredInterceptor = await plugin.createInterceptor(
+        createPluginContext('claude-desktop', 'claude-haiku-4-5-20251001'),
+      );
+      const context = createProxyContext({
+        thinking: { type: 'enabled' },
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+
+      await configuredInterceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toBeUndefined();
+    });
+
+    it('passes through malformed JSON without error', async () => {
+      const context = createProxyContext(null);
+      context.requestBody = Buffer.from('not valid json{{{', 'utf-8');
+      context.headers['content-length'] = String(context.requestBody.length);
+
+      await expect(interceptor.onRequest!(context)).resolves.toBeUndefined();
+      expect(context.requestBody.toString('utf-8')).toBe('not valid json{{{');
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/claude-non-thinking-model-sanitizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/claude-non-thinking-model-sanitizer.plugin.test.ts
@@ -1,8 +1,8 @@
 /**
  * Claude Non-Thinking Model Sanitizer Plugin Tests
  *
- * Verifies Claude Desktop requests are sanitized when the selected Claude model
- * does not support extended thinking, such as Claude Haiku.
+ * Verifies Claude API clients are sanitized when the selected Claude model does
+ * not support extended thinking, such as Claude Haiku.
  *
  * @group unit
  */
@@ -75,9 +75,16 @@ describe('ClaudeNonThinkingModelSanitizerPlugin', () => {
       expect(interceptor.name).toBe('claude-non-thinking-model-sanitizer');
     });
 
-    it('throws for codemie-claude', async () => {
-      await expect(plugin.createInterceptor(createPluginContext('codemie-claude')))
-        .rejects.toThrow('Plugin disabled for agent: codemie-claude');
+    it('creates interceptor for codemie-claude', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('codemie-claude'));
+
+      expect(interceptor).toBeDefined();
+      expect(interceptor.name).toBe('claude-non-thinking-model-sanitizer');
+    });
+
+    it('throws for codemie-opencode', async () => {
+      await expect(plugin.createInterceptor(createPluginContext('codemie-opencode')))
+        .rejects.toThrow('Plugin disabled for agent: codemie-opencode');
     });
   });
 

--- a/src/providers/plugins/sso/proxy/plugins/claude-non-thinking-model-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/claude-non-thinking-model-sanitizer.plugin.ts
@@ -1,0 +1,169 @@
+/**
+ * Claude Non-Thinking Model Sanitizer Plugin
+ * Priority: 17 (runs after Claude thinking parameter transforms)
+ *
+ * Some Claude clients preserve Anthropic `thinking` content blocks in message
+ * history. Those blocks are only valid for models that support extended
+ * thinking. When a user switches the same conversation to a model without
+ * extended thinking support, such as Claude Haiku, upstream adapters may reject
+ * the request with errors like "Content block is not a text block".
+ *
+ * For non-thinking Claude models, remove thinking controls and thinking-only
+ * history blocks while preserving ordinary text, tool, image, and document
+ * content.
+ */
+
+import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+
+const ALLOWED_AGENTS = ['claude-desktop'];
+const THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking']);
+const THINKING_BETA_PATTERN = /^interleaved-thinking-[^,\s]+$/i;
+
+function isJsonRequest(context: ProxyContext): boolean {
+  return Boolean(
+    context.requestBody
+      && context.headers['content-type']?.includes('application/json')
+  );
+}
+
+function modelSupportsExtendedThinking(modelName: string): boolean {
+  const normalized = modelName.toLowerCase();
+  return normalized.includes('claude-3-7-sonnet')
+    || /claude-(?:opus|sonnet)-4(?:[^0-9]|$)/i.test(normalized);
+}
+
+function isClaudeModel(modelName: string): boolean {
+  return /^claude-/i.test(modelName);
+}
+
+function modelRequiresThinkingSanitization(modelName: string): boolean {
+  return isClaudeModel(modelName) && !modelSupportsExtendedThinking(modelName);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stripThinkingBlocksFromContent(content: unknown): {
+  content: unknown;
+  strippedBlocks: number;
+} {
+  if (!Array.isArray(content)) {
+    return { content, strippedBlocks: 0 };
+  }
+
+  let strippedBlocks = 0;
+  const filtered = content.filter((block) => {
+    if (isRecord(block) && typeof block.type === 'string' && THINKING_BLOCK_TYPES.has(block.type)) {
+      strippedBlocks++;
+      return false;
+    }
+    return true;
+  });
+
+  return {
+    content: filtered.length > 0 ? filtered : [{ type: 'text', text: '' }],
+    strippedBlocks,
+  };
+}
+
+function stripInterleavedThinkingBeta(headerValue: string): string {
+  return headerValue
+    .split(',')
+    .map(part => part.trim())
+    .filter(part => part && !THINKING_BETA_PATTERN.test(part))
+    .join(',');
+}
+
+export class ClaudeNonThinkingModelSanitizerPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-claude-non-thinking-model-sanitizer';
+  name = 'Claude Non-Thinking Model Sanitizer';
+  version = '1.0.0';
+  priority = 17;
+
+  async createInterceptor(context: PluginContext): Promise<ProxyInterceptor> {
+    const clientType = context.config.clientType;
+    if (!clientType || !ALLOWED_AGENTS.includes(clientType)) {
+      throw new Error(`Plugin disabled for agent: ${clientType}`);
+    }
+    return new ClaudeNonThinkingModelSanitizerInterceptor(context.config.model);
+  }
+}
+
+class ClaudeNonThinkingModelSanitizerInterceptor implements ProxyInterceptor {
+  name = 'claude-non-thinking-model-sanitizer';
+
+  constructor(private readonly configModel?: string) {}
+
+  async onRequest(context: ProxyContext): Promise<void> {
+    if (!isJsonRequest(context)) {
+      return;
+    }
+
+    try {
+      const body = JSON.parse(context.requestBody!.toString('utf-8')) as Record<string, unknown>;
+      const model = (typeof body.model === 'string' && body.model) || this.configModel || '';
+      if (!modelRequiresThinkingSanitization(model)) {
+        return;
+      }
+
+      let changed = false;
+      let strippedBlocks = 0;
+      let removedTopLevelThinking = false;
+
+      if ('thinking' in body) {
+        delete body.thinking;
+        changed = true;
+        removedTopLevelThinking = true;
+      }
+
+      if (Array.isArray(body.messages)) {
+        for (const message of body.messages) {
+          if (!isRecord(message) || !('content' in message)) {
+            continue;
+          }
+
+          const result = stripThinkingBlocksFromContent(message.content);
+          if (result.strippedBlocks > 0) {
+            message.content = result.content;
+            strippedBlocks += result.strippedBlocks;
+            changed = true;
+          }
+        }
+      }
+
+      const betaHeader = context.headers['anthropic-beta'];
+      if (typeof betaHeader === 'string') {
+        const sanitizedBeta = stripInterleavedThinkingBeta(betaHeader);
+        if (sanitizedBeta !== betaHeader) {
+          if (sanitizedBeta) {
+            context.headers['anthropic-beta'] = sanitizedBeta;
+          } else {
+            delete context.headers['anthropic-beta'];
+          }
+          changed = true;
+        }
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      context.requestBody = Buffer.from(JSON.stringify(body), 'utf-8');
+      context.headers['content-length'] = String(context.requestBody.length);
+
+      logger.debug(
+        `[${this.name}] Removed extended thinking data for non-thinking model`,
+        {
+          model,
+          strippedBlocks,
+          removedTopLevelThinking,
+        }
+      );
+    } catch {
+      // Not valid JSON or unexpected structure - pass through unchanged.
+    }
+  }
+}

--- a/src/providers/plugins/sso/proxy/plugins/claude-non-thinking-model-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/claude-non-thinking-model-sanitizer.plugin.ts
@@ -17,7 +17,7 @@ import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
 import { ProxyContext } from '../proxy-types.js';
 import { logger } from '../../../../../utils/logger.js';
 
-const ALLOWED_AGENTS = ['claude-desktop'];
+const ALLOWED_AGENTS = ['claude-desktop', 'codemie-claude'];
 const THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking']);
 const THINKING_BETA_PATTERN = /^interleaved-thinking-[^,\s]+$/i;
 

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -14,6 +14,7 @@ import { JWTAuthPlugin } from './jwt-auth.plugin.js';
 import { HeaderInjectionPlugin } from './header-injection.plugin.js';
 import { RequestSanitizerPlugin } from './request-sanitizer.plugin.js';
 import { ClaudeThinkingTransformerPlugin } from './claude-thinking-transformer.plugin.js';
+import { ClaudeNonThinkingModelSanitizerPlugin } from './claude-non-thinking-model-sanitizer.plugin.js';
 import { LoggingPlugin } from './logging.plugin.js';
 import { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 
@@ -32,6 +33,7 @@ export function registerCorePlugins(): void {
   registry.register(new JWTAuthPlugin());
   registry.register(new RequestSanitizerPlugin()); // Priority 15 - strips unsupported reasoning params
   registry.register(new ClaudeThinkingTransformerPlugin()); // Priority 16 - transforms thinking params for Claude 4.7+ models
+  registry.register(new ClaudeNonThinkingModelSanitizerPlugin()); // Priority 17 - strips thinking blocks for Claude models without thinking support
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
   registry.register(new SSOSessionSyncPlugin()); // Priority 100 - syncs sessions via multiple processors
@@ -50,6 +52,7 @@ export {
   HeaderInjectionPlugin,
   RequestSanitizerPlugin,
   ClaudeThinkingTransformerPlugin,
+  ClaudeNonThinkingModelSanitizerPlugin,
   LoggingPlugin,
 };
 export { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';


### PR DESCRIPTION
## Summary
- Add a Claude proxy sanitizer for Claude models without extended thinking support, including Haiku.
- Strip top-level thinking controls, thinking/redacted_thinking history blocks, and interleaved-thinking beta headers only for non-thinking Claude models.
- Normalize Anthropic subscription model aliases so Claude Code uses Haiku 4.5 and Opus 4.7 instead of stale or gateway-only model names.

## Test Plan
- [x] npm run ci

## Notes
- Existing Vitest/Node warnings remain: test.poolOptions deprecation and NO_COLOR/FORCE_COLOR warnings.
