### PR TITLE
fix(utils): fix XSS,encryption security and server leak issues

### DIFF
--- a/src/providers/plugins/sso/proxy/proxy-errors.ts
+++ b/src/providers/plugins/sso/proxy/proxy-errors.ts
@@ -25,8 +25,7 @@ export class ProxyError extends Error {
       type: this.name,
       code: this.code,
       message: this.message,
-      statusCode: this.statusCode,
-      ...this.details
+      statusCode: this.statusCode
     };
   }
 }

--- a/src/providers/plugins/sso/sso.auth.ts
+++ b/src/providers/plugins/sso/sso.auth.ts
@@ -13,6 +13,15 @@ import type { SSOAuthConfig, SSOAuthResult, SSOCredentials } from '../../core/ty
 import { CredentialStore } from '../../../utils/security.js';
 import { ensureApiBase } from '../../core/codemie-auth-helpers.js';
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 /**
  * Normalize URL to base (protocol + host)
  * E.g., https://host.com/path -> https://host.com
@@ -232,7 +241,7 @@ export class CodeMieSSO {
                 </script>` : `
                 <h2 class="error">❌ Authentication Failed</h2>
                 <p>You can close this window and return to your terminal.</p>
-                ${result.error ? `<p class="error">Error: ${result.error}</p>` : ''}`
+                ${result.error ? `<p class="error">Error: ${escapeHtml(result.error)}</p>` : ''}`
                 }
               </body>
             </html>
@@ -254,7 +263,7 @@ export class CodeMieSSO {
               </head>
               <body>
                 <h2>❌ Authentication Failed</h2>
-                <p>Error: ${error.message}</p>
+                <p>Error: ${escapeHtml(error.message)}</p>
                 <p>You can close this window and return to your terminal.</p>
               </body>
             </html>

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -507,22 +507,34 @@ export class CredentialStore {
   }
 
   private encrypt(text: string): string {
-    const iv = crypto.randomBytes(16);
-    // Use a proper 32-byte key by hashing the encryptionKey
+    const iv = crypto.randomBytes(12);
     const key = crypto.createHash('sha256').update(this.encryptionKey).digest();
-    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
     let encrypted = cipher.update(text, 'utf8', 'hex');
     encrypted += cipher.final('hex');
-    return iv.toString('hex') + ':' + encrypted;
+    const authTag = cipher.getAuthTag();
+    return iv.toString('hex') + ':' + authTag.toString('hex') + ':' + encrypted;
   }
 
   private decrypt(text: string): string {
-    const [ivHex, encryptedHex] = text.split(':');
-    const iv = Buffer.from(ivHex, 'hex');
-    // Use a proper 32-byte key by hashing the encryptionKey
+    const parts = text.split(':');
     const key = crypto.createHash('sha256').update(this.encryptionKey).digest();
+
+    if (parts.length === 3) {
+      // GCM format: iv:authTag:encrypted
+      const iv = Buffer.from(parts[0], 'hex');
+      const authTag = Buffer.from(parts[1], 'hex');
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(authTag);
+      let decrypted = decipher.update(parts[2], 'hex', 'utf8');
+      decrypted += decipher.final('utf8');
+      return decrypted;
+    }
+
+    // Legacy CBC format: iv:encrypted (backward compat for existing stored credentials)
+    const iv = Buffer.from(parts[0], 'hex');
     const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-    let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
+    let decrypted = decipher.update(parts[1], 'hex', 'utf8');
     decrypted += decipher.final('utf8');
     return decrypted;
   }


### PR DESCRIPTION
- Upgrade CredentialStore cipher from AES-256-CBC to AES-256-GCM (AEAD) for authenticated encryption; legacy CBC format still decryptable
- Escape HTML in SSO callback server error responses to prevent XSS

Fixes EPMCDME-12203, EPMCDME-12204, EPMCDME-12210