### PR TITLE
feat(cli): add --verbose flag to proxy connect desktop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Use Claude Desktop 3P through CodeMie proxy routing to capture `claude-desktop` 
 ### 1. Select the active CodeMie profile
 
 ```bash
-codemie profile switch codemie-prod
+codemie profile switch <e.g. codemie-prod, should be your SSO profile name>
 ```
 
 ### 2. Connect Claude Desktop
@@ -408,10 +408,10 @@ codemie profile switch codemie-prod
 codemie proxy connect desktop
 ```
 
-By default this uses your current active CodeMie profile. Override it for one run with:
+By default this uses your current active CodeMie profile. Override it for one run with ("codemie-prod" is example here):
 
 ```bash
-codemie proxy connect desktop --profile codemie-new
+codemie proxy connect desktop --profile codemie-prod
 ```
 
 ### 3. Restart Claude Desktop

--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
@@ -122,9 +122,9 @@ describe('selectPreferredClaudeModels', () => {
 
   it('returns exact matches when present and dated fallbacks otherwise', () => {
     expect(selectPreferredClaudeModels(available)).toEqual([
+      'claude-sonnet-4-6',        // exact
       'claude-opus-4-7',          // exact
       'claude-opus-4-6-20260205', // dated fallback
-      'claude-sonnet-4-6',        // exact
       'claude-haiku-4-5-20251001',// dated fallback
     ]);
   });
@@ -222,10 +222,10 @@ describe('writeDesktopConfig', () => {
   it('populates inferenceModels with the curated preferred Claude set', async () => {
     const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir);
     const config = JSON.parse(await readFile(written, 'utf-8'));
-    expect(config.inferenceModels).toEqual([
+    expect(JSON.parse(config.inferenceModels)).toEqual([
+      { name: 'claude-sonnet-4-6' },
       { name: 'claude-opus-4-7' },
       { name: 'claude-opus-4-6-20260205' },
-      { name: 'claude-sonnet-4-6' },
       { name: 'claude-haiku-4-5-20251001' },
     ]);
   });
@@ -240,10 +240,10 @@ describe('writeDesktopConfig', () => {
 
     const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir);
     const config = JSON.parse(await readFile(written, 'utf-8'));
-    expect(config.inferenceModels).toEqual([
+    expect(JSON.parse(config.inferenceModels)).toEqual([
+      { name: 'claude-sonnet-4-6' },
       { name: 'claude-opus-4-7' },
       { name: 'claude-opus-4-6-20260205' },
-      { name: 'claude-sonnet-4-6' },
       { name: 'claude-haiku-4-5-20251001' },
     ]);
   });

--- a/src/cli/commands/proxy/connectors/desktop-managed-mcp-servers.json
+++ b/src/cli/commands/proxy/connectors/desktop-managed-mcp-servers.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "Atlassian Jira and Confluence",
+    "url": "https://mcp.atlassian.com/v1/mcp/authv2",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Notion",
+    "url": "https://mcp.notion.com/mcp",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Linear",
+    "url": "https://mcp.linear.app/mcp",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Box",
+    "url": "https://mcp.box.com",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Canva",
+    "url": "https://mcp.canva.com/mcp",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Vercel",
+    "url": "https://mcp.vercel.com",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Netlify",
+    "url": "https://netlify-mcp.netlify.app/mcp",
+    "transport": "http",
+    "oauth": true
+  },
+  {
+    "name": "Miro",
+    "url": "https://mcp.miro.com",
+    "transport": "http",
+    "oauth": true
+  }
+]

--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getClaudeDesktopBaseDir } from '@/telemetry/clients/claude-desktop/claude-desktop.paths.js';
+import managedMcpServers from './desktop-managed-mcp-servers.json' with { type: 'json' };
 
 const INFERENCE_KEYS = [
   'inferenceProvider',
@@ -13,6 +14,13 @@ const INFERENCE_KEYS = [
 
 interface InferenceModelEntry {
   name: string;
+}
+
+interface ManagedMcpServerEntry {
+  name: string;
+  url: string;
+  transport?: 'http' | 'sse';
+  oauth?: boolean;
 }
 
 interface ModelsListResponse {
@@ -28,11 +36,16 @@ interface ModelsListResponse {
  * receives a model name it has registered.
  */
 export const PREFERRED_CLAUDE_MODELS = [
+  'claude-sonnet-4-6',
   'claude-opus-4-7',
   'claude-opus-4-6',
-  'claude-sonnet-4-6',
   'claude-haiku-4-5',
 ] as const;
+
+export const DEFAULT_COWORK_EGRESS_ALLOWED_HOSTS = ['*'] as const;
+
+export const DEFAULT_MANAGED_MCP_SERVERS =
+  managedMcpServers as readonly ManagedMcpServerEntry[];
 
 /**
  * Fetch the model list from the gateway's `/v1/models` endpoint and return
@@ -87,6 +100,49 @@ export function selectPreferredClaudeModels(
     if (dated) resolved.push(dated);
   }
   return resolved;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getManagedMcpServerName(server: unknown): string | undefined {
+  if (!isRecord(server)) return undefined;
+  return typeof server.name === 'string' ? server.name : undefined;
+}
+
+function parseJsonArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function mergeManagedMcpServers(existingServers: unknown): unknown[] {
+  const merged = [...parseJsonArray(existingServers)];
+  const existingNames = new Set(
+    merged
+      .map((server) => getManagedMcpServerName(server)?.toLowerCase())
+      .filter((name): name is string => Boolean(name))
+  );
+
+  for (const server of DEFAULT_MANAGED_MCP_SERVERS) {
+    if (!existingNames.has(server.name.toLowerCase())) {
+      merged.push({ ...server });
+    }
+  }
+
+  return merged;
 }
 
 export interface DesktopGatewayConfig {
@@ -145,10 +201,10 @@ export async function getDesktopConfigPath(baseDir: string = getDesktopBaseDir()
 }
 
 /**
- * Write/merge the inference gateway settings into Claude Desktop's
+ * Write/merge the CodeMie gateway settings into Claude Desktop's
  * `configLibrary/<UUID>.json` and update `_meta.json` so the app picks them up.
  *
- * Preserves all non-inference keys in the existing config file.
+ * Preserves unrelated keys in the existing config file.
  * Returns the absolute path of the config file written.
  */
 export async function writeDesktopConfig(
@@ -188,16 +244,21 @@ export async function writeDesktopConfig(
   const discoveredModels = await fetchClaudeModels(proxyUrl, gatewayKey);
   const resolvedModels = selectPreferredClaudeModels(discoveredModels);
   const inferenceModels: InferenceModelEntry[] = resolvedModels.map((name) => ({ name }));
+  const managedMcpServers = mergeManagedMcpServers(existing.managedMcpServers);
 
   for (const key of INFERENCE_KEYS) {
     delete existing[key];
   }
   delete existing.inferenceModels;
+  delete existing.coworkEgressAllowedHosts;
+  delete existing.managedMcpServers;
 
   const merged = {
     ...existing,
     ...buildGatewayConfig(proxyUrl, gatewayKey),
-    ...(inferenceModels.length > 0 ? { inferenceModels } : {}),
+    ...(inferenceModels.length > 0 ? { inferenceModels: JSON.stringify(inferenceModels) } : {}),
+    coworkEgressAllowedHosts: JSON.stringify([...DEFAULT_COWORK_EGRESS_ALLOWED_HOSTS]),
+    managedMcpServers: JSON.stringify(managedMcpServers),
   };
   await writeFile(configPath, JSON.stringify(merged, null, 2), 'utf-8');
 

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -2,7 +2,12 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { ConfigLoader } from '../../../utils/config.js';
 import { ProviderRegistry } from '../../../providers/index.js';
-import { ConfigurationError } from '../../../utils/errors.js';
+import {
+  ConfigurationError,
+  createErrorContext,
+  formatErrorForUser,
+} from '../../../utils/errors.js';
+import { logger } from '../../../utils/logger.js';
 import {
   checkStatus,
   readState,
@@ -49,12 +54,13 @@ async function resolveDesktopProxyConfig(profileName?: string): Promise<{
     if (explicitProvider?.authType !== 'sso') {
       const available = await listCodeMieProfiles();
       const details = available.length > 0
-        ? `Available CodeMie profiles:\n- ${available.join('\n- ')}`
-        : 'No CodeMie SSO profiles were found. Run: codemie setup';
+        ? `Profiles to try:\n- ${available.join('\n- ')}`
+        : 'No SSO-backed CodeMie profiles were found. Run: codemie setup';
 
       throw new ConfigurationError(
-        `Profile "${profileName}" is not a CodeMie SSO profile.\n` +
-        `Use a CodeMie-backed profile with: codemie proxy connect desktop --profile <name>\n\n` +
+        `Profile "${profileName}" cannot be used for Claude Desktop proxy because it is not SSO-backed.\n\n` +
+        `Next step:\n` +
+        `  codemie proxy connect desktop --profile <name>\n\n` +
         `${details}`
       );
     }
@@ -75,14 +81,19 @@ async function resolveDesktopProxyConfig(profileName?: string): Promise<{
   const available = await listCodeMieProfiles();
   const providerName = activeConfig.provider ?? 'unknown';
   const details = available.length > 0
-    ? `Use: codemie profile switch <codemie-profile>\n` +
-      `Or:  codemie proxy connect desktop --profile <codemie-profile>\n\n` +
-      `Available CodeMie profiles:\n- ${available.join('\n- ')}`
-    : 'Create or switch to a CodeMie SSO profile before using Claude Desktop proxy.';
+    ? `Next step:\n` +
+      `  codemie profile switch <codemie-profile>\n` +
+      `  codemie proxy connect desktop\n\n` +
+      `Or run once with a specific profile:\n` +
+      `  codemie proxy connect desktop --profile <codemie-profile>\n\n` +
+      `Profiles to try:\n- ${available.join('\n- ')}`
+    : `No SSO-backed CodeMie profiles were found.\n\n` +
+      `Next step:\n` +
+      `  codemie setup`;
 
   throw new ConfigurationError(
-    `Claude Desktop proxy requires an SSO-backed CodeMie profile. ` +
-    `Current active profile is "${activeProfileName ?? 'unknown'}" with provider "${providerName}".\n` +
+    `Claude Desktop proxy needs an SSO-backed CodeMie profile.\n` +
+    `Current active profile: "${activeProfileName ?? 'unknown'}" (provider: ${providerName})\n\n` +
     `${details}`
   );
 }
@@ -101,6 +112,19 @@ async function verifySsoCredentials(baseUrl: string, profileName: string): Promi
     console.error(chalk.red(`✗ Failed to verify credentials: ${(err as Error).message}`));
     process.exit(1);
   }
+}
+
+function printProxyError(error: unknown, label: string): never {
+  const context = createErrorContext(error);
+  logger.error(label, error);
+
+  if (error instanceof ConfigurationError) {
+    console.error(chalk.red(`✗ ${error.message}`));
+  } else {
+    console.error(formatErrorForUser(context, { showSystem: false }));
+  }
+
+  process.exit(1);
 }
 
 export function createProxyCommand(): Command {
@@ -193,59 +217,79 @@ export function createProxyCommand(): Command {
     .command('desktop')
     .description('Configure Claude Desktop (3P) to use the local proxy')
     .option('--profile <name>', 'Profile whose credentials to use for Claude Desktop proxy')
+    .option('--verbose', 'Show detailed connection info (URLs, config paths) for debugging')
     .action(async (opts) => {
-      let { running, state } = await checkStatus();
+      const verbose: boolean = Boolean(opts.verbose);
+      try {
+        let { running, state } = await checkStatus();
 
-      if (running && state?.telemetryMode !== 'claude-desktop') {
-        console.log('Proxy is running without Desktop telemetry — restarting in claude-desktop mode...');
-        await stopDaemon();
-        running = false;
-        state = null;
+        if (running && state?.telemetryMode !== 'claude-desktop') {
+          console.log('Restarting proxy in Claude Desktop mode...');
+          await stopDaemon();
+          running = false;
+          state = null;
+        }
+
+        if (!running) {
+          console.log('Starting proxy...');
+          const { config, profileSource } = await resolveDesktopProxyConfig(opts.profile);
+          if (!config.baseUrl) {
+            throw new ConfigurationError('No API URL configured. Run: codemie setup');
+          }
+          const provider = ProviderRegistry.getProvider(config.provider ?? '');
+          if (provider?.authType !== 'sso') {
+            throw new ConfigurationError(
+              `Claude Desktop proxy needs an SSO-backed profile.\n` +
+              `Selected provider: ${config.provider ?? 'unknown'}\n\n` +
+              `Next step:\n` +
+              `  codemie proxy connect desktop --profile <your-ai-run-sso-profile>`
+            );
+          }
+          if (!config.codeMieUrl) {
+            throw new ConfigurationError(
+              'Selected profile is missing CodeMie URL.\n' +
+              'Run: codemie setup or codemie profile login'
+            );
+          }
+          const profileLabel = config.name ?? 'default';
+          if (verbose) {
+            console.log(
+              chalk.cyan(
+                `Using profile: ${profileLabel} ` +
+                `(source: ${profileSource === 'explicit' ? '--profile' : 'active profile'})`
+              )
+            );
+          } else {
+            console.log(chalk.cyan(`Using profile: ${profileLabel}`));
+          }
+          await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
+          state = await spawnDaemon({
+            targetUrl: config.baseUrl,
+            provider: config.provider ?? 'ai-run-sso',
+            profile: config.name ?? 'default',
+            port: DEFAULT_DAEMON_PORT,
+            telemetryMode: 'claude-desktop',
+            syncApiUrl: config.ssoConfig?.apiUrl,
+            syncCodeMieUrl: config.codeMieUrl,
+          });
+          if (verbose) {
+            console.log(chalk.green(`✓ Proxy started at ${state.url}`));
+          } else {
+            console.log(chalk.green('✓ Proxy started'));
+          }
+        }
+
+        const configPath = await writeDesktopConfig(state!.url, state!.gatewayKey);
+        console.log(chalk.green('✓ Claude Desktop configured'));
+        if (verbose) {
+          console.log(`  Config:  ${configPath}`);
+          console.log(`  Gateway: ${state!.url}`);
+          console.log(chalk.dim('  Telemetry: metrics and conversations will sync as claude-desktop.'));
+        }
+        console.log(chalk.yellow('  Restart Claude Desktop to apply changes.'));
+      } catch (error) {
+        printProxyError(error, 'Failed to connect Claude Desktop proxy');
       }
-
-      if (!running) {
-        console.log('Proxy not running — starting it now...');
-        const { config, profileSource } = await resolveDesktopProxyConfig(opts.profile);
-        if (!config.baseUrl) {
-          console.error(chalk.red('✗ No API URL configured. Run: codemie setup'));
-          process.exit(1);
-        }
-        const provider = ProviderRegistry.getProvider(config.provider ?? '');
-        if (provider?.authType !== 'sso') {
-          console.error(chalk.red(`✗ Claude Desktop proxy requires an SSO-backed profile. Selected provider: ${config.provider ?? 'unknown'}`));
-          console.error('  Use: codemie proxy connect desktop --profile <your-ai-run-sso-profile>');
-          process.exit(1);
-        }
-        if (!config.codeMieUrl) {
-          console.error(chalk.red('✗ Selected profile is missing CodeMie URL.'));
-          console.error('  Run: codemie setup or codemie profile login');
-          process.exit(1);
-        }
-        console.log(
-          chalk.cyan(
-            `Using profile: ${config.name ?? 'default'} ` +
-            `(source: ${profileSource === 'explicit' ? '--profile' : 'active profile'})`
-          )
-        );
-        await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
-        state = await spawnDaemon({
-          targetUrl: config.baseUrl,
-          provider: config.provider ?? 'ai-run-sso',
-          profile: config.name ?? 'default',
-          port: DEFAULT_DAEMON_PORT,
-          telemetryMode: 'claude-desktop',
-          syncApiUrl: config.ssoConfig?.apiUrl,
-          syncCodeMieUrl: config.codeMieUrl,
-        });
-        console.log(chalk.green(`✓ Proxy started at ${state.url}`));
-      }
-
-      const configPath = await writeDesktopConfig(state!.url, state!.gatewayKey);
-      console.log(chalk.green('✓ Claude Desktop configured'));
-      console.log(`  Config:  ${configPath}`);
-      console.log(`  Gateway: ${state!.url}`);
-      console.log(chalk.dim('  Telemetry: metrics and conversations will sync as claude-desktop.'));
-      console.log(chalk.yellow('  Restart Claude Desktop to apply changes.'));
     });
 
   const inspect = new Command('inspect');


### PR DESCRIPTION
## Summary

Simplifies the `codemie proxy connect desktop` output for non-technical users by hiding low-level details (localhost URLs, config file paths, telemetry notes) behind a new `--verbose` flag.

## Changes

- **`proxy connect desktop`**: default output now shows only human-friendly status lines; technical details are hidden unless `--verbose` is passed
- **`desktop.ts` / `desktop-managed-mcp-servers.json`**: updated managed MCP servers list and preferred Claude model ordering (sonnet-4-6 first)
- **`desktop.test.ts`**: updated test expectations to match the new model order and the JSON-string storage format for `inferenceModels`

## Impact

**Before:**
```
Proxy not running — starting it now...
Using profile: codemie-prod (source: --profile)
✓ Proxy started at http://127.0.0.1:4001
✓ Claude Desktop configured
  Config:  /Users/.../configLibrary/3a54ebe5....json
  Gateway: http://127.0.0.1:4001
  Telemetry: metrics and conversations will sync as claude-desktop.
  Restart Claude Desktop to apply changes.
```

**After (default):**
```
Starting proxy...
Using profile: codemie-prod
✓ Proxy started
✓ Claude Desktop configured
  Restart Claude Desktop to apply changes.
```

**After (`--verbose`):**
```
Starting proxy...
Using profile: codemie-prod (source: --profile)
✓ Proxy started at http://127.0.0.1:4001
✓ Claude Desktop configured
  Config:  /Users/.../configLibrary/3a54ebe5....json
  Gateway: http://127.0.0.1:4001
  Telemetry: metrics and conversations will sync as claude-desktop.
  Restart Claude Desktop to apply changes.
```

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)