### PR TITLE
fix(cli): add profile refresh to next steps help output

### DIFF
--- a/src/cli/commands/profile/display.ts
+++ b/src/cli/commands/profile/display.ts
@@ -80,6 +80,7 @@ export class ProfileDisplay {
     console.log('');
     console.log('  ' + chalk.white('• Switch active profile:') + '  ' + chalk.cyan('codemie profile switch'));
     console.log('  ' + chalk.white('• View profile status:') + '    ' + chalk.cyan('codemie profile status'));
+    console.log('  ' + chalk.white('• Refresh profile auth:') + '   ' + chalk.cyan('codemie profile refresh'));
     console.log('  ' + chalk.white('• Create new profile:') + '     ' + chalk.cyan('codemie setup'));
     console.log('  ' + chalk.white('• Remove a profile:') + '       ' + chalk.cyan('codemie profile delete'));
     console.log('  ' + chalk.white('• Explore more:') + '           ' + chalk.cyan('codemie --help'));


### PR DESCRIPTION
## Summary

The `codemie profile refresh` command was missing from the **Next Steps** section displayed after listing profiles, even though the command exists.

## Changes

- Added `• Refresh profile auth: codemie profile refresh` entry to the Next Steps section in `ProfileDisplay.formatList()`

## Impact

**Before:**
```
• Switch active profile:  codemie profile switch
• View profile status:    codemie profile status
• Create new profile:     codemie setup
• Remove a profile:       codemie profile delete
• Explore more:           codemie --help
```

**After:**
```
• Switch active profile:  codemie profile switch
• View profile status:    codemie profile status
• Refresh profile auth:   codemie profile refresh
• Create new profile:     codemie setup
• Remove a profile:       codemie profile delete
• Explore more:           codemie --help
```

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)