### PR TITLE
chore(agents): set Claude autocompact default to 80

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -168,7 +168,7 @@ export const ClaudePluginMetadata: AgentMetadata = {
       }
 
       if (!env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE) {
-        let autocompactPct = 70;
+        let autocompactPct = 80;
         if (env.CODEMIE_PROFILE_CONFIG) {
           try {
             const profileConfig = JSON.parse(env.CODEMIE_PROFILE_CONFIG);


### PR DESCRIPTION
## Summary
Updates the Claude Code auto-compact default threshold from 70 to 80 by changing the default value used for CLAUDE_AUTOCOMPACT_PCT_OVERRIDE.

## Changes
- Set the Claude autocompact default percentage to 80
- Preserved explicit CLAUDE_AUTOCOMPACT_PCT_OVERRIDE and profile config override behavior

## Validation
- Verified the branch contains the intended one-line source change
- Tests not run per repo policy; tests only run on explicit request