### PR TITLE
fix(providers): hide no-litellm integration message from user output

### DIFF
--- a/src/providers/plugins/sso/sso.setup-steps.ts
+++ b/src/providers/plugins/sso/sso.setup-steps.ts
@@ -132,9 +132,9 @@ export const SSOSetupSteps: ProviderSetupSteps = {
     } else {
       // No integrations found
       if (integrationsFetchError) {
-        console.log(chalk.dim(`ℹ️  Proceeding without LiteLLM integration (fetch failed)\n`));
+        logger.debug(`Proceeding without LiteLLM integration (fetch failed): ${integrationsFetchError}`);
       } else {
-        console.log(chalk.dim(`ℹ️  No LiteLLM integrations configured${projectLabel}\n`));
+        logger.debug(`No LiteLLM integrations configured${projectLabel}`);
       }
     }
 


### PR DESCRIPTION
## Summary

Removes noisy informational messages about missing LiteLLM integrations from the user-facing setup output. These messages appeared after project selection during `codemie setup` even when the absence of LiteLLM integrations is expected and unimportant.

## Changes

- Replaced two `console.log` calls in `sso.setup-steps.ts` with `logger.debug` so they only surface when `CODEMIE_DEBUG=true`

## Impact

Before: users saw `ℹ️  No LiteLLM integrations configured for project "X"` during normal setup flow.
After: message is silent unless debug mode is enabled.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)