### PR TITLE
fix(skills): emit actual target agent in skills events instead of wrapper sentinel

### DIFF
--- a/src/cli/commands/skills/lib/__tests__/skills-metrics.test.ts
+++ b/src/cli/commands/skills/lib/__tests__/skills-metrics.test.ts
@@ -341,6 +341,159 @@ describe('skill events emitter (transport behavior)', () => {
     expect(body.attributes).toBeUndefined();
   });
 
+  it('uses target agent as agent field when a single agent is targeted', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('add');
+    await emitCompleted(session, {
+      scope: 'project',
+      source: 'owner/repo',
+      skill_names: ['foo'],
+      skill_count: 1,
+      target_agents: ['claude-code'],
+      agent_selection_mode: 'auto_detected',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+    expect(body.agent).toBe('claude-code');
+    expect(body.target_agents).toEqual(['claude-code']);
+    expect(body.skill_name).toBe('foo');
+  });
+
+  it('fans out one POST per (skill, agent) tuple when both are known', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('add');
+    await emitCompleted(session, {
+      scope: 'project',
+      source: 'owner/repo',
+      skill_names: ['foo', 'bar'],
+      skill_count: 2,
+      target_agents: ['claude-code', 'cursor'],
+      agent_selection_mode: 'explicit',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    const bodies = fetchSpy.mock.calls.map((call) => JSON.parse(call[1].body));
+
+    expect(bodies.map((b) => [b.skill_name, b.agent])).toEqual([
+      ['foo', 'claude-code'],
+      ['foo', 'cursor'],
+      ['bar', 'claude-code'],
+      ['bar', 'cursor'],
+    ]);
+    for (const body of bodies) {
+      expect(body.target_agents).toEqual(['claude-code', 'cursor']);
+      expect(body.agent_selection_mode).toBe('explicit');
+      expect(body.source).toBe('owner/repo');
+    }
+  });
+
+  it('fans out per agent with no skill_name when target agents are known but skill names are not', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('add');
+    await emitCompleted(session, {
+      scope: 'project',
+      source: 'owner/repo',
+      target_agents: ['claude-code', 'cursor'],
+      agent_selection_mode: 'prompted',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const bodies = fetchSpy.mock.calls.map((call) => JSON.parse(call[1].body));
+    expect(bodies.map((b) => b.agent)).toEqual(['claude-code', 'cursor']);
+    for (const body of bodies) {
+      expect(body.skill_name).toBeUndefined();
+      expect(body.skill_slug).toBeUndefined();
+      expect(body.skill_id).toBeUndefined();
+      expect(body.target_agents).toEqual(['claude-code', 'cursor']);
+    }
+  });
+
+  it('falls back to codemie-skills agent when target_agents is empty (upstream mode)', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('add');
+    await emitCompleted(session, {
+      scope: 'project',
+      source: 'owner/repo',
+      skill_names: ['foo', 'bar'],
+      skill_count: 2,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const bodies = fetchSpy.mock.calls.map((call) => JSON.parse(call[1].body));
+    for (const body of bodies) {
+      expect(body.agent).toBe('codemie-skills');
+      expect(body.target_agents).toBeUndefined();
+    }
+  });
+
+  it('uses target agent on remove when --agent is supplied', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('remove');
+    await emitCompleted(session, {
+      scope: 'project',
+      skill_names: ['foo'],
+      skill_count: 1,
+      target_agents: ['cursor'],
+      agent_selection_mode: 'explicit',
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+    expect(body.command).toBe('remove');
+    expect(body.agent).toBe('cursor');
+    expect(body.skill_name).toBe('foo');
+  });
+
+  it('falls back to codemie-skills agent on remove when --agent is omitted', async () => {
+    mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
+    mockGetStoredCredentials.mockResolvedValue({
+      cookies: { session: 'abc' },
+      apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+    });
+
+    const { startSkillMetric, emitCompleted } = await importMetrics();
+    const session = await startSkillMetric('remove');
+    await emitCompleted(session, {
+      scope: 'project',
+      skill_names: ['foo'],
+      skill_count: 1,
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+    expect(body.agent).toBe('codemie-skills');
+    expect(body.target_agents).toBeUndefined();
+  });
+
   it('falls back to ensureApiBase when credentials store has no apiUrl', async () => {
     mockConfigLoad.mockResolvedValue({ codeMieUrl: 'https://codemie.lab.epam.com' });
     mockGetStoredCredentials.mockResolvedValue({

--- a/src/cli/commands/skills/lib/skills-metrics.ts
+++ b/src/cli/commands/skills/lib/skills-metrics.ts
@@ -28,7 +28,15 @@ import { detectGitBranch, detectGitRemoteRepo } from '@/utils/processes.js';
 import { getDirname } from '@/utils/paths.js';
 import type { CodeMieConfigOptions } from '@/env/types.js';
 
-const AGENT_NAME = 'codemie-skills';
+/**
+ * Fallback `agent` value when the wrapper cannot determine the actual target
+ * agent for the operation (e.g. bare `list`/`find`, or `add` with no explicit
+ * `--agent` and no detectable project marker — upstream mode). When the
+ * wrapper does know the targets (via `partial.target_agents`), the emitter
+ * fans out one event per target so the backend's `by_agent` aggregation
+ * counts real agents instead of this wrapper sentinel.
+ */
+const FALLBACK_AGENT_NAME = 'codemie-skills';
 const ENDPOINT_PATH = '/v1/skills/events';
 
 // Wrapper-known input shapes (typed once here so command files don't reach
@@ -168,7 +176,7 @@ async function emit(
       detectGitRemoteRepo(session.workingDirectory),
     ]);
 
-    const baseBody: Omit<SkillEventBody, 'skill_name' | 'skill_slug' | 'skill_id'> = {
+    const baseBody: Omit<SkillEventBody, 'skill_name' | 'skill_slug' | 'skill_id' | 'agent'> = {
       session_id: session.sessionId,
       command: session.command,
       status,
@@ -181,7 +189,6 @@ async function emit(
         target_agents: partial.target_agents,
       }),
       ...(partial.source !== undefined && { source: partial.source }),
-      agent: AGENT_NAME,
       agent_version: session.agentVersion,
       ...(repository && { repository }),
       ...(branch && { branch }),
@@ -190,16 +197,7 @@ async function emit(
       }),
     };
 
-    const targetedSkills = partial.skill_names ?? [];
-    const bodies: SkillEventBody[] =
-      targetedSkills.length > 0
-        ? targetedSkills.map((name) => ({
-            ...baseBody,
-            skill_name: name,
-            skill_slug: toSkillSlug(name),
-            skill_id: composeSkillId(partial.source, toSkillSlug(name)),
-          }))
-        : [{ ...baseBody }];
+    const bodies = buildEventBodies(baseBody, partial);
 
     logger.debug('[skills] Emitting skill events', {
       command: session.command,
@@ -214,6 +212,50 @@ async function emit(
     const message = error instanceof Error ? error.message : String(error);
     logger.debug(`[skills] Event emission failed (${status}): ${message}`);
   }
+}
+
+/**
+ * Expand a base event body into the concrete events to POST. Fan-out runs
+ * along two dimensions:
+ *
+ *   - skill name (when explicit `--skill` or parsed from upstream telemetry)
+ *   - target agent (when wrapper knows them via `target_agents`)
+ *
+ * The combinatorial product is intentional: the backend aggregates `agent`
+ * for `by_agent` analytics, so a single skill installed for two agents must
+ * produce one event per agent. Without target agents, the emitter falls back
+ * to the wrapper sentinel so callers that genuinely don't target an agent
+ * (`list`, `find`, `upstream` add) still produce countable rows.
+ */
+function buildEventBodies(
+  baseBody: Omit<SkillEventBody, 'skill_name' | 'skill_slug' | 'skill_id' | 'agent'>,
+  partial: PartialAttributes
+): SkillEventBody[] {
+  const skillNames = partial.skill_names ?? [];
+  const agentNames =
+    partial.target_agents && partial.target_agents.length > 0
+      ? partial.target_agents
+      : [FALLBACK_AGENT_NAME];
+
+  if (skillNames.length === 0) {
+    return agentNames.map((agent) => ({ ...baseBody, agent }));
+  }
+
+  const bodies: SkillEventBody[] = [];
+  for (const name of skillNames) {
+    const slug = toSkillSlug(name);
+    const skillId = composeSkillId(partial.source, slug);
+    for (const agent of agentNames) {
+      bodies.push({
+        ...baseBody,
+        agent,
+        skill_name: name,
+        skill_slug: slug,
+        ...(skillId !== undefined && { skill_id: skillId }),
+      });
+    }
+  }
+  return bodies;
 }
 
 async function postOne(transport: SkillEventTransport, body: SkillEventBody): Promise<void> {


### PR DESCRIPTION
## Summary

- `codemie skills add` / `codemie skills remove` were emitting `agent: \"codemie-skills\"` on every backend event, so the backend's `by_agent` aggregation always counted the wrapper sentinel instead of the real target (e.g. `claude-code`, `cursor`).
- Replaced the hardcoded value in `src/cli/commands/skills/lib/skills-metrics.ts` with a fan-out over `partial.target_agents` (already populated by both `add.ts` and `remove.ts` — no call-site changes).
- Result: a `codemie skills add owner/repo --skill foo --agent claude-code` now emits `agent: \"claude-code\"`, and a multi-agent install fans out one event per agent so `by_agent` counts each real agent.

## Fan-out matrix

| Inputs | Behaviour |
|---|---|
| `skill_names` + `target_agents` known | one event per `(skill, agent)` tuple, `agent = <that agent>` |
| `target_agents` known, no `skill_names` | one event per agent, `skill_*` fields omitted |
| `skill_names` known, no `target_agents` (upstream-mode add, remove without `--agent`) | one event per skill, `agent = 'codemie-skills'` fallback |
| neither known (`list`, `find`) | one event, `agent = 'codemie-skills'` fallback (unchanged) |

`target_agents` array stays on each event for context.

## Verification

- `npm run build` – OK
- `npm run lint` on modified files – clean
- `npx vitest run src/cli/commands/skills` – **139/139 pass** (21 in `skills-metrics.test.ts`, including 6 new fan-out cases)
- `npm run ci` – all green **except one pre-existing failure** unrelated to this change: `tests/integration/cli-commands/skills.test.ts > add: injects DO_NOT_TRACK / DISABLE_TELEMETRY / CI / NODE_OPTIONS shim`. Verified by stashing this commit and re-running on plain `main` — same failure reproduces, so it is not introduced here.

## Test plan

- [ ] CI matrix (Linux + Windows) green on PR
- [ ] Confirm in backend that `by_agent` now shows real agent names (`claude-code`, `cursor`, ...) after merge
- [ ] Spot-check pre-existing `DO_NOT_TRACK` integration test failure separately — out of scope for this PR