### PR TITLE
fix(proxy): fix two Claude Desktop Windows startup failures

### DIFF
--- a/src/cli/commands/proxy/connectors/desktop-managed-mcp-servers.json
+++ b/src/cli/commands/proxy/connectors/desktop-managed-mcp-servers.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Atlassian Jira and Confluence",
+    "name": "Atlassian-Jira-and-Confluence",
     "url": "https://mcp.atlassian.com/v1/mcp/authv2",
     "transport": "http",
     "oauth": true

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/claude-request-normalizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/claude-request-normalizer.plugin.test.ts
@@ -82,6 +82,25 @@ describe('ClaudeRequestNormalizerPlugin', () => {
       expect(interceptor.name).toBe('claude-request-normalizer');
     });
 
+    it('creates interceptor for claude-desktop (Desktop 3P mode)', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('claude-desktop'));
+      expect(interceptor).toBeDefined();
+      expect(interceptor.name).toBe('claude-request-normalizer');
+    });
+
+    it('strips haiku thinking for claude-desktop agent', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('claude-desktop'));
+      const context = createProxyContext({
+        model: 'claude-haiku-4-5-20251001',
+        thinking: { type: 'enabled', budget_tokens: 31999 },
+      });
+
+      await interceptor.onRequest!(context);
+
+      const body = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(body.thinking).toBeUndefined();
+    });
+
     it('throws for codemie-code agent', async () => {
       await expect(plugin.createInterceptor(createPluginContext('codemie-code')))
         .rejects.toThrow('Plugin disabled for agent: codemie-code');

--- a/src/providers/plugins/sso/proxy/plugins/claude-request-normalizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/claude-request-normalizer.plugin.ts
@@ -16,7 +16,7 @@
  * - Haiku models reject thinking field with HTTP 400
  * - Opus 4-7+ requires adaptive thinking format with output_config.effort
  *
- * Scope: Only enabled for codemie-claude agent (Claude Code via SSO proxy).
+ * Scope: Enabled for codemie-claude (Claude Code via SSO proxy) and claude-desktop (Desktop 3P mode).
  *
  * To add model support: update NO_THINKING_MODEL_PATTERNS or ADAPTIVE_THINKING_MODEL_PATTERNS.
  */
@@ -112,8 +112,8 @@ function handleAdaptiveThinkingTransform(body: any, model: string): boolean {
   return true;
 }
 
-/** Agent that sends Claude API requests through the codemie proxy */
-const ALLOWED_AGENT = 'codemie-claude';
+/** Agents whose Claude API requests need thinking normalization */
+const ALLOWED_AGENTS = ['codemie-claude', 'claude-desktop'];
 
 export class ClaudeRequestNormalizerPlugin implements ProxyPlugin {
   id = '@codemie/proxy-claude-request-normalizer';
@@ -123,7 +123,7 @@ export class ClaudeRequestNormalizerPlugin implements ProxyPlugin {
 
   async createInterceptor(context: PluginContext): Promise<ProxyInterceptor> {
     const clientType = context.config.clientType;
-    if (!clientType || clientType !== ALLOWED_AGENT) {
+    if (!clientType || !ALLOWED_AGENTS.includes(clientType)) {
       throw new Error(`Plugin disabled for agent: ${clientType}`);
     }
     // Pass the configured model as a fallback for requests that omit body.model


### PR DESCRIPTION
## Summary

Two separate Windows-only bugs that prevented Claude Desktop (3P mode) from starting successfully when certain conditions were met.

## Changes

### 1. Haiku model crash — `Content block is not a text block`

**Root cause:** When the user selects `claude-haiku-4-5-20251001` in Claude Desktop, the app resolves `maxThinkingTokens = 31999` and sends `thinking: { type: "enabled", budget_tokens: 31999 }` to the API via the CodeMie proxy. Haiku returns thinking content blocks in the response stream. The Desktop SDK, expecting only text blocks, throws:

```
API Error: Content block is not a text block
```

The SSO proxy already had a `ClaudeRequestNormalizerPlugin` that strips the `thinking` field for Haiku models — but it was scoped only to `codemie-claude` (Claude Code). Desktop 3P requests carry `clientType: 'claude-desktop'` and were silently bypassing the plugin.

**Fix:** Added `'claude-desktop'` to `ALLOWED_AGENTS` in `ClaudeRequestNormalizerPlugin` so the Haiku thinking-strip logic runs for Desktop proxy requests as well.

### 2. Session crash on startup — `Server name can only contain letters, numbers, hyphens, and underscores`

**Root cause:** The managed MCP server entry `"Atlassian Jira and Confluence"` contained spaces. Claude Code validates `allowedMcpServers` names against `/^[a-zA-Z0-9_-]+$/`. On Windows, loading the managed-policy settings file failed with:

```
parent managed settings: Server name can only contain letters, numbers, hyphens, and underscores
```

This caused the Claude Code process to exit with code 1 before the session could start.

**Fix:** Renamed the entry to `"Atlassian-Jira-and-Confluence"` (spaces → hyphens).

## Test Plan

- [x] Unit tests for `ClaudeRequestNormalizerPlugin` updated — new cases cover `claude-desktop` agent scoping and Haiku stripping via Desktop agent
- [x] All 1686 unit tests pass (`npm run test:unit`)
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles clean (`tsc --noEmit`)

## Checklist

- [x] Code follows style guide
- [x] All tests pass
- [x] No ESLint warnings
- [x] No secrets introduced
- [x] Architecture boundaries respected (proxy plugin layer)