### PR TITLE
fix(proxy): remove invalid MCP server names with spaces on desktop config write

### DIFF
--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -202,21 +202,26 @@ function parseJsonArray(value: unknown): unknown[] {
   }
 }
 
+function isValidMcpServerName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name);
+}
+
 export function mergeManagedMcpServers(existingServers: unknown): unknown[] {
-  const merged = [...parseJsonArray(existingServers)];
-  const existingNames = new Set(
-    merged
-      .map((server) => getManagedMcpServerName(server)?.toLowerCase())
-      .filter((name): name is string => Boolean(name))
-  );
+  const defaultUrls = new Set(DEFAULT_MANAGED_MCP_SERVERS.map((s) => s.url));
+  const defaultNames = new Set(DEFAULT_MANAGED_MCP_SERVERS.map((s) => s.name.toLowerCase()));
 
-  for (const server of DEFAULT_MANAGED_MCP_SERVERS) {
-    if (!existingNames.has(server.name.toLowerCase())) {
-      merged.push({ ...server });
-    }
-  }
+  // Remove existing entries that are invalid (spaces in name) or superseded by a default entry with the same URL
+  const filtered = parseJsonArray(existingServers).filter((server) => {
+    const name = getManagedMcpServerName(server);
+    if (!name) return true;
+    if (!isValidMcpServerName(name)) return false;
+    if (defaultNames.has(name.toLowerCase())) return false;
+    const url = isRecord(server) && typeof server.url === 'string' ? server.url : undefined;
+    if (url && defaultUrls.has(url)) return false;
+    return true;
+  });
 
-  return merged;
+  return [...filtered, ...DEFAULT_MANAGED_MCP_SERVERS.map((s) => ({ ...s }))];
 }
 
 export interface DesktopGatewayConfig {


### PR DESCRIPTION
## Summary

When writing the Claude Desktop `configLibrary` config, existing `managedMcpServers` entries with spaces in their names (e.g. `"Atlassian Jira and Confluence"`) were preserved alongside the corrected hyphenated entries, causing Claude Code to fail with: _"Server name can only contain letters, numbers, hyphens, and underscores"_.

## Changes

- Added `isValidMcpServerName` validator (regex `^[a-zA-Z0-9_-]+$`)
- `mergeManagedMcpServers` now filters out existing entries with invalid names (spaces) before merging
- Also deduplicates by URL — old entries pointing to the same URL as a default are replaced
- Default entries are always written in canonical form, replacing any stale versions

## Impact

Before: proxy connect left both `"Atlassian Jira and Confluence"` and `"Atlassian-Jira-and-Confluence"` in the config → Claude Code crashed on startup.  
After: invalid/superseded entries are cleaned up automatically on next proxy connect.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)