### PR TITLE
docs(complexity-assessment): add story points estimates

### DIFF
--- a/.claude/agents/complexity-assessor.md
+++ b/.claude/agents/complexity-assessor.md
@@ -117,16 +117,16 @@ Cap any dimension at 6 (XXL) after bumping.
 
 ### Step 6 — Calculate total and determine routing
 
-Sum all 6 dimension scores. Map to size label:
+Sum all 6 dimension scores. Map to size label and story points:
 
-| Total | Size | Routing |
-|-------|------|---------|
-| 6–9   | XS   | Direct implementation — superpowers:subagent-driven-development (no planning needed) |
-| 10–14 | S    | Direct implementation — superpowers:subagent-driven-development (no planning needed) |
-| 15–20 | M    | superpowers:brainstorming |
-| 21–26 | L    | superpowers:brainstorming |
-| 27–31 | XL   | SPLIT REQUIRED — present splitting strategies, wait for user decomposition |
-| 32–36 | XXL  | SPLIT REQUIRED — hard block, do not invoke any planning skill |
+| Total | Size | Story Points | Routing |
+|-------|------|--------------|---------|
+| 6–9   | XS   | 1            | Direct implementation — superpowers:subagent-driven-development (no planning needed) |
+| 10–14 | S    | 2            | Direct implementation — superpowers:subagent-driven-development (no planning needed) |
+| 15–20 | M    | 3            | superpowers:brainstorming |
+| 21–26 | L    | 5            | superpowers:brainstorming |
+| 27–31 | XL   | 8            | SPLIT REQUIRED — present splitting strategies, wait for user decomposition |
+| 32–36 | XXL  | 13           | SPLIT REQUIRED — hard block, do not invoke any planning skill |
 
 For borderline scores (9→10, 14→15, 20→21, 26→27, 31→32): lean higher if Technical Risk or Component Scope is at XL (5) or XXL (6). Lean lower only if Technical Risk is M (3) or below AND existing patterns cover more than half the implementation.
 
@@ -156,6 +156,7 @@ Return exactly this structure, filled in with your assessment:
 | Affected Layers      | [1-6] | [XS–XXL] |
 
 ### Total: [sum]/36 — [XS | S | M | L | XL | XXL]
+### Story Points: [1 | 2 | 3 | 5 | 8 | 13]
 
 ### Key Reasoning:
 - **[List all dimensions scoring L (4) or higher]**: [why — component names, not code]
@@ -195,6 +196,7 @@ If the user disagrees with the assessment — by providing corrections, pointing
 If the user says yes:
 - Determine the file name: use the ticket ID from task_description if present (e.g., `epmcdme-12345-short-description.md`), otherwise derive from feature_area keywords (e.g., `feature-add-sharepoint-indexer.md`).
 - Determine `<size>` from the final agreed label (xs/s/m/l/xl/xxl).
+- Determine `<story_points>` according to size to story point mapping.
 - Write the file to `.claude/references/complexity-assessment/examples/<size>/<filename>.md` using this format (match existing examples):
 
 ```markdown
@@ -202,6 +204,7 @@ If the user says yes:
 
 **Ticket:** [ticket ID or "N/A"]
 **Size:** [XS | S | M | L | XL | XXL]
+**Story Points:** [1 | 2 | 3 | 5 | 8 | 13]
 **Actual Outcome:** [brief description]
 
 ## Assessment

--- a/.claude/references/complexity-assessment/guide/complexity-assessment-guide.md
+++ b/.claude/references/complexity-assessment/guide/complexity-assessment-guide.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This guide provides detailed criteria for assessing feature complexity. Each dimension is scored XS–XXL (1–6). Six dimensions sum to a total of 6–36, which maps directly to the T-shirt size output. The scoring system is self-consistent: if all dimensions score M, the story is M; if all score XL, the story is XL.
+This guide provides detailed criteria for assessing feature complexity. Each dimension is scored XS–XXL (1–6). Six dimensions sum to a total of 6–36, which maps directly to the T-shirt size output and Story Point estimate. The scoring system is self-consistent: if all dimensions score M, the story is M; if all score XL, the story is XL.
 
 ## Scoring Scale
 
@@ -226,14 +226,14 @@ Scores which architectural/infrastructure layers require changes: UI, API/backen
 
 Score each dimension XS–XXL (1–6). Total range: 6–36.
 
-| Total Score | Size | Typical Cycle | Routing |
-|-------------|------|---------------|---------|
-| 6–9         | XS   | < half day    | → `superpowers:writing-plans` directly |
-| 10–14       | S    | 1 day         | → `superpowers:writing-plans` directly |
-| 15–20       | M    | 2–3 days      | → `superpowers:brainstorming` first |
-| 21–26       | L    | 4–5 days      | → `superpowers:brainstorming` first |
-| 27–31       | XL   | > 1 sprint    | → **Recommend splitting** before planning |
-| 32–36       | XXL  | > 1 sprint    | → **Must split** — do not proceed until decomposed |
+| Total Score | Size | Story Points | Typical Cycle | Routing |
+|-------------|------|--------------|---------------|---------|
+| 6–9         | XS   | 1            | < half day    | → `superpowers:writing-plans` directly |
+| 10–14       | S    | 2            | 1 day         | → `superpowers:writing-plans` directly |
+| 15–20       | M    | 3            | 2–3 days      | → `superpowers:brainstorming` first |
+| 21–26       | L    | 5            | 4–5 days      | → `superpowers:brainstorming` first |
+| 27–31       | XL   | 8            | > 1 sprint    | → **Recommend splitting** before planning |
+| 32–36       | XXL  | 13           | > 1 sprint    | → **Must split** — do not proceed until decomposed |
 
 Self-check: all-M dimensions (6×3=18) → M. All-L (6×4=24) → L. All-XL (6×5=30) → XL. ✓
 
@@ -280,6 +280,7 @@ Example scoring:
 ### Total Score: [sum]/36
 
 ### Size: [XS | S | M | L | XL | XXL]
+### Story Points: [1 | 2 | 3 | 5 | 8 | 13]
 ```
 
 ## Example Assessments
@@ -382,6 +383,7 @@ Always provide assessment in this structure:
 ## Implementation Analysis: EPMCDME-XXXXX
 
 ### Size: [XS | S | M | L | XL | XXL]  ([total]/36)
+### Story Points: [1 | 2 | 3 | 5 | 8 | 13]
 
 ### Dimension Scores:
 | Dimension            | Score | Label |

--- a/.claude/skills/tech-lead/SKILL.md
+++ b/.claude/skills/tech-lead/SKILL.md
@@ -118,6 +118,8 @@ git branch --list <branch-name>
 
 ## Phase 3: Complexity Assessment and Routing
 
+### Assessment
+
 Dispatch the `complexity-assessor` agent:
 
 ```
@@ -131,6 +133,8 @@ Use the Agent tool:
 ```
 
 Present the full assessment block returned by the agent.
+
+**If a Jira ticket was provided**, update the Story Points field on the ticket with the estimated SP value via brianna skill.
 
 ### Routing
 


### PR DESCRIPTION
Maps Fibonacci story points (1,2,3,5,8,13) to each complexity size (XS–XXL) across the assessor agent and guide. Routing tables now include SP column and assessment output blocks emit the Story Points field.

Generated with AI

## Summary

<!-- Brief overview of what this PR does and why -->

## Changes

<!-- List of major changes which must be higlighed. Do not lsit all, just important to focus, Do not include code snippets. -->

## Impact

<!-- Optional: Show before/after examples for user-facing changes -->

## Checklist

- [ ] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
