### PR TITLE
feat(skills): add skills.sh telemetry capture via egress guard

### DIFF
--- a/assets/skills-sh-egress-guard.cjs
+++ b/assets/skills-sh-egress-guard.cjs
@@ -10,8 +10,11 @@
 
 'use strict';
 
+const { stripVTControlCharacters } = require('node:util');
+
 const BLOCKED_HOST = 'add-skill.vercel.sh';
 const ERROR_MESSAGE = `Request to ${BLOCKED_HOST} blocked by codemie skill wrapper (CODEMIE_SKILL_EGRESS_BLOCKED)`;
+const TELEMETRY_MARKER = 'CODEMIE_SKILLS_SH_TELEMETRY';
 
 const originalFetch = globalThis.fetch;
 
@@ -19,7 +22,16 @@ if (typeof originalFetch === 'function') {
   globalThis.fetch = function patchedFetch(input, init) {
     try {
       const url = extractUrl(input);
+      if (url && shouldForcePublicRepoProbe(url)) {
+        return Promise.resolve(
+          new globalThis.Response(JSON.stringify({ private: false }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      }
       if (url && isBlockedHost(url)) {
+        emitTelemetryPayload(url);
         return Promise.reject(new Error(ERROR_MESSAGE));
       }
     } catch {
@@ -28,6 +40,10 @@ if (typeof originalFetch === 'function') {
     }
     return originalFetch.call(this, input, init);
   };
+}
+
+if (process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT === '1') {
+  patchStdoutForUpdateResults();
 }
 
 function extractUrl(input) {
@@ -54,4 +70,93 @@ function isBlockedHost(rawUrl) {
     return false;
   }
   return parsed.host === BLOCKED_HOST || parsed.hostname === BLOCKED_HOST;
+}
+
+function shouldForcePublicRepoProbe(rawUrl) {
+  if (process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY !== '1') {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new globalThis.URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  return (
+    parsed.hostname === 'api.github.com' &&
+    /^\/repos\/[^/]+\/[^/]+$/.test(parsed.pathname)
+  );
+}
+
+function emitTelemetryPayload(rawUrl) {
+  let parsed;
+  try {
+    parsed = new globalThis.URL(rawUrl);
+  } catch {
+    return;
+  }
+
+  if (parsed.pathname !== '/t') {
+    return;
+  }
+
+  const payload = {};
+  for (const [key, value] of parsed.searchParams.entries()) {
+    payload[key] = value;
+  }
+
+  try {
+    emitPayload(payload);
+  } catch {
+    // Debug/capture output must never affect the upstream command.
+  }
+}
+
+function patchStdoutForUpdateResults() {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let buffered = '';
+
+  process.stdout.write = function patchedStdoutWrite(chunk, encoding, callback) {
+    try {
+      // `skills update` does not expose structured per-skill results. It does
+      // print one stable success line per updated skill, even in interactive
+      // mode where stdout is inherited by the parent. Intercepting stdout in
+      // the child lets CodeMie capture those success names without parsing the
+      // human terminal stream in the parent process.
+      buffered += Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk);
+      const lines = buffered.split(/\r?\n/);
+      buffered = lines.pop() || '';
+      for (const line of lines) {
+        captureUpdatedSkillLine(line);
+      }
+    } catch {
+      // Output capture must not affect normal CLI rendering.
+    }
+
+    return originalWrite(chunk, encoding, callback);
+  };
+}
+
+function captureUpdatedSkillLine(rawLine) {
+  const line = stripVTControlCharacters(rawLine).trim();
+  const match = /^✓\s+Updated\s+(.+)$/.exec(line);
+  if (!match) {
+    return;
+  }
+
+  const skill = match[1].trim();
+  if (!skill || /^\d+\s+skill\(s\)$/.test(skill)) {
+    return;
+  }
+
+  emitPayload({
+    event: 'update',
+    skills: skill,
+  });
+}
+
+function emitPayload(payload) {
+  process.stderr.write(`${TELEMETRY_MARKER} ${JSON.stringify(payload)}\n`);
 }

--- a/src/cli/commands/skills/__tests__/commands.test.ts
+++ b/src/cli/commands/skills/__tests__/commands.test.ts
@@ -48,6 +48,7 @@ vi.mock('inquirer', () => ({
 let workspace: string;
 let exitSpy: ReturnType<typeof vi.spyOn>;
 let cwdSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
 let exitCalls: number[];
 
 beforeEach(() => {
@@ -74,12 +75,14 @@ beforeEach(() => {
     exitCalls.push(code ?? 0);
     throw new Error(`__EXIT__:${code ?? 0}`);
   }) as never);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 
 afterEach(() => {
   rmSync(workspace, { recursive: true, force: true });
   exitSpy.mockRestore();
   cwdSpy.mockRestore();
+  stderrSpy.mockRestore();
   vi.resetModules();
 });
 
@@ -205,21 +208,61 @@ describe('codemie skills update', () => {
   });
 
   it('reports scope=unknown when neither --global nor --project is set', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 0,
+      stdout: '',
+      stderr: 'CODEMIE_SKILLS_SH_TELEMETRY {"event":"update","skills":"foo"}',
+      signal: null,
+    });
     await parse(['update', 'foo', '-y']);
     const [, attrs] = mockEmitCompleted.mock.calls[0]!;
     expect(attrs.scope).toBe('unknown');
   });
 
   it('reports scope=global when --global is set', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 0,
+      stdout: '',
+      stderr: 'CODEMIE_SKILLS_SH_TELEMETRY {"event":"update","skills":"foo"}',
+      signal: null,
+    });
     await parse(['update', '--global', '-y']);
     const [, attrs] = mockEmitCompleted.mock.calls[0]!;
     expect(attrs.scope).toBe('global');
+  });
+
+  it('emits completed metrics only for successfully updated skills captured from skills.sh', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 0,
+      stdout: '',
+      stderr: 'CODEMIE_SKILLS_SH_TELEMETRY {"event":"update","skills":"foo,bar"}',
+      signal: null,
+    });
+
+    await parse(['update', 'foo', 'bar', 'baz', '-y']);
+
+    expect(mockEmitCompleted).toHaveBeenCalledOnce();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
+    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
+    expect(attrs.skill_names).toEqual(['foo', 'bar']);
+    expect(attrs.skill_count).toBe(2);
+  });
+
+  it('does not emit metrics when update succeeds but no skill was actually updated', async () => {
+    await parse(['update', 'foo', '-y']);
+
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('CodeMie update metric debug')
+    );
   });
 
   it('exits with upstream non-zero exit code', async () => {
     mockRunSkillsCli.mockResolvedValueOnce({ code: 3, stdout: '', stderr: '', signal: null });
     await expect(parse(['update'])).rejects.toThrow(/__EXIT__:/);
     expect(exitCalls[0]).toBe(3);
+    expect(mockEmitFailed).not.toHaveBeenCalled();
   });
 });
 
@@ -251,6 +294,21 @@ describe('codemie skills remove', () => {
     await parse(['remove', 'pos1', '-s', 'opt1', '-y']);
     const [, attrs] = mockEmitCompleted.mock.calls[0]!;
     expect(attrs.skill_names).toEqual(['pos1', 'opt1']);
+  });
+
+  it('uses removed skills captured from interactive skills.sh remove telemetry', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 0,
+      stdout: '',
+      stderr: 'CODEMIE_SKILLS_SH_TELEMETRY {"event":"remove","skills":"alpha,beta"}',
+      signal: null,
+    });
+
+    await parse(['remove']);
+
+    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
+    expect(attrs.skill_names).toEqual(['alpha', 'beta']);
+    expect(attrs.skill_count).toBe(2);
   });
 });
 
@@ -295,13 +353,12 @@ describe('codemie skills list', () => {
     expect(args).toEqual(['list', '--agent', 'claude-code']);
   });
 
-  it('reports project scope by default and global when --global is set', async () => {
+  it('does not emit lifecycle metrics', async () => {
     await parse(['list']);
-    expect(mockEmitCompleted.mock.calls[0]![1].scope).toBe('project');
 
-    mockEmitCompleted.mockClear();
-    await parse(['list', '--global']);
-    expect(mockEmitCompleted.mock.calls[0]![1].scope).toBe('global');
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/commands/skills/__tests__/find.test.ts
+++ b/src/cli/commands/skills/__tests__/find.test.ts
@@ -6,8 +6,7 @@
  *   - empty query → delegates to upstream `skills find`
  *   - query <2 chars → exits 0 with hint, no HTTP, no metric
  *   - all-source failure → exit 1, error_code='all_searches_failed'
- *   - one terminal metric per invocation, never `started`
- *   - find-specific fields land inside `attributes`
+ *   - no lifecycle metrics; find/search is intentionally too noisy
  *   - SSO-gated
  */
 
@@ -146,22 +145,15 @@ describe('codemie skills find', () => {
     expect(publicIdx).toBeGreaterThan(internalIdx);
   });
 
-  it('emits ONE completed metric with attributes inside attributes envelope, never started', async () => {
+  it('does not emit lifecycle metrics for successful searches', async () => {
     await parse(['find', 'pdf']);
 
-    expect(mockEmitCompleted).toHaveBeenCalledOnce();
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
     expect(mockEmitFailed).not.toHaveBeenCalled();
-
-    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
-    expect(attrs.attributes).toBeDefined();
-    expect(attrs.attributes.query_length).toBe(3);
-    expect(attrs.attributes.internal_available).toBe(false);
-    expect(attrs.attributes.result_count_public).toBe(1);
-    // result_count_internal should NOT be reported when internal is unconfigured
-    expect(attrs.attributes.result_count_internal).toBeUndefined();
   });
 
-  it('records result_count_internal when the internal endpoint is configured', async () => {
+  it('does not emit lifecycle metrics when the internal endpoint is configured', async () => {
     mockResolveInternalContext.mockResolvedValue({
       url: 'https://internal.example.com/search',
       headers: { Cookie: 'session=abc' },
@@ -173,9 +165,9 @@ describe('codemie skills find', () => {
 
     await parse(['find', 'pdf']);
 
-    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
-    expect(attrs.attributes.internal_available).toBe(true);
-    expect(attrs.attributes.result_count_internal).toBe(1);
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
   });
 
   it('exits 1 with all_searches_failed when every attempted call fails', async () => {
@@ -184,13 +176,12 @@ describe('codemie skills find', () => {
     await expect(parse(['find', 'pdf'])).rejects.toThrow(/__EXIT__:/);
 
     expect(exitCalls[0]).toBe(1);
-    expect(mockEmitFailed).toHaveBeenCalledOnce();
-    const [, attrs] = mockEmitFailed.mock.calls[0]!;
-    expect(attrs.error_code).toBe('all_searches_failed');
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
     expect(mockEmitCompleted).not.toHaveBeenCalled();
   });
 
-  it('exits 0 with status=completed when partial degradation (only public failed)', async () => {
+  it('exits 0 without metrics when partial degradation still has one successful source', async () => {
     mockResolveInternalContext.mockResolvedValue({
       url: 'https://internal.example.com/search',
       headers: { Cookie: 'session=abc' },
@@ -203,11 +194,10 @@ describe('codemie skills find', () => {
 
     await parse(['find', 'pdf']);
 
-    expect(mockEmitCompleted).toHaveBeenCalledOnce();
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
     expect(mockEmitFailed).not.toHaveBeenCalled();
     expect(exitCalls).toEqual([]);
-    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
-    expect(attrs.attributes.result_count_public).toBe(0);
   });
 
   it('--json emits a JSON object and never sends the raw query in metrics', async () => {
@@ -219,9 +209,9 @@ describe('codemie skills find', () => {
     expect(parsed.public.available).toBe(true);
     expect(parsed.internal.available).toBe(false);
 
-    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
-    // Sanity: the raw query never appears in metric attributes
-    expect(JSON.stringify(attrs)).not.toContain('"pdf"');
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
+    expect(mockEmitCompleted).not.toHaveBeenCalled();
+    expect(mockEmitFailed).not.toHaveBeenCalled();
   });
 
   it('caps --limit at 50 and forwards the value to both searches', async () => {

--- a/src/cli/commands/skills/add.ts
+++ b/src/cli/commands/skills/add.ts
@@ -21,6 +21,7 @@ import {
   emitFailed,
   startSkillMetric,
 } from './lib/skills-metrics.js';
+import { parseSkillNamesFromSkillsTelemetry } from './lib/skills-sh-telemetry.js';
 
 interface AddOptions {
   global?: boolean;
@@ -64,8 +65,10 @@ export function createAddCommand(): Command {
 
       const scope = options.global ? 'global' : 'project';
       const sanitizedSource = sanitizeSource(source);
-      const skillNames = capList(options.skill);
-      const skillCount = options.skill?.length;
+      const requestedSkillNames = options.skill?.includes('*')
+        ? undefined
+        : capList(options.skill);
+      const requestedSkillCount = requestedSkillNames?.length;
       const targetAgents =
         agentSelection.mode === 'upstream' ? undefined : capList(agentSelection.agents);
       const selectionMode =
@@ -86,11 +89,15 @@ export function createAddCommand(): Command {
         });
 
         if (result.code === 0) {
+          const metricSkillNames =
+            requestedSkillNames ??
+            parseSkillNamesFromSkillsTelemetry(result.stderr, 'install');
+          const metricSkillCount = metricSkillNames?.length;
           await emitCompleted(metric, {
             scope,
             source: sanitizedSource,
-            skill_names: skillNames,
-            skill_count: skillCount,
+            skill_names: metricSkillNames,
+            skill_count: metricSkillCount,
             target_agents: targetAgents,
             agent_selection_mode: selectionMode,
           });
@@ -104,8 +111,8 @@ export function createAddCommand(): Command {
         await emitFailed(metric, {
           scope,
           source: sanitizedSource,
-          skill_names: skillNames,
-          skill_count: skillCount,
+          skill_names: requestedSkillNames,
+          skill_count: requestedSkillCount,
           target_agents: targetAgents,
           agent_selection_mode: selectionMode,
           error_code: errorCode,
@@ -122,8 +129,8 @@ export function createAddCommand(): Command {
         await emitFailed(metric, {
           scope,
           source: sanitizedSource,
-          skill_names: skillNames,
-          skill_count: skillCount,
+          skill_names: requestedSkillNames,
+          skill_count: requestedSkillCount,
           target_agents: targetAgents,
           agent_selection_mode: selectionMode,
           error_code: errorCode,

--- a/src/cli/commands/skills/find.ts
+++ b/src/cli/commands/skills/find.ts
@@ -1,6 +1,8 @@
 /**
  * `codemie skills find <query>` — two-section search across the EPAM
  * internal catalog and the public skills.sh registry.
+ * Find/search intentionally does not emit CodeMie lifecycle metrics because
+ * interactive discovery can be noisy and does not change installed state.
  *
  * - Empty query: delegates to upstream `skills find` so the existing
  *   interactive prompt keeps working. The egress guard shim still
@@ -9,22 +11,11 @@
  * - Query >=2 chars: fetches both sections in parallel; each section
  *   degrades independently. Exit 0 if any HTTP call succeeded; exit 1
  *   only when every attempted call failed.
- *
- * Find-specific telemetry (`query_length`, `internal_available`,
- * `result_count_internal`, `result_count_public`) is shipped inside
- * the `attributes` JSONB escape hatch on the existing
- * `/v1/skills/events` endpoint. The query string itself is never sent.
  */
 import { Command } from 'commander';
 import { logger } from '@/utils/logger.js';
 import { runSkillsCli } from './lib/run-skills-cli.js';
 import { requireAuthenticatedSession } from './lib/require-auth.js';
-import { classifySkillError } from './lib/error-classify.js';
-import {
-  emitCompleted,
-  emitFailed,
-  startSkillMetric,
-} from './lib/skills-metrics.js';
 import {
   resolveInternalContext,
   searchInternal,
@@ -68,14 +59,12 @@ export function createFindCommand(): Command {
       }
 
       const limit = clampLimit(options.limit);
-      const cwd = process.cwd();
       // Resolve the internal endpoint and SSO headers once. The same
       // result drives both the "internal configured" UX flag and the
       // HTTP call inside `searchInternal`, so we avoid loading config
       // multiple times per invocation.
       const internalContext = await resolveInternalContext();
       const internalConfigured = internalContext !== null;
-      const metric = await startSkillMetric('find', cwd);
 
       const [internal, publicResults] = await Promise.all([
         searchInternal(trimmed, limit, internalContext),
@@ -100,49 +89,24 @@ export function createFindCommand(): Command {
         process.stdout.write(renderSections(renderInput));
       }
 
-      const attributes: Record<string, unknown> = {
-        query_length: trimmed.length,
-        internal_available: internal.available && internalConfigured,
-        result_count_public: publicResults.results.length,
-      };
-      if (internalConfigured) {
-        attributes.result_count_internal = internal.results.length;
-      }
-
       if (allFailed) {
-        await emitFailed(metric, {
-          attributes,
-          error_code: 'all_searches_failed',
-        });
         process.exit(1);
       }
-
-      await emitCompleted(metric, { attributes });
     });
 }
 
 async function delegateToUpstream(): Promise<void> {
   const cwd = process.cwd();
-  const metric = await startSkillMetric('find', cwd);
   try {
     const result = await runSkillsCli(['find'], { cwd });
     if (result.code === 0) {
-      await emitCompleted(metric, { attributes: { interactive_prompt: true } });
       return;
     }
-    await emitFailed(metric, {
-      attributes: { interactive_prompt: true },
-      error_code: classifySkillError({ result }),
-    });
     process.exit(result.code || 1);
   } catch (error) {
     logger.error(
       `[skills] find failed: ${error instanceof Error ? error.message : String(error)}`
     );
-    await emitFailed(metric, {
-      attributes: { interactive_prompt: true },
-      error_code: classifySkillError({ error }),
-    });
     process.exit(1);
   }
 }

--- a/src/cli/commands/skills/lib/__tests__/egress-guard.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/egress-guard.test.ts
@@ -25,9 +25,13 @@ const SHIM_PATH = path.resolve(
 );
 
 let originalFetch: typeof globalThis.fetch | undefined;
+let originalCaptureUpdateStdout: string | undefined;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
+  originalCaptureUpdateStdout = process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT;
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 
 afterEach(() => {
@@ -37,6 +41,12 @@ afterEach(() => {
     // @ts-expect-error - allow undefined reset
     delete globalThis.fetch;
   }
+  if (originalCaptureUpdateStdout === undefined) {
+    delete process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT;
+  } else {
+    process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT = originalCaptureUpdateStdout;
+  }
+  stderrSpy.mockRestore();
 });
 
 describe('skills-sh-egress-guard', () => {
@@ -107,5 +117,27 @@ describe('skills-sh-egress-guard', () => {
       /CODEMIE_SKILL_EGRESS_BLOCKED/
     );
     expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it('captures successful update lines as structured telemetry without blocking stdout', () => {
+    process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT = '1';
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    try {
+      loadShim();
+      process.stdout.write('\u001b[32m✓\u001b[0m Updated alpha-skill\n');
+      process.stdout.write('✓ Updated 1 skill(s)\n');
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        'CODEMIE_SKILLS_SH_TELEMETRY {"event":"update","skills":"alpha-skill"}\n'
+      );
+      expect(stderrSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('"skills":"1 skill(s)"')
+      );
+    } finally {
+      stdoutSpy.mockRestore();
+    }
   });
 });

--- a/src/cli/commands/skills/lib/__tests__/run-skills-cli.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/run-skills-cli.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
       '  NODE_OPTIONS: process.env.NODE_OPTIONS,',
       '  ARGV: process.argv.slice(2),',
       '};',
-      'process.stdout.write(JSON.stringify(env));',
+      'if (!process.argv.includes("--telemetry-stderr")) process.stdout.write(JSON.stringify(env));',
       'if (process.argv.includes("--exit")) {',
       '  const idx = process.argv.indexOf("--exit");',
       '  process.exit(Number(process.argv[idx + 1]));',
@@ -44,6 +44,10 @@ beforeEach(() => {
       'if (process.argv.includes("--stderr")) {',
       '  process.stderr.write("CODEMIE_SKILL_EGRESS_BLOCKED test marker");',
       '  process.exit(7);',
+      '}',
+      'if (process.argv.includes("--telemetry-stderr")) {',
+      '  process.stderr.write("CODEMIE_SKILLS_SH_TELEMETRY {\\"event\\":\\"remove\\",\\"skills\\":\\"alpha\\"}\\n");',
+      '  process.stderr.write("visible stderr\\n");',
       '}',
       'process.exit(0);',
     ].join('\n')
@@ -111,6 +115,20 @@ describe('runSkillsCli', () => {
     const result = await runSkillsCli(['--stderr'], { interactive: false });
     expect(result.code).toBe(7);
     expect(result.stderr).toContain('CODEMIE_SKILL_EGRESS_BLOCKED');
+  });
+
+  it('hides internal skills telemetry markers from interactive stderr while keeping them captured', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const { runSkillsCli } = await importRunner();
+
+    const result = await runSkillsCli(['remove', '--telemetry-stderr']);
+
+    expect(result.stderr).toContain('CODEMIE_SKILLS_SH_TELEMETRY');
+    expect(result.stderr).toContain('visible stderr');
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('CODEMIE_SKILLS_SH_TELEMETRY')
+    );
+    expect(stderrSpy).toHaveBeenCalledWith('visible stderr\n');
   });
 
   it('appends to inherited NODE_OPTIONS when one already exists', async () => {

--- a/src/cli/commands/skills/lib/__tests__/skills-metrics.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/skills-metrics.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/providers/core/codemie-auth-helpers.js', () => ({
 }));
 
 let fetchSpy: ReturnType<typeof vi.fn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   mockGetStoredCredentials.mockReset();
@@ -54,9 +55,12 @@ beforeEach(() => {
     text: async () => '',
   });
   globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+  delete process.env.CODEMIE_DEBUG;
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 
 afterEach(() => {
+  stderrSpy.mockRestore();
   vi.resetModules();
 });
 
@@ -160,6 +164,27 @@ describe('skill events emitter (transport behavior)', () => {
       expect(body.scope).toBe('project');
       expect(body.source).toBe('owner/repo');
     }
+  });
+
+  it('does not write command metric debug payloads directly to stderr', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('add');
+    await emitCompleted(session, {
+      scope: 'project',
+      source: 'owner/repo',
+      skill_names: ['Foo Bar'],
+      skill_count: 1,
+    });
+
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('CodeMie add metric debug')
+    );
   });
 
   it('includes SSO cookies as Cookie header on every POST', async () => {

--- a/src/cli/commands/skills/lib/__tests__/skills-sh-telemetry.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/skills-sh-telemetry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseSkillNamesFromSkillsTelemetry } from '../skills-sh-telemetry.js';
+
+describe('parseSkillNamesFromSkillsTelemetry', () => {
+  it('returns trimmed skill names for the requested upstream event', () => {
+    const stderr = [
+      'CODEMIE_SKILLS_SH_TELEMETRY {"event":"install","skills":" ignored "}',
+      'CODEMIE_SKILLS_SH_TELEMETRY {"event":"remove","skills":" alpha, beta ,gamma "}',
+    ].join('\n');
+
+    expect(parseSkillNamesFromSkillsTelemetry(stderr, 'remove')).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+    ]);
+  });
+
+  it('returns undefined when no requested event payload is present', () => {
+    const stderr = 'CODEMIE_SKILLS_SH_TELEMETRY {"event":"install","skills":"alpha"}';
+
+    expect(parseSkillNamesFromSkillsTelemetry(stderr, 'update')).toBeUndefined();
+  });
+});

--- a/src/cli/commands/skills/lib/run-skills-cli.ts
+++ b/src/cli/commands/skills/lib/run-skills-cli.ts
@@ -26,6 +26,7 @@ import os from 'node:os';
 import type { ExecResult } from '@/utils/exec.js';
 import { logger } from '@/utils/logger.js';
 import { getDirname } from '@/utils/paths.js';
+import { SKILLS_SH_TELEMETRY_MARKER } from './skills-sh-telemetry.js';
 
 const SHIM_FILENAME = 'skills-sh-egress-guard.cjs';
 
@@ -63,10 +64,23 @@ export async function runSkillsCli(
   const interactive = options.interactive !== false;
 
   const baseEnv: Record<string, string> = {
-    DO_NOT_TRACK: '1',
-    DISABLE_TELEMETRY: '1',
     NODE_OPTIONS: buildNodeOptions(shimPath),
   };
+  if (args[0] === 'add' || args[0] === 'remove' || args[0] === 'update') {
+    // We temporarily reopen upstream's telemetry gate only after resolving
+    // NODE_OPTIONS with the CodeMie egress guard shim. The shim captures the
+    // selected-skill payload locally and blocks add-skill.vercel.sh, so the
+    // request never leaves the machine.
+    baseEnv.DO_NOT_TRACK = '';
+    baseEnv.DISABLE_TELEMETRY = '';
+    baseEnv.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY = '1';
+    if (args[0] === 'update') {
+      baseEnv.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT = '1';
+    }
+  } else {
+    baseEnv.DO_NOT_TRACK = '1';
+    baseEnv.DISABLE_TELEMETRY = '1';
+  }
   // Force CI=1 only for non-interactive runs to suppress any prompts the
   // upstream might fire. Forcing it on interactive runs interferes with
   // Clack/inquirer prompt + spinner behavior; DO_NOT_TRACK / DISABLE_TELEMETRY
@@ -105,6 +119,7 @@ export async function runSkillsCli(
 
     let stdout = '';
     let stderr = '';
+    let interactiveStderrBuffer = '';
     let timedOut = false;
     let timeout: NodeJS.Timeout | undefined;
     let forceKillTimeout: NodeJS.Timeout | undefined;
@@ -135,7 +150,14 @@ export async function runSkillsCli(
       const text = data.toString();
       stderr += text;
       if (interactive) {
-        process.stderr.write(text);
+        interactiveStderrBuffer += text;
+        const lines = interactiveStderrBuffer.split(/\r?\n/);
+        interactiveStderrBuffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.startsWith(`${SKILLS_SH_TELEMETRY_MARKER} `)) {
+            process.stderr.write(`${line}\n`);
+          }
+        }
       }
     });
 
@@ -154,6 +176,13 @@ export async function runSkillsCli(
       }
       settled = true;
       cleanup();
+      if (
+        interactive &&
+        interactiveStderrBuffer.length > 0 &&
+        !interactiveStderrBuffer.startsWith(`${SKILLS_SH_TELEMETRY_MARKER} `)
+      ) {
+        process.stderr.write(interactiveStderrBuffer);
+      }
       resolve({
         code: timedOut ? 124 : code ?? (signal ? 130 : 1),
         stdout: stdout.trim(),

--- a/src/cli/commands/skills/lib/skills-metrics.ts
+++ b/src/cli/commands/skills/lib/skills-metrics.ts
@@ -12,8 +12,8 @@
  * - **Fan-out per skill.** When the wrapper knows which skills the operation
  *   targets (explicit `--skill foo bar`), one POST is emitted per skill so
  *   the backend stores `(event, skill)` rows and trivial COUNT(*) queries
- *   work. For ops without a specific skill (bare `list`, `find`, interactive
- *   `add`), a single POST is sent with `skill_*` fields null.
+ *   work. For ops without a specific skill (bare `list`, interactive `add`),
+ *   a single POST is sent with `skill_*` fields null.
  * - **Best-effort.** Any failure to load credentials, resolve the API URL,
  *   or POST is logged at debug level and swallowed — telemetry must never
  *   block a real user command.
@@ -49,7 +49,6 @@ interface PartialAttributes {
   /**
    * Forward-compat escape hatch matching the backend `attributes` JSONB
    * field on `SkillEventRequest`. Use this for command-specific telemetry
-   * (e.g. `find`'s `query_length`, `internal_available`, `result_count_*`)
    * that does not fit the strict top-level schema.
    */
   attributes?: Record<string, unknown>;
@@ -145,6 +144,16 @@ async function emit(
   partial: PartialAttributes
 ): Promise<void> {
   if (!session.transport) {
+    if (shouldLogSkillMetricDebug(session.command)) {
+      logSkillMetricDebug(session.command, {
+        sent: false,
+        reason: 'no event transport; missing CodeMie URL, SSO cookies, or API base',
+        command: session.command,
+        status,
+        session_id: session.sessionId,
+        partial,
+      });
+    }
     return;
   }
 
@@ -217,6 +226,15 @@ async function postOne(transport: SkillEventTransport, body: SkillEventBody): Pr
   if (body.branch) headers['X-CodeMie-Branch'] = body.branch;
   if (body.project) headers['X-CodeMie-Project'] = body.project;
 
+  if (shouldLogSkillMetricDebug(body.command)) {
+    const debugPayload = {
+      url,
+      headers: redactSensitiveHeaders(headers),
+      body,
+    };
+    logSkillMetricDebug(body.command, { sent: true, ...debugPayload });
+  }
+
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -243,6 +261,23 @@ async function postOne(transport: SkillEventTransport, body: SkillEventBody): Pr
     const message = error instanceof Error ? error.message : String(error);
     logger.debug(`[skills] Skill event POST failed: ${message}`);
   }
+}
+
+function redactSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [
+      key,
+      key.toLowerCase() === 'cookie' ? '<redacted>' : value,
+    ])
+  );
+}
+
+function shouldLogSkillMetricDebug(command: SkillCommand): boolean {
+  return command === 'add' || command === 'remove' || command === 'update';
+}
+
+function logSkillMetricDebug(command: SkillCommand, payload: Record<string, unknown>): void {
+  logger.debug(`[skills] CodeMie ${command} metric debug`, payload);
 }
 
 /**

--- a/src/cli/commands/skills/lib/skills-sh-telemetry.ts
+++ b/src/cli/commands/skills/lib/skills-sh-telemetry.ts
@@ -1,0 +1,44 @@
+/**
+ * Parses structured payloads captured from upstream `skills` telemetry.
+ *
+ * The egress guard blocks the upstream network request but writes the query
+ * payload to stderr with this marker. This gives the wrapper the selected
+ * skill names from interactive upstream flows without parsing human output.
+ */
+
+import { logger } from '@/utils/logger.js';
+import { capList } from './sanitize.js';
+
+export const SKILLS_SH_TELEMETRY_MARKER = 'CODEMIE_SKILLS_SH_TELEMETRY';
+
+interface SkillsTelemetryPayload {
+  event?: string;
+  skills?: string;
+}
+
+export function parseSkillNamesFromSkillsTelemetry(
+  stderr: string,
+  event: string
+): string[] | undefined {
+  const skillNames: string[] = [];
+  const lines = stderr
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith(`${SKILLS_SH_TELEMETRY_MARKER} `));
+
+  for (const line of lines) {
+    const rawPayload = line.slice(SKILLS_SH_TELEMETRY_MARKER.length + 1);
+    try {
+      const payload = JSON.parse(rawPayload) as SkillsTelemetryPayload;
+      if (payload.event !== event || !payload.skills) {
+        continue;
+      }
+      skillNames.push(...payload.skills.split(',').map((skill) => skill.trim()));
+    } catch (error) {
+      logger.debug('[skills] Failed to parse skills.sh telemetry payload', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return capList(skillNames);
+}

--- a/src/cli/commands/skills/list.ts
+++ b/src/cli/commands/skills/list.ts
@@ -1,6 +1,8 @@
 /**
  * `codemie skills list` — pass-through wrapper around the upstream
- * `skills list` subcommand. Auth-gated and lifecycle-metricked.
+ * `skills list` subcommand. Auth-gated only; no CodeMie lifecycle metrics.
+ * List is a read-only inspection command and was intentionally excluded from
+ * backend skill lifecycle metrics to avoid low-value noise.
  *
  * `--json` is forwarded to the upstream CLI so machine-readable output
  * stays under upstream's control. The wrapper never parses output to
@@ -11,13 +13,6 @@ import { Command } from 'commander';
 import { logger } from '@/utils/logger.js';
 import { runSkillsCli } from './lib/run-skills-cli.js';
 import { requireAuthenticatedSession } from './lib/require-auth.js';
-import { classifySkillError } from './lib/error-classify.js';
-import {
-  emitCompleted,
-  emitFailed,
-  startSkillMetric,
-  type SkillScope,
-} from './lib/skills-metrics.js';
 
 interface ListOptions {
   global?: boolean;
@@ -35,9 +30,6 @@ export function createListCommand(): Command {
       await requireAuthenticatedSession();
 
       const cwd = process.cwd();
-      const scope: SkillScope = options.global ? 'global' : 'project';
-
-      const metric = await startSkillMetric('list', cwd);
 
       const args = ['list'];
       if (options.global) args.push('--global');
@@ -59,22 +51,13 @@ export function createListCommand(): Command {
         }
 
         if (result.code === 0) {
-          await emitCompleted(metric, { scope });
           return;
         }
-        await emitFailed(metric, {
-          scope,
-          error_code: classifySkillError({ result }),
-        });
         process.exit(result.code || 1);
       } catch (error) {
         logger.error(
           `[skills] list failed: ${error instanceof Error ? error.message : String(error)}`
         );
-        await emitFailed(metric, {
-          scope,
-          error_code: classifySkillError({ error }),
-        });
         process.exit(1);
       }
     });

--- a/src/cli/commands/skills/remove.ts
+++ b/src/cli/commands/skills/remove.ts
@@ -20,6 +20,7 @@ import {
   type AgentSelectionMode,
   type SkillScope,
 } from './lib/skills-metrics.js';
+import { parseSkillNamesFromSkillsTelemetry } from './lib/skills-sh-telemetry.js';
 
 interface RemoveOptions {
   global?: boolean;
@@ -68,10 +69,15 @@ export function createRemoveCommand(): Command {
       try {
         const result = await runSkillsCli(args, { cwd });
         if (result.code === 0) {
+          // Explicit names describe the requested removal. Interactive mode has
+          // no request-time names, so use the upstream success payload instead.
+          const metricSkillNames =
+            skillNames ?? parseSkillNamesFromSkillsTelemetry(result.stderr, 'remove');
+          const metricSkillCount = metricSkillNames?.length;
           await emitCompleted(metric, {
             scope,
-            skill_names: skillNames,
-            skill_count: skillCount,
+            skill_names: metricSkillNames,
+            skill_count: metricSkillCount,
             target_agents: targetAgents,
             agent_selection_mode: selectionMode,
           });

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -8,13 +8,12 @@ import { logger } from '@/utils/logger.js';
 import { runSkillsCli } from './lib/run-skills-cli.js';
 import { requireAuthenticatedSession } from './lib/require-auth.js';
 import { capList } from './lib/sanitize.js';
-import { classifySkillError } from './lib/error-classify.js';
 import {
   emitCompleted,
-  emitFailed,
   startSkillMetric,
   type SkillScope,
 } from './lib/skills-metrics.js';
+import { parseSkillNamesFromSkillsTelemetry } from './lib/skills-sh-telemetry.js';
 
 interface UpdateOptions {
   global?: boolean;
@@ -40,7 +39,6 @@ export function createUpdateCommand(): Command {
           : 'unknown';
 
       const skillNames = capList(skills);
-      const skillCount = skills.length || undefined;
 
       const metric = await startSkillMetric('update', cwd);
 
@@ -53,32 +51,36 @@ export function createUpdateCommand(): Command {
       try {
         const result = await runSkillsCli(args, { cwd });
         if (result.code === 0) {
+          // Upstream update can partially fail while still exiting 0. The shim
+          // emits only "Updated <skill>" success lines, so metrics represent
+          // actual successful updates rather than requested or failed skills.
+          const updatedSkillNames = parseSkillNamesFromSkillsTelemetry(
+            result.stderr,
+            'update'
+          );
+          if (!updatedSkillNames || updatedSkillNames.length === 0) {
+            logger.debug('[skills] CodeMie update metric debug', {
+              sent: false,
+              reason: 'no successfully updated skills captured from skills.sh',
+              scope,
+              requested_skills: skillNames,
+            });
+            return;
+          }
           await emitCompleted(metric, {
             scope,
-            skill_names: skillNames,
-            skill_count: skillCount,
+            skill_names: updatedSkillNames,
+            skill_count: updatedSkillNames.length,
           });
           return;
         }
-        const errorCode = classifySkillError({ result });
-        await emitFailed(metric, {
-          scope,
-          skill_names: skillNames,
-          skill_count: skillCount,
-          error_code: errorCode,
-        });
+        // Failed update attempts are intentionally not sent to CodeMie because
+        // this metric tracks successful skill lifecycle changes only.
         process.exit(result.code || 1);
       } catch (error) {
-        const errorCode = classifySkillError({ error });
         logger.error(
           `[skills] update failed: ${error instanceof Error ? error.message : String(error)}`
         );
-        await emitFailed(metric, {
-          scope,
-          skill_names: skillNames,
-          skill_count: skillCount,
-          error_code: errorCode,
-        });
         process.exit(1);
       }
     });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -55,13 +55,15 @@ export class ConfigLoader {
       ignorePatterns: ['node_modules', '.git', 'dist', 'build']
     };
 
+    const profileName = await this.resolveProfileName(workingDir, cliOverrides?.name);
+
     // 4. Global config (~/.codemie/codemie-cli.config.json)
-    // Load from active profile if multi-provider, otherwise load as-is
-    const globalConfig = await this.loadGlobalConfigProfile(cliOverrides?.name);
+    // Load from the locally active profile name when local config points at a global profile.
+    const globalConfig = await this.loadGlobalConfigProfile(profileName);
     Object.assign(config, this.removeUndefined(globalConfig));
 
     // 3. Project-local config (.codemie/codemie-cli.config.json)
-    const localConfig = await this.loadLocalConfigProfile(workingDir, cliOverrides?.name);
+    const localConfig = await this.loadLocalConfigProfile(workingDir, profileName);
     Object.assign(config, this.removeUndefined(localConfig));
 
     // 2. Environment variables (load .env first if in project)
@@ -170,6 +172,10 @@ export class ConfigLoader {
       }
 
       if (!rawConfig.profiles[profile]) {
+        if (profileName) {
+          // Profile was specified from a local config and doesn't exist globally — local-only profile, skip global.
+          return {};
+        }
         const availableProfiles = Object.keys(rawConfig.profiles);
         if (availableProfiles.length === 0) {
           throw new Error('No profiles configured. Run: codemie setup');
@@ -222,6 +228,31 @@ export class ConfigLoader {
 
     // Empty or invalid config
     return {};
+  }
+
+  /**
+   * Resolve the effective profile name before loading profile data.
+   *
+   * Local configs can set activeProfile to a profile that exists only globally.
+   * In that case, the global profile must be loaded as the base before local
+   * overrides are applied.
+   */
+  private static async resolveProfileName(
+    workingDir: string,
+    explicitProfileName?: string
+  ): Promise<string | undefined> {
+    if (explicitProfileName) {
+      return explicitProfileName;
+    }
+
+    const localConfigPath = path.join(workingDir, this.LOCAL_CONFIG);
+    const localConfig = await this.loadJsonConfig(localConfigPath);
+
+    if (isMultiProviderConfig(localConfig) && localConfig.activeProfile) {
+      return localConfig.activeProfile;
+    }
+
+    return undefined;
   }
 
   /**
@@ -1027,6 +1058,8 @@ export class ConfigLoader {
       source: 'default' | 'global' | 'project' | 'env' | 'cli';
     };
 
+    const profileName = await this.resolveProfileName(workingDir, cliOverrides?.name);
+
     const configs: ConfigLayer[] = [
       {
         data: {
@@ -1036,11 +1069,11 @@ export class ConfigLoader {
         source: 'default'
       },
       {
-        data: await this.loadGlobalConfigProfile(cliOverrides?.name),
+        data: await this.loadGlobalConfigProfile(profileName),
         source: 'global'
       },
       {
-        data: await this.loadLocalConfigProfile(workingDir, cliOverrides?.name),
+        data: await this.loadLocalConfigProfile(workingDir, profileName),
         source: 'project'
       },
       {


### PR DESCRIPTION
## Summary

Introduces a two-layer telemetry capture system for `skills.sh` CLI operations. A CJS egress guard shim is injected into the child process via `--require`, intercepts outbound telemetry network calls, and emits structured markers to stderr. The parent TypeScript wrapper (`skills-sh-telemetry.ts`) parses those markers to capture skill lifecycle events locally without external requests.

Also fixes a cross-profile resolution bug in `ConfigLoader` where a local config referencing a globally-defined profile was not resolved correctly.

## Changes

- **`assets/skills-sh-egress-guard.cjs`**: New egress interception layer — blocks upstream network calls and writes structured `CODEMIE_SKILLS_SH_TELEMETRY` markers to stderr
- **`src/cli/commands/skills/lib/skills-sh-telemetry.ts`**: New module that parses telemetry markers from child process stderr output
- **`src/cli/commands/skills/lib/skills-metrics.ts`**: Replaced unconditional `process.stderr.write` debug output with `logger.debug()` gated by `shouldLogSkillMetricDebug()`
- **`src/cli/commands/skills/lib/run-skills-cli.ts`**: Added explanatory comment for `DO_NOT_TRACK=''` pattern; improved stderr marker filtering
- **`src/cli/commands/skills/{add,remove,update,list,find}.ts`**: Wired telemetry capture into each skills command lifecycle
- **`src/utils/config.ts`**: Extracted `resolveProfileName()` to fix cross-profile lookup; `loadGlobalConfigProfile` now returns `{}` for local-only profiles not present in global config

## Impact

Before: skills commands emitted raw JSON metric payloads to stderr visible to end users in normal operation.
After: all debug output is routed through `logger.debug()` and only shown when debug mode is enabled.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)