### PR TITLE
feat(agents): add prompt caching and autocompact defaults for codemie-claude

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -163,6 +163,25 @@ export const ClaudePluginMetadata: AgentMetadata = {
         env.ENABLE_TOOL_SEARCH = '0';
       }
 
+      if (!env.ENABLE_PROMPT_CACHING_1H) {
+        env.ENABLE_PROMPT_CACHING_1H = '1';
+      }
+
+      if (!env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE) {
+        let autocompactPct = 70;
+        if (env.CODEMIE_PROFILE_CONFIG) {
+          try {
+            const profileConfig = JSON.parse(env.CODEMIE_PROFILE_CONFIG);
+            if (typeof profileConfig.claudeAutocompactPct === 'number') {
+              autocompactPct = profileConfig.claudeAutocompactPct;
+            }
+          } catch {
+            // ignore malformed profile config
+          }
+        }
+        env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = String(autocompactPct);
+      }
+
       // Statusline setup: when --status flag is passed, configure Claude Code
       // status bar with a multi-line display showing model, context, git, cost
       // https://code.claude.com/docs/en/statusline

--- a/src/env/types.ts
+++ b/src/env/types.ts
@@ -97,6 +97,9 @@ export interface ProviderProfile {
   assistants?: {
     maxHistoryMessages?: number; // Maximum conversation turns to load (default: 10, which loads 20 messages = 10 user + 10 AI)
   };
+
+  // Claude Code-specific settings
+  claudeAutocompactPct?: number; // Auto-compact threshold percentage (sets CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, default: 70)
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds two environment variable defaults that are applied at startup when running codemie-claude, improving performance and context management out of the box.

## Changes

- **`ENABLE_PROMPT_CACHING_1H=1`** — enabled by default in `beforeRun` if not already set in the environment, activating 1-hour prompt caching for Claude Code
- **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=70`** — set to `70` by default if not already in env; reads `claudeAutocompactPct` from the active provider profile config to allow per-profile overrides
- Added `claudeAutocompactPct?: number` field to `ProviderProfile` type in `src/env/types.ts`

## Impact

Users running `codemie claude` will automatically benefit from prompt caching and a sensible auto-compact threshold without any manual configuration. Both values can be overridden via env vars or the `claudeAutocompactPct` field in the profile config.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)