### PR TITLE
fix(proxy): restore Claude Desktop SSO proxy routing

### DIFF
--- a/src/bin/proxy-daemon.ts
+++ b/src/bin/proxy-daemon.ts
@@ -31,6 +31,7 @@ const { values } = parseArgs({
     'target-url':   { type: 'string' },
     'provider':     { type: 'string' },
     'profile':      { type: 'string' },
+    'project':      { type: 'string' },
     'port':         { type: 'string' },
     'gateway-key':  { type: 'string' },
     'state-file':   { type: 'string' },
@@ -60,6 +61,7 @@ const port = parsedPort;
 const gatewayKey = (values['gateway-key'] as string | undefined) ?? 'codemie-proxy';
 const profile    = (values['profile'] as string | undefined) ?? 'default';
 const provider   = (values['provider'] as string | undefined) ?? 'ai-run-sso';
+const project = values['project'] as string | undefined;
 const authMethod = ((values['auth-method'] as string | undefined) ?? 'sso') as 'sso' | 'jwt';
 const telemetryMode = ((values['telemetry-mode'] as string | undefined) ?? 'none') as 'none' | 'claude-desktop';
 const syncApiUrl = values['sync-api-url'] as string | undefined;
@@ -74,6 +76,7 @@ const config: ProxyConfig = {
   host: '127.0.0.1',
   provider,
   profile,
+  project,
   gatewayKey,
   authMethod,
   clientType: telemetryMode === 'claude-desktop' ? 'claude-desktop' : 'codemie-daemon',
@@ -130,6 +133,7 @@ try {
     gatewayKey,
     targetUrl: config.targetApiUrl,
     provider: config.provider,
+    project: config.project,
     clientType: config.clientType,
     telemetryMode,
     syncApiUrl: config.syncApiUrl,

--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
@@ -74,7 +74,17 @@ describe('fetchClaudeModels', () => {
   it('returns Claude family ids and excludes vertex / non-claude entries', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => MODEL_LIST_RESPONSE,
+      json: async () => [
+        { base_name: 'claude-sonnet-4-5-20250929' },
+        { base_name: 'claude-4-5-sonnet' },
+        { base_name: 'claude-sonnet-4-6' },
+        { base_name: 'claude-opus-4-5-20251101' },
+        { base_name: 'claude-opus-4-6-20260205' },
+        { base_name: 'claude-opus-4-7' },
+        { base_name: 'claude-haiku-4-5-20251001' },
+        { base_name: 'claude-opus-4-6-vertex' },
+        { base_name: 'gpt-5.5-2026-04-24' },
+      ],
     }) as any;
 
     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
@@ -98,14 +108,16 @@ describe('fetchClaudeModels', () => {
     expect(init.headers.Authorization).toBe('Bearer my-key');
   });
 
-  it('returns [] when fetch fails', async () => {
+  it('throws when fetch fails', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down')) as any;
-    expect(await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy')).toEqual([]);
+    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+      .rejects.toThrow('Local proxy model discovery could not reach');
   });
 
-  it('returns [] when response is not ok', async () => {
+  it('throws when response is not ok', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }) as any;
-    expect(await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy')).toEqual([]);
+    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+      .rejects.toThrow('Local proxy model discovery failed');
   });
 });
 
@@ -248,11 +260,10 @@ describe('writeDesktopConfig', () => {
     ]);
   });
 
-  it('omits inferenceModels when discovery returns nothing', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) }) as any;
-    const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir);
-    const config = JSON.parse(await readFile(written, 'utf-8'));
-    expect(config.inferenceModels).toBeUndefined();
+  it('fails fast when discovery returns nothing', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] }) as any;
+    await expect(writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir))
+      .rejects.toThrow('Local proxy did not expose any Claude models');
   });
 
   it('overwrites the four inference keys with new values', async () => {

--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -3,6 +3,9 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getClaudeDesktopBaseDir } from '@/telemetry/clients/claude-desktop/claude-desktop.paths.js';
+import { ConfigurationError } from '@/utils/errors.js';
+import { logger } from '@/utils/logger.js';
+import { sanitizeLogArgs } from '@/utils/security.js';
 import managedMcpServers from './desktop-managed-mcp-servers.json' with { type: 'json' };
 
 const INFERENCE_KEYS = [
@@ -27,6 +30,12 @@ interface ModelsListResponse {
   data?: Array<{ id?: string }>;
 }
 
+interface CodeMieLlmModel {
+  id?: string;
+  base_name?: string;
+  deployment_name?: string;
+}
+
 /**
  * Curated list of Claude models we expose by default.
  *
@@ -48,33 +57,85 @@ export const DEFAULT_MANAGED_MCP_SERVERS =
   managedMcpServers as readonly ManagedMcpServerEntry[];
 
 /**
- * Fetch the model list from the gateway's `/v1/models` endpoint and return
- * the IDs of usable Claude-family models (excludes `-vertex` aliases since
- * the gateway already picks the right backend for the canonical names).
- *
- * Returns [] if the gateway is unreachable or returns a non-OK response.
+ * Fetch the model list from the gateway's SSO-backed `/v1/llm_models?include_all=true`
+ * endpoint and return the IDs of usable Claude-family models (excludes `-vertex`
+ * aliases since the gateway already picks the right backend for the canonical names).
  */
 export async function fetchClaudeModels(proxyUrl: string, gatewayKey: string): Promise<string[]> {
+  const endpoint = new URL('/v1/llm_models?include_all=true', proxyUrl).toString();
   try {
-    const response = await fetch(new URL('/v1/models', proxyUrl), {
+    logger.info(
+      '[proxy] Fetching Claude models from gateway',
+      ...sanitizeLogArgs({
+        endpoint,
+        inferenceGatewayBaseUrl: proxyUrl,
+        inferenceGatewayApiKey: gatewayKey,
+        preferredModels: [...PREFERRED_CLAUDE_MODELS],
+      })
+    );
+    const response = await fetch(new URL('/v1/llm_models?include_all=true', proxyUrl), {
       headers: { Authorization: `Bearer ${gatewayKey}` },
     });
-    if (!response.ok) return [];
-    const json = await response.json() as ModelsListResponse;
-    const ids = (json.data ?? [])
-      .map((m) => m.id)
-      .filter((id): id is string => typeof id === 'string');
-    return ids
+    if (!response.ok) {
+      logger.warn(
+        '[proxy] Gateway model discovery failed',
+        ...sanitizeLogArgs({
+          endpoint,
+          status: response.status,
+          statusText: response.statusText,
+          inferenceGatewayBaseUrl: proxyUrl,
+        })
+      );
+      throw new ConfigurationError(
+        response.status === 401
+          ? `Local proxy model discovery was rejected with 401 Unauthorized at ${endpoint}. ` +
+            'The local gateway key was not accepted by the proxy or was forwarded upstream incorrectly.'
+          : `Local proxy model discovery failed at ${endpoint}: ${response.status} ${response.statusText}`
+      );
+    }
+    const json = await response.json() as ModelsListResponse | CodeMieLlmModel[];
+    const ids = Array.isArray(json)
+      ? json
+        .map((model) => model.id || model.base_name || model.deployment_name)
+        .filter((id): id is string => typeof id === 'string')
+      : (json.data ?? [])
+        .map((m) => m.id)
+        .filter((id): id is string => typeof id === 'string');
+    const claudeIds = ids
       .filter((id) => /^claude-/i.test(id))
       .filter((id) => !/-vertex$/i.test(id));
-  } catch {
-    return [];
+    logger.info(
+      '[proxy] Gateway model discovery completed',
+      ...sanitizeLogArgs({
+        endpoint,
+        totalModelCount: ids.length,
+        totalClaudeModelCount: claudeIds.length,
+        availableClaudeModels: claudeIds,
+      })
+    );
+    return claudeIds;
+  } catch (error) {
+    if (error instanceof ConfigurationError) {
+      throw error;
+    }
+    logger.warn(
+      '[proxy] Gateway model discovery threw before completion',
+      ...sanitizeLogArgs({
+        endpoint,
+        inferenceGatewayBaseUrl: proxyUrl,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    );
+    throw new ConfigurationError(
+      `Local proxy model discovery could not reach ${endpoint}. ` +
+      `Reason: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 
 /**
  * Resolve each entry in {@link PREFERRED_CLAUDE_MODELS} against the gateway's
- * `/v1/models` response. For each preferred name, prefer the exact ID; fall
+ * model discovery response. For each preferred name, prefer the exact ID; fall
  * back to the dated variant `<preferred>-YYYYMMDD` (latest if multiple).
  * Entries with no available match are dropped silently.
  *
@@ -99,6 +160,19 @@ export function selectPreferredClaudeModels(
       .pop();
     if (dated) resolved.push(dated);
   }
+  const missingPreferredModels = preferred.filter((name) => {
+    if (resolved.includes(name)) return false;
+    return !resolved.some((resolvedName) => resolvedName.startsWith(`${name}-`));
+  });
+  logger.info(
+    '[proxy] Preferred Claude model selection completed',
+    ...sanitizeLogArgs({
+      preferredModels: [...preferred],
+      availableClaudeModels: available,
+      selectedModels: resolved,
+      missingPreferredModels,
+    })
+  );
   return resolved;
 }
 
@@ -242,9 +316,36 @@ export async function writeDesktopConfig(
   // Discover available Claude models from the gateway and curate down to the
   // preferred set so the user doesn't have to type them manually in the GUI.
   const discoveredModels = await fetchClaudeModels(proxyUrl, gatewayKey);
+  if (discoveredModels.length === 0) {
+    throw new ConfigurationError(
+      `Local proxy did not expose any Claude models from ${new URL('/v1/llm_models?include_all=true', proxyUrl).toString()}.`
+    );
+  }
   const resolvedModels = selectPreferredClaudeModels(discoveredModels);
+  if (resolvedModels.length === 0) {
+    throw new ConfigurationError(
+      'Local proxy discovered Claude models, but none matched the preferred CodeMie desktop set.'
+    );
+  }
   const inferenceModels: InferenceModelEntry[] = resolvedModels.map((name) => ({ name }));
   const managedMcpServers = mergeManagedMcpServers(existing.managedMcpServers);
+
+  logger.info(
+    '[proxy] Preparing Claude Desktop config payload',
+    ...sanitizeLogArgs({
+      baseDir,
+      configPath,
+      inferenceGatewayBaseUrl: proxyUrl,
+      inferenceGatewayApiKey: gatewayKey,
+      discoveredModelCount: discoveredModels.length,
+      discoveredModels,
+      resolvedModelCount: resolvedModels.length,
+      resolvedModels,
+      inferenceModelsWritten: inferenceModels.length > 0,
+      managedMcpServerCount: managedMcpServers.length,
+      existingConfigKeys: Object.keys(existing),
+    })
+  );
 
   for (const key of INFERENCE_KEYS) {
     delete existing[key];
@@ -261,6 +362,18 @@ export async function writeDesktopConfig(
     managedMcpServers: JSON.stringify(managedMcpServers),
   };
   await writeFile(configPath, JSON.stringify(merged, null, 2), 'utf-8');
+  logger.info(
+    '[proxy] Claude Desktop config file updated',
+    ...sanitizeLogArgs({
+      configPath,
+      inferenceGatewayBaseUrl: proxyUrl,
+      inferenceGatewayApiKey: gatewayKey,
+      inferenceModelsWritten: inferenceModels.length > 0,
+      resolvedModels,
+      managedMcpServerCount: managedMcpServers.length,
+      finalConfigKeys: Object.keys(merged),
+    })
+  );
 
   const entries = meta.entries ?? [];
   if (!entries.find((e) => e.id === configId)) {

--- a/src/cli/commands/proxy/daemon-manager.ts
+++ b/src/cli/commands/proxy/daemon-manager.ts
@@ -78,6 +78,7 @@ export interface SpawnOptions {
   profile: string;
   port?: number;
   gatewayKey?: string;
+  project?: string;
   telemetryMode?: 'none' | 'claude-desktop';
   syncApiUrl?: string;
   syncCodeMieUrl?: string;
@@ -97,6 +98,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<DaemonState> {
     '--provider', opts.provider,
     '--profile', opts.profile,
     '--gateway-key', gatewayKey,
+    ...(opts.project ? ['--project', opts.project] : []),
     '--state-file', stateFile,
     ...(opts.port ? ['--port', String(opts.port)] : []),
     ...(opts.telemetryMode ? ['--telemetry-mode', opts.telemetryMode] : []),
@@ -113,6 +115,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<DaemonState> {
       profile: opts.profile,
       port: opts.port,
       gatewayKey,
+      project: opts.project,
       telemetryMode: opts.telemetryMode,
       syncApiUrl: opts.syncApiUrl,
       syncCodeMieUrl: opts.syncCodeMieUrl

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -8,6 +8,7 @@ import {
   formatErrorForUser,
 } from '../../../utils/errors.js';
 import { logger } from '../../../utils/logger.js';
+import { sanitizeLogArgs } from '../../../utils/security.js';
 import {
   checkStatus,
   readState,
@@ -163,6 +164,7 @@ export function createProxyCommand(): Command {
         provider: config.provider ?? 'ai-run-sso',
         profile: config.name ?? 'default',
         port: parsePortOption(opts.port, DEFAULT_DAEMON_PORT),
+        project: config.codeMieProject,
         syncApiUrl: config.ssoConfig?.apiUrl,
         syncCodeMieUrl: config.codeMieUrl,
       });
@@ -220,6 +222,7 @@ export function createProxyCommand(): Command {
     .option('--verbose', 'Show detailed connection info (URLs, config paths) for debugging')
     .action(async (opts) => {
       const verbose: boolean = Boolean(opts.verbose);
+      let startedInThisRun = false;
       try {
         let { running, state } = await checkStatus();
 
@@ -262,24 +265,61 @@ export function createProxyCommand(): Command {
           } else {
             console.log(chalk.cyan(`Using profile: ${profileLabel}`));
           }
+          logger.info(
+            '[proxy] Resolved Claude Desktop proxy configuration',
+            ...sanitizeLogArgs({
+              profile: profileLabel,
+              profileSource,
+              provider: config.provider ?? 'ai-run-sso',
+              baseUrl: config.baseUrl,
+              codeMieUrl: config.codeMieUrl,
+              syncApiUrl: config.ssoConfig?.apiUrl,
+            })
+          );
           await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
           state = await spawnDaemon({
             targetUrl: config.baseUrl,
             provider: config.provider ?? 'ai-run-sso',
             profile: config.name ?? 'default',
             port: DEFAULT_DAEMON_PORT,
+            project: config.codeMieProject,
             telemetryMode: 'claude-desktop',
             syncApiUrl: config.ssoConfig?.apiUrl,
             syncCodeMieUrl: config.codeMieUrl,
           });
+          startedInThisRun = true;
           if (verbose) {
             console.log(chalk.green(`✓ Proxy started at ${state.url}`));
           } else {
             console.log(chalk.green('✓ Proxy started'));
           }
+          logger.info(
+            '[proxy] Claude Desktop proxy daemon is ready',
+            ...sanitizeLogArgs({
+              url: state.url,
+              port: state.port,
+              profile: state.profile,
+              telemetryMode: state.telemetryMode,
+              targetUrl: state.targetUrl,
+              clientType: state.clientType,
+              syncApiUrl: state.syncApiUrl,
+              syncCodeMieUrl: state.syncCodeMieUrl,
+              inferenceGatewayApiKey: state.gatewayKey,
+            })
+          );
         }
 
         const configPath = await writeDesktopConfig(state!.url, state!.gatewayKey);
+        logger.info(
+          '[proxy] Claude Desktop proxy configuration written',
+          ...sanitizeLogArgs({
+            configPath,
+            gatewayUrl: state!.url,
+            telemetryMode: state!.telemetryMode,
+            profile: state!.profile,
+            inferenceGatewayApiKey: state!.gatewayKey,
+          })
+        );
         console.log(chalk.green('✓ Claude Desktop configured'));
         if (verbose) {
           console.log(`  Config:  ${configPath}`);
@@ -288,6 +328,19 @@ export function createProxyCommand(): Command {
         }
         console.log(chalk.yellow('  Restart Claude Desktop to apply changes.'));
       } catch (error) {
+        if (startedInThisRun) {
+          try {
+            await stopDaemon();
+            logger.info('[proxy] Claude Desktop proxy startup rolled back after configuration failure');
+          } catch (stopError) {
+            logger.warn(
+              '[proxy] Failed to stop Claude Desktop proxy after configuration failure',
+              ...sanitizeLogArgs({
+                error: stopError instanceof Error ? stopError.message : String(stopError),
+              })
+            );
+          }
+        }
         printProxyError(error, 'Failed to connect Claude Desktop proxy');
       }
     });

--- a/src/providers/plugins/sso/proxy/plugins/gateway-key.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/gateway-key.plugin.ts
@@ -3,6 +3,7 @@ import type { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
 import type { ProxyContext } from '../proxy-types.js';
 import type { ProxyHTTPClient } from '../proxy-http-client.js';
 import { logger } from '../../../../../utils/logger.js';
+import { sanitizeLogArgs } from '../../../../../utils/security.js';
 
 export class GatewayKeyPlugin implements ProxyPlugin {
   id = '@codemie/proxy-gateway-key';
@@ -12,6 +13,13 @@ export class GatewayKeyPlugin implements ProxyPlugin {
 
   createInterceptor(context: PluginContext): ProxyInterceptor {
     const gatewayKey = context.config.gatewayKey;
+    logger.info(
+      '[gateway-key] Initializing gateway auth interceptor',
+      ...sanitizeLogArgs({
+        enabled: Boolean(gatewayKey),
+        configuredGatewayKey: gatewayKey,
+      })
+    );
 
     return {
       name: this.name,
@@ -25,11 +33,30 @@ export class GatewayKeyPlugin implements ProxyPlugin {
         if (!gatewayKey) return false;
         if (ctx.metadata.gatewayKeyValidated) return false;
 
-        const authHeader = ctx.headers['authorization'];
+        const authHeader = ctx.headers['authorization'] ?? ctx.headers['Authorization'];
         const expected = `Bearer ${gatewayKey}`;
 
+        logger.info(
+          '[gateway-key] Validating incoming gateway authorization header',
+          ...sanitizeLogArgs({
+            url: ctx.url,
+            hasAuthorizationHeader: Boolean(authHeader),
+            authorizationHeader: authHeader,
+            expectedAuthorizationHeader: expected,
+            headerKeys: Object.keys(ctx.headers),
+          })
+        );
+
         if (!authHeader || authHeader !== expected) {
-          logger.debug('[gateway-key] Rejected: invalid or missing gateway key');
+          logger.warn(
+            '[gateway-key] Rejected request: invalid or missing gateway key',
+            ...sanitizeLogArgs({
+              url: ctx.url,
+              hasAuthorizationHeader: Boolean(authHeader),
+              authorizationHeader: authHeader,
+              expectedAuthorizationHeader: expected,
+            })
+          );
           res.statusCode = 401;
           res.setHeader('Content-Type', 'application/json');
           res.end(JSON.stringify({
@@ -40,8 +67,15 @@ export class GatewayKeyPlugin implements ProxyPlugin {
         }
 
         delete ctx.headers['authorization'];
+        delete ctx.headers['Authorization'];
         ctx.metadata.gatewayKeyValidated = true;
-        logger.debug('[gateway-key] Gateway key validated, authorization header stripped');
+        logger.info(
+          '[gateway-key] Gateway key validated and authorization header stripped',
+          ...sanitizeLogArgs({
+            url: ctx.url,
+            remainingHeaderKeys: Object.keys(ctx.headers),
+          })
+        );
         return false;
       },
     };

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -8,6 +8,7 @@
 import { getPluginRegistry } from "./registry.js";
 import { MCPAuthPlugin } from "./mcp-auth.plugin.js";
 import { EndpointBlockerPlugin } from "./endpoint-blocker.plugin.js";
+import { GatewayKeyPlugin } from "./gateway-key.plugin.js";
 import { SSOAuthPlugin } from "./sso-auth.plugin.js";
 import { JWTAuthPlugin } from "./jwt-auth.plugin.js";
 import { HeaderInjectionPlugin } from "./header-injection.plugin.js";
@@ -27,6 +28,7 @@ export function registerCorePlugins(): void {
   // Register in any order (priority determines execution order)
   registry.register(new MCPAuthPlugin()); // Priority 3 - MCP auth relay routing
   registry.register(new EndpointBlockerPlugin()); // Priority 5 - blocks unwanted endpoints early
+  registry.register(new GatewayKeyPlugin()); // Priority 7 - validates local gateway auth, strips header before upstream
   registry.register(new SSOAuthPlugin());
   registry.register(new JWTAuthPlugin());
   registry.register(new ClaudeRequestNormalizerPlugin()); // Priority 14 - normalizes thinking params for claude models
@@ -44,6 +46,7 @@ registerCorePlugins();
 export {
   MCPAuthPlugin,
   EndpointBlockerPlugin,
+  GatewayKeyPlugin,
   SSOAuthPlugin,
   JWTAuthPlugin,
   HeaderInjectionPlugin,

--- a/src/providers/plugins/sso/proxy/sso.proxy.ts
+++ b/src/providers/plugins/sso/proxy/sso.proxy.ts
@@ -119,6 +119,10 @@ export class CodeMieProxy {
     // 4. Initialize plugins from registry
     const registry = getPluginRegistry();
     this.interceptors = await registry.initialize(pluginContext);
+    logger.info('[proxy] Initialized proxy interceptors', {
+      interceptors: this.interceptors.map((interceptor) => interceptor.name),
+      interceptorCount: this.interceptors.length,
+    });
 
     // 5. Find available port
     this.actualPort = this.config.port || await this.findAvailablePort();
@@ -256,6 +260,22 @@ export class CodeMieProxy {
       // 3. Forward request to upstream
       const targetUrl = this.buildTargetUrl(req.url!);
       context.targetUrl = targetUrl.toString();
+
+      logger.info(
+        '[proxy] Forwarding request to upstream',
+        {
+          requestId: context.requestId,
+          url: context.url,
+          targetUrl: context.targetUrl,
+          hasAuthorizationHeader: Boolean(
+            context.headers['authorization'] ?? context.headers['Authorization']
+          ),
+          authorizationHeader: context.headers['authorization'] ?? context.headers['Authorization'],
+          hasCookieHeader: Boolean(context.headers['cookie'] ?? context.headers['Cookie']),
+          headerKeys: Object.keys(context.headers),
+          gatewayKeyValidated: Boolean(context.metadata.gatewayKeyValidated),
+        }
+      );
 
       logger.debug(`[proxy] Forwarding request to upstream for ${context.requestId}`);
       const upstreamResponse = await this.httpClient.forward(targetUrl, {


### PR DESCRIPTION
## Summary
Restores the Claude Desktop proxy flow so requests continue to pass through the generic SSO proxy path instead of relying on ad hoc endpoint handling.

## Changes
- fix gateway key validation/stripping in the original proxy auth flow
- switch desktop model discovery to the SSO-backed /v1/llm_models endpoint
- pass CodeMie project context into the desktop proxy daemon so forwarded Claude Desktop requests include the required project header
- update desktop proxy tests to match the new fail-fast model discovery behavior

## Verification
- Verified desktop proxy model discovery populates inferenceModels
- Verified /v1/messages succeeds through the local desktop proxy when project context is injected
- Full unit suite passes
- Full integration suite has one unrelated existing failure in tests/integration/cli-commands/skills.test.ts (DO_NOT_TRACK env assertion)

## Notes
- Excluded local .codemie/codemie-cli.config.json changes from this PR
