### PR TITLE
fix(utils): reject credentials over insecure HTTP in sonar script

### DIFF
--- a/scripts/sonar/run-local-sonar.js
+++ b/scripts/sonar/run-local-sonar.js
@@ -173,6 +173,11 @@ function resolveScannerCommand() {
 function sonarRequestJson(sonarHostUrl, sonarToken, endpoint, searchParams = {}) {
     return new Promise((resolve, reject) => {
         const requestUrl = new URL(endpoint, sonarHostUrl);
+        if (requestUrl.protocol !== 'https:') {
+            reject(new Error(`Refusing to send credentials over insecure protocol "${requestUrl.protocol}". Configure sonarQubeUri with https://.`));
+            return;
+        }
+
         for (const [key, value] of Object.entries(searchParams)) {
             if (value !== undefined && value !== null && value !== '') {
                 requestUrl.searchParams.set(key, String(value));


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where `Authorization` credentials (Sonar token) could be sent over unencrypted HTTP if `sonarQubeUri` in `.sonarlint/connectedMode.json` was configured with `http://` instead of `https://`.

## Changes

- Added protocol validation in `sonarRequestJson` — rejects with a clear error if URL protocol is not `https:`

## Impact

Before: HTTP-configured Sonar URLs silently sent auth tokens unencrypted.
After: Hard reject with actionable error message pointing to the config fix.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)