### PR TITLE
docs: remove obsolete profile switch example

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -56,7 +56,6 @@ Behavior:
 Recommended setup:
 
 ```bash
-codemie profile switch codemie-prod
 codemie proxy connect desktop
 ```
 


### PR DESCRIPTION
## Summary
Removes the obsolete \ command from the Claude Desktop proxy recommended setup documentation.

## Changes
- Keeps the recommended setup focused on \Starting proxy...
Using profile: epm-cdme
✓ Proxy started
✓ Claude Desktop configured
  Restart Claude Desktop to apply changes., matching the documented default active-profile behavior.

## Test Plan
- Not run per repository policy; documentation-only change.