### PR TITLE
fix(skills): HTTPS source normalization, egress guard, and metric lifecycle fixes

### DIFF
--- a/assets/skills-sh-egress-guard.cjs
+++ b/assets/skills-sh-egress-guard.cjs
@@ -23,6 +23,10 @@ if (typeof originalFetch === 'function') {
     try {
       const url = extractUrl(input);
       if (url && shouldForcePublicRepoProbe(url)) {
+        // Upstream sends selected skill names only for repos it classifies as
+        // public. CodeMie captures that payload locally and blocks the outbound
+        // telemetry request below, so force the probe public without leaking the
+        // repo visibility decision to add-skill.vercel.sh.
         return Promise.resolve(
           new globalThis.Response(JSON.stringify({ private: false }), {
             status: 200,

--- a/src/cli/commands/skills/__tests__/commands.test.ts
+++ b/src/cli/commands/skills/__tests__/commands.test.ts
@@ -179,6 +179,119 @@ describe('codemie skills add', () => {
     expect(attrs.error_code).toBe('egress_blocked');
   });
 
+  it('normalizes HTTPS repository-like sources with .git before spawning upstream', async () => {
+    const source = 'https://gitbud.example.com/group/repo';
+    await parse(['add', source, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
+
+    expect(mockEmitCompleted).toHaveBeenCalledOnce();
+    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
+    expect(attrs.source).toBe(source);
+    expect(mockEmitFailed).not.toHaveBeenCalled();
+  });
+
+  it('does not append .git to HTTPS sources that already end with .git', async () => {
+    const source = 'https://gitbud.example.com/group/repo.git';
+    await parse(['add', source, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
+  });
+
+  it('does not append .git to well-known HTTPS endpoint URLs', async () => {
+    const source = 'https://gitbud.example.com/.well-known/agent-skills/index.json';
+    await parse(['add', source, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
+  });
+
+  it('does not append .git to HTTPS sources with query strings or fragments', async () => {
+    const querySource = 'https://gitbud.example.com/group/repo?ref=main';
+    await parse(['add', querySource, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', querySource, '--yes']);
+
+    mockRunSkillsCli.mockClear();
+    mockEmitCompleted.mockClear();
+
+    const fragmentSource = 'https://gitbud.example.com/group/repo#main';
+    await parse(['add', fragmentSource, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', fragmentSource, '--yes']);
+  });
+
+  it('does not retry ambiguous HTTPS sources with .git for unrelated upstream failures', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 7,
+      stdout: '',
+      stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
+      signal: null,
+    });
+
+    await expect(parse(['add', 'https://gitbud.example.com/group/repo', '-y'])).rejects.toThrow(
+      /__EXIT__:/
+    );
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(exitCalls[0]).toBe(7);
+  });
+
+  it('does not show Git access help for egress-blocked normalized HTTPS sources', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 7,
+      stdout: '',
+      stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
+      signal: null,
+    });
+
+    const source = 'https://gitbud.example.com/group/repo';
+    await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('CodeMie cannot read this Git repository yet')
+    );
+    expect(exitCalls[0]).toBe(7);
+  });
+
+  it('does not append .git to http sources', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 0,
+      stdout: '',
+      stderr: '',
+      signal: null,
+    });
+
+    const source = 'http://gitbud.example.com/group/repo';
+    await parse(['add', source, '-y']);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
+  });
+
+  it('shows Git access help for failed normalized HTTPS repository-like sources', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 1,
+      stdout: '',
+      stderr: 'git clone failed: unable to access repository',
+      signal: null,
+    });
+    const source = 'https://gitbud.example.com/group/repo';
+    await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
+
+    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('The repository clone failed.'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`git ls-remote ${source}`));
+    expect(exitCalls[0]).toBe(1);
+  });
+
   it('forwards --skill list to upstream args (spec §8.3 fan-out source)', async () => {
     await parse(['add', 'owner/repo', '--skill', 'a', 'b', 'c', '-y']);
     const [args] = mockRunSkillsCli.mock.calls[0]!;
@@ -262,6 +375,7 @@ describe('codemie skills update', () => {
     mockRunSkillsCli.mockResolvedValueOnce({ code: 3, stdout: '', stderr: '', signal: null });
     await expect(parse(['update'])).rejects.toThrow(/__EXIT__:/);
     expect(exitCalls[0]).toBe(3);
+    expect(mockStartSkillMetric).not.toHaveBeenCalled();
     expect(mockEmitFailed).not.toHaveBeenCalled();
   });
 });
@@ -309,6 +423,22 @@ describe('codemie skills remove', () => {
     const [, attrs] = mockEmitCompleted.mock.calls[0]!;
     expect(attrs.skill_names).toEqual(['alpha', 'beta']);
     expect(attrs.skill_count).toBe(2);
+  });
+
+  it('keeps failed metric skill_count aligned with capped skill_names', async () => {
+    mockRunSkillsCli.mockResolvedValueOnce({
+      code: 5,
+      stdout: '',
+      stderr: 'could not find skill',
+      signal: null,
+    });
+
+    const skillArgs = Array.from({ length: 21 }, (_, index) => `skill-${index + 1}`);
+    await expect(parse(['remove', ...skillArgs, '-y'])).rejects.toThrow(/__EXIT__:/);
+
+    const [, attrs] = mockEmitFailed.mock.calls[0]!;
+    expect(attrs.skill_names).toHaveLength(20);
+    expect(attrs.skill_count).toBe(20);
   });
 });
 

--- a/src/cli/commands/skills/__tests__/commands.test.ts
+++ b/src/cli/commands/skills/__tests__/commands.test.ts
@@ -179,117 +179,129 @@ describe('codemie skills add', () => {
     expect(attrs.error_code).toBe('egress_blocked');
   });
 
-  it('normalizes HTTPS repository-like sources with .git before spawning upstream', async () => {
-    const source = 'https://gitbud.example.com/group/repo';
-    await parse(['add', source, '-y']);
+  describe('HTTPS source normalization', () => {
+    let platformSpy: ReturnType<typeof vi.spyOn>;
 
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
-
-    expect(mockEmitCompleted).toHaveBeenCalledOnce();
-    const [, attrs] = mockEmitCompleted.mock.calls[0]!;
-    expect(attrs.source).toBe(source);
-    expect(mockEmitFailed).not.toHaveBeenCalled();
-  });
-
-  it('does not append .git to HTTPS sources that already end with .git', async () => {
-    const source = 'https://gitbud.example.com/group/repo.git';
-    await parse(['add', source, '-y']);
-
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
-  });
-
-  it('does not append .git to well-known HTTPS endpoint URLs', async () => {
-    const source = 'https://gitbud.example.com/.well-known/agent-skills/index.json';
-    await parse(['add', source, '-y']);
-
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
-  });
-
-  it('does not append .git to HTTPS sources with query strings or fragments', async () => {
-    const querySource = 'https://gitbud.example.com/group/repo?ref=main';
-    await parse(['add', querySource, '-y']);
-
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', querySource, '--yes']);
-
-    mockRunSkillsCli.mockClear();
-    mockEmitCompleted.mockClear();
-
-    const fragmentSource = 'https://gitbud.example.com/group/repo#main';
-    await parse(['add', fragmentSource, '-y']);
-
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', fragmentSource, '--yes']);
-  });
-
-  it('does not retry ambiguous HTTPS sources with .git for unrelated upstream failures', async () => {
-    mockRunSkillsCli.mockResolvedValueOnce({
-      code: 7,
-      stdout: '',
-      stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
-      signal: null,
+    beforeEach(() => {
+      platformSpy = vi.spyOn(os, 'platform').mockReturnValue('linux' as NodeJS.Platform);
     });
 
-    await expect(parse(['add', 'https://gitbud.example.com/group/repo', '-y'])).rejects.toThrow(
-      /__EXIT__:/
-    );
-
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(exitCalls[0]).toBe(7);
-  });
-
-  it('does not show Git access help for egress-blocked normalized HTTPS sources', async () => {
-    mockRunSkillsCli.mockResolvedValueOnce({
-      code: 7,
-      stdout: '',
-      stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
-      signal: null,
+    afterEach(() => {
+      platformSpy.mockRestore();
     });
 
-    const source = 'https://gitbud.example.com/group/repo';
-    await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
+    it('normalizes HTTPS repository-like sources with .git before spawning upstream', async () => {
+      const source = 'https://gitbud.example.com/group/repo';
+      await parse(['add', source, '-y']);
 
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
-    expect(stderrSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('CodeMie cannot read this Git repository yet')
-    );
-    expect(exitCalls[0]).toBe(7);
-  });
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
 
-  it('does not append .git to http sources', async () => {
-    mockRunSkillsCli.mockResolvedValueOnce({
-      code: 0,
-      stdout: '',
-      stderr: '',
-      signal: null,
+      expect(mockEmitCompleted).toHaveBeenCalledOnce();
+      const [, attrs] = mockEmitCompleted.mock.calls[0]!;
+      expect(attrs.source).toBe(source);
+      expect(mockEmitFailed).not.toHaveBeenCalled();
     });
 
-    const source = 'http://gitbud.example.com/group/repo';
-    await parse(['add', source, '-y']);
+    it('does not append .git to HTTPS sources that already end with .git', async () => {
+      const source = 'https://gitbud.example.com/group/repo.git';
+      await parse(['add', source, '-y']);
 
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
-  });
-
-  it('shows Git access help for failed normalized HTTPS repository-like sources', async () => {
-    mockRunSkillsCli.mockResolvedValueOnce({
-      code: 1,
-      stdout: '',
-      stderr: 'git clone failed: unable to access repository',
-      signal: null,
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
     });
-    const source = 'https://gitbud.example.com/group/repo';
-    await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
 
-    expect(mockRunSkillsCli).toHaveBeenCalledOnce();
-    expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('The repository clone failed.'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`git ls-remote ${source}`));
-    expect(exitCalls[0]).toBe(1);
+    it('does not append .git to well-known HTTPS endpoint URLs', async () => {
+      const source = 'https://gitbud.example.com/.well-known/agent-skills/index.json';
+      await parse(['add', source, '-y']);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
+    });
+
+    it('does not append .git to HTTPS sources with query strings or fragments', async () => {
+      const querySource = 'https://gitbud.example.com/group/repo?ref=main';
+      await parse(['add', querySource, '-y']);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', querySource, '--yes']);
+
+      mockRunSkillsCli.mockClear();
+      mockEmitCompleted.mockClear();
+
+      const fragmentSource = 'https://gitbud.example.com/group/repo#main';
+      await parse(['add', fragmentSource, '-y']);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', fragmentSource, '--yes']);
+    });
+
+    it('does not retry ambiguous HTTPS sources with .git for unrelated upstream failures', async () => {
+      mockRunSkillsCli.mockResolvedValueOnce({
+        code: 7,
+        stdout: '',
+        stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
+        signal: null,
+      });
+
+      await expect(parse(['add', 'https://gitbud.example.com/group/repo', '-y'])).rejects.toThrow(
+        /__EXIT__:/
+      );
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(exitCalls[0]).toBe(7);
+    });
+
+    it('does not show Git access help for egress-blocked normalized HTTPS sources', async () => {
+      mockRunSkillsCli.mockResolvedValueOnce({
+        code: 7,
+        stdout: '',
+        stderr: 'CODEMIE_SKILL_EGRESS_BLOCKED audit attempt',
+        signal: null,
+      });
+
+      const source = 'https://gitbud.example.com/group/repo';
+      await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
+      expect(stderrSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('CodeMie cannot read this Git repository yet')
+      );
+      expect(exitCalls[0]).toBe(7);
+    });
+
+    it('does not append .git to http sources', async () => {
+      mockRunSkillsCli.mockResolvedValueOnce({
+        code: 0,
+        stdout: '',
+        stderr: '',
+        signal: null,
+      });
+
+      const source = 'http://gitbud.example.com/group/repo';
+      await parse(['add', source, '-y']);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', source, '--yes']);
+    });
+
+    it('shows Git access help for failed normalized HTTPS repository-like sources', async () => {
+      mockRunSkillsCli.mockResolvedValueOnce({
+        code: 1,
+        stdout: '',
+        stderr: 'git clone failed: unable to access repository',
+        signal: null,
+      });
+      const source = 'https://gitbud.example.com/group/repo';
+      await expect(parse(['add', source, '-y'])).rejects.toThrow(/__EXIT__:/);
+
+      expect(mockRunSkillsCli).toHaveBeenCalledOnce();
+      expect(mockRunSkillsCli.mock.calls[0]![0]).toEqual(['add', `${source}.git`, '--yes']);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('The repository clone failed.'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`git ls-remote ${source}`));
+      expect(exitCalls[0]).toBe(1);
+    });
   });
 
   it('forwards --skill list to upstream args (spec §8.3 fan-out source)', async () => {

--- a/src/cli/commands/skills/add.ts
+++ b/src/cli/commands/skills/add.ts
@@ -76,7 +76,8 @@ export function createAddCommand(): Command {
 
       const metric = await startSkillMetric('add', cwd);
 
-      const args = buildAddArgs(source, options, agentSelection.agents);
+      const upstreamSource = normalizeHttpsRepositorySource(source) ?? source;
+      const args = buildAddArgs(upstreamSource, options, agentSelection.agents);
 
       try {
         const result = await runSkillsCli(args, {
@@ -174,6 +175,39 @@ function isGitSource(source: string): boolean {
     /^https?:\/\/.+\.git(?:[#?].*)?$/i.test(source) ||
     /^ssh:\/\/.+\.git(?:[#?].*)?$/i.test(source) ||
     /^git@[^:]+:.+\.git(?:[#?].*)?$/i.test(source)
+  );
+}
+
+function normalizeHttpsRepositorySource(source: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(source);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.search || parsed.hash) {
+    return undefined;
+  }
+
+  const pathWithoutTrailingSlash = parsed.pathname.replace(/\/+$/, '');
+  if (
+    !pathWithoutTrailingSlash ||
+    pathWithoutTrailingSlash.toLowerCase().endsWith('.git') ||
+    isWellKnownSkillsEndpoint(pathWithoutTrailingSlash)
+  ) {
+    return undefined;
+  }
+
+  parsed.pathname = `${pathWithoutTrailingSlash}.git`;
+  return parsed.toString();
+}
+
+function isWellKnownSkillsEndpoint(pathname: string): boolean {
+  const normalizedPathname = pathname.toLowerCase();
+  return (
+    normalizedPathname.endsWith('/.well-known/agent-skills/index.json') ||
+    normalizedPathname.endsWith('/.well-known/skills/index.json')
   );
 }
 

--- a/src/cli/commands/skills/lib/__tests__/egress-guard.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/egress-guard.test.ts
@@ -25,11 +25,13 @@ const SHIM_PATH = path.resolve(
 );
 
 let originalFetch: typeof globalThis.fetch | undefined;
+let originalCaptureInstallTelemetry: string | undefined;
 let originalCaptureUpdateStdout: string | undefined;
 let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
+  originalCaptureInstallTelemetry = process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY;
   originalCaptureUpdateStdout = process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT;
   stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
@@ -40,6 +42,11 @@ afterEach(() => {
   } else {
     // @ts-expect-error - allow undefined reset
     delete globalThis.fetch;
+  }
+  if (originalCaptureInstallTelemetry === undefined) {
+    delete process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY;
+  } else {
+    process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY = originalCaptureInstallTelemetry;
   }
   if (originalCaptureUpdateStdout === undefined) {
     delete process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT;
@@ -119,6 +126,34 @@ describe('skills-sh-egress-guard', () => {
     expect(upstream).not.toHaveBeenCalled();
   });
 
+  it('forces GitHub repo probes to public only while capturing install telemetry', async () => {
+    process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY = '1';
+    const upstream = vi.fn().mockResolvedValue(new Response(JSON.stringify({ private: true })));
+    globalThis.fetch = upstream as unknown as typeof globalThis.fetch;
+    loadShim();
+
+    const response = await globalThis.fetch('https://api.github.com/repos/example/private-repo');
+
+    expect(upstream).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ private: false });
+  });
+
+  it('does not force public responses for deeper GitHub repo API paths', async () => {
+    process.env.CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY = '1';
+    const upstream = vi.fn().mockResolvedValue(new Response(JSON.stringify({ tag_name: 'v1' })));
+    globalThis.fetch = upstream as unknown as typeof globalThis.fetch;
+    loadShim();
+
+    const response = await globalThis.fetch(
+      'https://api.github.com/repos/example/private-repo/releases'
+    );
+
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ tag_name: 'v1' });
+  });
+
   it('captures successful update lines as structured telemetry without blocking stdout', () => {
     process.env.CODEMIE_CAPTURE_SKILLS_SH_UPDATE_STDOUT = '1';
     const stdoutSpy = vi
@@ -140,4 +175,5 @@ describe('skills-sh-egress-guard', () => {
       stdoutSpy.mockRestore();
     }
   });
+
 });

--- a/src/cli/commands/skills/lib/skills-metrics.ts
+++ b/src/cli/commands/skills/lib/skills-metrics.ts
@@ -101,6 +101,9 @@ export async function emitStarted(
     'scope' | 'source' | 'skill_names' | 'skill_count' | 'target_agents' | 'agent_selection_mode'
   >
 ): Promise<void> {
+  // Kept as a lifecycle primitive for callers that need in-flight visibility.
+  // Current skills commands emit terminal states only so interrupted upstream
+  // prompts do not leave durable started-only rows.
   await emit(session, 'started', partial);
 }
 

--- a/src/cli/commands/skills/remove.ts
+++ b/src/cli/commands/skills/remove.ts
@@ -48,7 +48,7 @@ export function createRemoveCommand(): Command {
         ...(options.skill ?? []),
       ];
       const skillNames = capList(explicitSkills);
-      const skillCount = explicitSkills.length || undefined;
+      const skillCount = skillNames?.length;
       const targetAgents = capList(options.agent);
       const selectionMode: AgentSelectionMode | undefined =
         options.agent && options.agent.length > 0 ? 'explicit' : undefined;

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -40,8 +40,6 @@ export function createUpdateCommand(): Command {
 
       const skillNames = capList(skills);
 
-      const metric = await startSkillMetric('update', cwd);
-
       const args = ['update'];
       if (options.global) args.push('--global');
       if (options.project) args.push('--project');
@@ -67,6 +65,7 @@ export function createUpdateCommand(): Command {
             });
             return;
           }
+          const metric = await startSkillMetric('update', cwd);
           await emitCompleted(metric, {
             scope,
             skill_names: updatedSkillNames,


### PR DESCRIPTION
## Summary

Four targeted fixes to the `skills` CLI subsystem: HTTPS repository source normalization, egress guard hardening, and two metric lifecycle/alignment corrections.

## Changes

- **HTTPS source normalization** (`add.ts`): Bare HTTPS repo URLs (e.g. `https://host/group/repo`) are now normalized to `.git` form before being passed to the upstream skills CLI. URLs with query strings, fragments, an existing `.git` suffix, or a `.well-known` path are passed through unchanged. Non-HTTPS schemes are unaffected.
- **Egress guard** (`skills-sh-egress-guard.cjs`): When `CODEMIE_CAPTURE_SKILLS_SH_INSTALL_TELEMETRY` is set, GitHub repo visibility probes are forced to return `{ private: false }`, preventing the private/public decision from leaking to `add-skill.vercel.sh`.
- **Update metric lifecycle** (`update.ts`): `startSkillMetric` is now called only after a successful upstream result, eliminating orphaned `started`-only rows when the command is interrupted or fails.
- **Remove metric cap alignment** (`remove.ts`): `skill_count` now uses `skillNames?.length` (the already-capped array) instead of `explicitSkills.length`, keeping `skill_count` consistent with the `skill_names` field (both capped at 20).

## Impact

- `codemie skills add https://host/group/repo` now works without requiring users to append `.git` manually.
- Metric rows emitted by `update` and `remove` are more accurate.
- No breaking changes to CLI interface or public APIs.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)