### PR TITLE
fix(proxy): handle SSO session expiry — auto-reauth and clean Anthropic error fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,9 @@ jobs:
       - name: Run integration tests
         run: npm run test:integration
 
+      - name: Run e2e tests
+        run: npm run test:e2e
+
   test-windows:
     name: Test (Windows)
     runs-on: windows-latest

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "commitlint:last": "commitlint --from HEAD~1 --to HEAD --verbose",
     "validate:secrets": "node scripts/validate-secrets.js",
     "license-check": "node scripts/license-check.js",
-    "ci": "npm run license-check && npm run lint && npm run build && npm run test:unit && npm run test:integration",
+    "ci": "npm run license-check && npm run lint && npm run build && npm run test:unit && npm run test:integration && npm run test:e2e",
     "ci:full": "npm run commitlint:last && npm run ci",
     "prepare": "husky",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "vitest",
     "test:unit": "vitest run src",
     "test:integration": "vitest run tests/integration",
+    "test:e2e": "vitest run tests/e2e",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",

--- a/src/providers/plugins/sso/proxy/__tests__/sso.proxy.session-expiry.test.ts
+++ b/src/providers/plugins/sso/proxy/__tests__/sso.proxy.session-expiry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * CodeMieProxy — session-expiry unit tests
+ *
+ * S6: sendSessionExpiredResponse emits a correct Anthropic authentication_error body
+ * S7: attemptSSOReauth returns false immediately when authMethod === 'jwt'
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- module mocks must come before all imports ---
+
+vi.mock('../../../../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Prevent the proxy constructor / start() from touching ProviderRegistry
+vi.mock('../../../../core/registry.js', () => ({
+  ProviderRegistry: {
+    getProvider: vi.fn().mockReturnValue(null),
+  },
+}));
+
+// Prevent ProxyHTTPClient from opening real sockets
+vi.mock('../proxy-http-client.js', () => {
+  const MockClient = function MockProxyHTTPClient(this: any) {
+    this.close = vi.fn();
+  };
+  return { ProxyHTTPClient: MockClient };
+});
+
+// Prevent auto-registration of plugins which may have side effects
+vi.mock('../plugins/index.js', () => ({}));
+
+// Provide a registry that returns an empty interceptors list
+vi.mock('../plugins/registry.js', () => ({
+  getPluginRegistry: vi.fn().mockReturnValue({
+    initialize: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+// SSO module — authenticate is the spy we will assert on in S7
+const mockAuthenticate = vi.fn();
+vi.mock('../../sso.auth.js', () => ({
+  CodeMieSSO: vi.fn().mockImplementation(() => ({
+    authenticate: mockAuthenticate,
+    getStoredCredentials: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+import { ServerResponse } from 'http';
+import { CodeMieProxy } from '../sso.proxy.js';
+import { ProxyConfig, ProxyContext } from '../proxy-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMinimalConfig(overrides: Partial<ProxyConfig> = {}): ProxyConfig {
+  return {
+    targetApiUrl: 'https://api.codemie.example.com',
+    sessionId: 'test-session',
+    ...overrides,
+  };
+}
+
+function createMockRes(): {
+  statusCode: number;
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  capturedBody: string;
+} {
+  let body = '';
+  return {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((data: string) => {
+      body = data;
+    }),
+    get capturedBody() {
+      return body;
+    },
+  };
+}
+
+function createProxyContext(overrides: Partial<ProxyContext> = {}): ProxyContext {
+  return {
+    requestId: 'test-request-id',
+    sessionId: 'test-session',
+    agentName: 'test-agent',
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {},
+    requestBody: null,
+    requestStartTime: Date.now(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CodeMieProxy — session expiry behaviour', () => {
+  let proxy: CodeMieProxy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // S6 — sendSessionExpiredResponse
+  // -------------------------------------------------------------------------
+  describe('S6: sendSessionExpiredResponse', () => {
+    beforeEach(() => {
+      proxy = new CodeMieProxy(createMinimalConfig());
+    });
+
+    it('sets response statusCode to 401', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('sets Content-Type header to application/json', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+    });
+
+    it('sends a body with type === "error"', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      const parsed = JSON.parse(res.capturedBody);
+      expect(parsed.type).toBe('error');
+    });
+
+    it('sends a body with error.type === "authentication_error"', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      const parsed = JSON.parse(res.capturedBody);
+      expect(parsed.error.type).toBe('authentication_error');
+    });
+
+    it('sends a message that references "codemie profile login"', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      const parsed = JSON.parse(res.capturedBody);
+      expect(parsed.error.message).toContain('codemie profile login');
+    });
+
+    it('calls res.end exactly once', () => {
+      const res = createMockRes();
+      const ctx = createProxyContext();
+
+      (proxy as any).sendSessionExpiredResponse(res as unknown as ServerResponse, ctx);
+
+      expect(res.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // S7 — attemptSSOReauth JWT bypass
+  // -------------------------------------------------------------------------
+  describe('S7: attemptSSOReauth — JWT bypass', () => {
+    it('returns false immediately when authMethod is "jwt"', async () => {
+      proxy = new CodeMieProxy(createMinimalConfig({ authMethod: 'jwt' }));
+
+      const result = await (proxy as any).attemptSSOReauth();
+
+      expect(result).toBe(false);
+    });
+
+    it('does NOT call CodeMieSSO.authenticate when authMethod is "jwt"', async () => {
+      proxy = new CodeMieProxy(createMinimalConfig({ authMethod: 'jwt' }));
+
+      await (proxy as any).attemptSSOReauth();
+
+      expect(mockAuthenticate).not.toHaveBeenCalled();
+    });
+
+    it('returns false for JWT even when profileConfig.codeMieUrl is set', async () => {
+      proxy = new CodeMieProxy(
+        createMinimalConfig({
+          authMethod: 'jwt',
+          profileConfig: { codeMieUrl: 'https://codemie.example.com' } as any,
+        })
+      );
+
+      const result = await (proxy as any).attemptSSOReauth();
+
+      expect(result).toBe(false);
+      expect(mockAuthenticate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/session-expiry-handler.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/session-expiry-handler.plugin.test.ts
@@ -1,0 +1,130 @@
+/**
+ * SessionExpiryHandlerPlugin Tests
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../../../../utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { SessionExpiryHandlerPlugin } from '../session-expiry-handler.plugin.js';
+import { PluginContext, ProxyInterceptor } from '../types.js';
+import { ProxyContext } from '../../proxy-types.js';
+import { logger } from '../../../../../../utils/logger.js';
+
+function createPluginContext(): PluginContext {
+  return {
+    config: {
+      targetApiUrl: 'https://api.codemie.com',
+      provider: 'test',
+      sessionId: 'test-session',
+    },
+    logger,
+  };
+}
+
+function createProxyContext(upstreamStatusCode?: number): ProxyContext {
+  return {
+    requestId: 'test-req',
+    sessionId: 'test-session',
+    agentName: 'test-agent',
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {},
+    requestBody: null,
+    requestStartTime: Date.now(),
+    metadata: upstreamStatusCode !== undefined ? { upstreamStatusCode } : {},
+  };
+}
+
+describe('SessionExpiryHandlerPlugin', () => {
+  let plugin: SessionExpiryHandlerPlugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new SessionExpiryHandlerPlugin();
+  });
+
+  describe('Plugin Metadata', () => {
+    it('has correct id', () => {
+      expect(plugin.id).toBe('@codemie/proxy-session-expiry-handler');
+    });
+
+    it('has correct name', () => {
+      expect(plugin.name).toBe('Session Expiry Handler');
+    });
+
+    it('has correct version', () => {
+      expect(plugin.version).toBe('1.0.0');
+    });
+
+    it('has priority 20 (after auth plugins at 10/13)', () => {
+      expect(plugin.priority).toBe(20);
+    });
+  });
+
+  describe('createInterceptor', () => {
+    it('returns an interceptor named session-expiry-handler', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext());
+      expect(interceptor.name).toBe('session-expiry-handler');
+    });
+
+    it('interceptor implements onResponseHeaders', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext());
+      expect(typeof interceptor.onResponseHeaders).toBe('function');
+    });
+  });
+
+  describe('onResponseHeaders — session expiry detection', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext());
+    });
+
+    it('sets sessionExpired=true when upstreamStatusCode is 401', async () => {
+      const context = createProxyContext(401);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(context.metadata.sessionExpired).toBe(true);
+    });
+
+    it('sets sessionExpired=true when upstreamStatusCode is 403', async () => {
+      const context = createProxyContext(403);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(context.metadata.sessionExpired).toBe(true);
+    });
+
+    it('does NOT set sessionExpired for 200', async () => {
+      const context = createProxyContext(200);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(context.metadata.sessionExpired).toBeUndefined();
+    });
+
+    it('does NOT set sessionExpired for 500', async () => {
+      const context = createProxyContext(500);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(context.metadata.sessionExpired).toBeUndefined();
+    });
+
+    it('does NOT set sessionExpired when upstreamStatusCode is absent', async () => {
+      const context = createProxyContext();
+      await interceptor.onResponseHeaders!(context, {});
+      expect(context.metadata.sessionExpired).toBeUndefined();
+    });
+
+    it('logs a warning when session is expired', async () => {
+      const context = createProxyContext(401);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('does not log when status is 200', async () => {
+      const context = createProxyContext(200);
+      await interceptor.onResponseHeaders!(context, {});
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/session-expiry-handler.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/session-expiry-handler.plugin.test.ts
@@ -61,7 +61,7 @@ describe('SessionExpiryHandlerPlugin', () => {
       expect(plugin.version).toBe('1.0.0');
     });
 
-    it('has priority 20 (after auth plugins at 10/13)', () => {
+    it('has priority 20', () => {
       expect(plugin.priority).toBe(20);
     });
   });

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -17,6 +17,7 @@ import { ClaudeRequestNormalizerPlugin } from "./claude-request-normalizer.plugi
 import { CodexEncryptedContentSanitizerPlugin } from "./codex-encrypted-content-sanitizer.plugin.js";
 import { LoggingPlugin } from "./logging.plugin.js";
 import { SSOSessionSyncPlugin } from "./sso.session-sync.plugin.js";
+import { SessionExpiryHandlerPlugin } from "./session-expiry-handler.plugin.js";
 
 /**
  * Register core plugins
@@ -36,6 +37,7 @@ export function registerCorePlugins(): void {
   registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - strips encrypted reasoning state for Codex
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
+  registry.register(new SessionExpiryHandlerPlugin()); // Priority 20 - detects 401/403, triggers re-auth in proxy core
   registry.register(new SSOSessionSyncPlugin()); // Priority 100 - syncs sessions via multiple processors
 }
 
@@ -56,5 +58,6 @@ export {
   LoggingPlugin,
 };
 export { SSOSessionSyncPlugin } from "./sso.session-sync.plugin.js";
+export { SessionExpiryHandlerPlugin } from "./session-expiry-handler.plugin.js";
 export { getPluginRegistry, resetPluginRegistry } from "./registry.js";
 export * from "./types.js";

--- a/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
@@ -1,0 +1,37 @@
+import { IncomingHttpHeaders } from 'http';
+import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+
+const SESSION_EXPIRED_STATUS_CODES = new Set([401, 403]);
+
+export class SessionExpiryHandlerPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-session-expiry-handler';
+  name = 'Session Expiry Handler';
+  version = '1.0.0';
+  priority = 20;
+
+  async createInterceptor(_context: PluginContext): Promise<ProxyInterceptor> {
+    return new SessionExpiryInterceptor();
+  }
+}
+
+class SessionExpiryInterceptor implements ProxyInterceptor {
+  name = 'session-expiry-handler';
+
+  async onResponseHeaders(
+    context: ProxyContext,
+    _headers: IncomingHttpHeaders
+  ): Promise<void> {
+    const statusCode = context.metadata.upstreamStatusCode as number | undefined;
+    if (statusCode === undefined || !SESSION_EXPIRED_STATUS_CODES.has(statusCode)) {
+      return;
+    }
+
+    context.metadata.sessionExpired = true;
+    logger.warn(
+      '[session-expiry-handler] Upstream returned session-expired status — will attempt re-authentication',
+      { statusCode, requestId: context.requestId }
+    );
+  }
+}

--- a/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'http';
 import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
-import { ProxyContext } from '../proxy-types.js';
+import type { ProxyContext } from '../proxy-types.js';
 import { logger } from '../../../../../utils/logger.js';
 
 const SESSION_EXPIRED_STATUS_CODES = new Set([401, 403]);

--- a/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'http';
 import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
 import { ProxyContext } from '../proxy-types.js';
 import { logger } from '../../../../../utils/logger.js';

--- a/src/providers/plugins/sso/proxy/sso.proxy.ts
+++ b/src/providers/plugins/sso/proxy/sso.proxy.ts
@@ -285,10 +285,46 @@ export class CodeMieProxy {
       });
       logger.debug(`[proxy] Received upstream response object for ${context.requestId}`);
 
+      // Expose upstream status code to onResponseHeaders plugins before hook chain runs
+      context.metadata.upstreamStatusCode = upstreamResponse.statusCode || 0;
+
       // 4. Run onResponseHeaders hooks (BEFORE streaming)
       await this.runHook('onResponseHeaders', interceptor =>
         interceptor.onResponseHeaders?.(context, upstreamResponse.headers)
       );
+
+      // 4.5. Handle session expiry: attempt SSO re-auth and retry the original request
+      if (context.metadata.sessionExpired) {
+        upstreamResponse.resume(); // drain and discard the 401 body
+        const reauthed = await this.attemptSSOReauth();
+
+        if (reauthed) {
+          const { CodeMieSSO } = await import('../sso.auth.js');
+          const sso = new CodeMieSSO();
+          const freshCreds = await sso.getStoredCredentials(this.config.targetApiUrl);
+
+          if (freshCreds && freshCreds.cookies) {
+            context.headers['cookie'] = Object.entries(freshCreds.cookies)
+              .map(([k, v]) => `${k}=${v}`)
+              .join('; ');
+          }
+
+          const retryResponse = await this.httpClient.forward(targetUrl, {
+            method: req.method!,
+            headers: context.headers,
+            body: context.requestBody || undefined
+          });
+
+          const retryMetadata = await this.streamResponse(context, retryResponse, res, startTime);
+          await this.runHook('onResponseComplete', interceptor =>
+            interceptor.onResponseComplete?.(context, retryMetadata)
+          );
+          return;
+        }
+
+        this.sendSessionExpiredResponse(res, context);
+        return;
+      }
 
       // 5. Stream response to client
       logger.debug(`[proxy] Starting response streaming for ${context.requestId}`);
@@ -641,5 +677,64 @@ export class CodeMieProxy {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Attempt SSO re-authentication when session has expired mid-session.
+   * Returns true if re-auth succeeded, false otherwise.
+   */
+  private async attemptSSOReauth(): Promise<boolean> {
+    if (this.config.authMethod === 'jwt') {
+      return false;
+    }
+
+    const codeMieUrl = this.config.profileConfig?.codeMieUrl || this.config.targetApiUrl;
+
+    try {
+      logger.warn('[proxy] Session expired mid-session — opening browser for re-authentication');
+      process.stderr.write(
+        '\n⚠️  Session expired. Opening browser for re-authentication...\n'
+      );
+
+      const { CodeMieSSO } = await import('../sso.auth.js');
+      const sso = new CodeMieSSO();
+      const result = await sso.authenticate({ codeMieUrl, timeout: 120000 });
+
+      if (result.success) {
+        process.stderr.write('✅ Re-authentication successful — retrying your request.\n\n');
+        logger.info('[proxy] SSO re-authentication succeeded — retrying original request');
+        return true;
+      }
+
+      logger.warn('[proxy] SSO re-authentication failed', { error: result.error });
+      return false;
+    } catch (error) {
+      logger.error('[proxy] SSO re-authentication threw an error', error);
+      return false;
+    }
+  }
+
+  /**
+   * Send a well-formed Anthropic authentication_error JSON response when
+   * session expiry re-auth is not possible or has failed.
+   */
+  private sendSessionExpiredResponse(res: ServerResponse, context: ProxyContext): void {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'authentication_error',
+        message: 'Your session has expired. To re-authenticate, run: codemie profile login',
+      },
+    });
+
+    res.statusCode = 401;
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Length', String(Buffer.byteLength(body)));
+    res.end(body);
+
+    logger.warn(
+      '[proxy] Sent session-expired error response to client. Run: codemie profile login',
+      { requestId: context.requestId }
+    );
   }
 }

--- a/tests/e2e/sso/session-expiry.e2e.test.ts
+++ b/tests/e2e/sso/session-expiry.e2e.test.ts
@@ -1,0 +1,180 @@
+/**
+ * E2E Tests: SSO Session Expiry Handling
+ *
+ * True end-to-end: real CodeMieProxy + real mock upstream HTTP server.
+ * Zero vi.mock() — the full proxy stack runs as-is.
+ *
+ * Scenarios:
+ *   E1 — upstream 401 → proxy returns HTTP 401 + Anthropic authentication_error JSON
+ *   E2 — upstream 403 → proxy returns HTTP 401 + Anthropic authentication_error JSON
+ *   E3 — upstream 200 → proxy passes response through intact (regression guard)
+ *
+ * @group e2e
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer } from 'node:http';
+import type { Server, IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { CodeMieProxy } from '../../../src/providers/plugins/sso/proxy/sso.proxy.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function startMockUpstream(
+  handler: (req: IncomingMessage, res: ServerResponse) => void
+): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer(handler);
+    server.on('error', reject);
+    server.listen(0, 'localhost', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://localhost:${port}` });
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+}
+
+async function startProxyAgainst(upstreamUrl: string): Promise<{ proxy: CodeMieProxy; url: string }> {
+  const proxy = new CodeMieProxy({
+    targetApiUrl: upstreamUrl,
+    authMethod: 'jwt',
+    jwtToken: 'e2e-test-token',
+    sessionId: 'e2e-session',
+  });
+  const { url } = await proxy.start();
+  return { proxy, url };
+}
+
+// ---------------------------------------------------------------------------
+// E1 — upstream returns 401
+// ---------------------------------------------------------------------------
+
+describe('E1: upstream 401 → clean authentication_error response', () => {
+  let upstream: Server;
+  let proxy: CodeMieProxy;
+  let proxyUrl: string;
+
+  beforeAll(async () => {
+    const mock = await startMockUpstream((_req, res) => {
+      res.statusCode = 401;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Token expired' }));
+    });
+    upstream = mock.server;
+    ({ proxy, url: proxyUrl } = await startProxyAgainst(mock.url));
+  });
+
+  afterAll(async () => {
+    await proxy.stop();
+    await stopServer(upstream);
+  });
+
+  it('returns HTTP 401', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('sets Content-Type to application/json', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('body has type === "error"', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.type).toBe('error');
+  });
+
+  it('body.error.type === "authentication_error"', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    const body = await res.json() as { error: { type: string; message: string } };
+    expect(body.error.type).toBe('authentication_error');
+  });
+
+  it('body.error.message references "codemie profile login"', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    const body = await res.json() as { error: { type: string; message: string } };
+    expect(body.error.message).toContain('codemie profile login');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2 — upstream returns 403
+// ---------------------------------------------------------------------------
+
+describe('E2: upstream 403 → clean authentication_error response', () => {
+  let upstream: Server;
+  let proxy: CodeMieProxy;
+  let proxyUrl: string;
+
+  beforeAll(async () => {
+    const mock = await startMockUpstream((_req, res) => {
+      res.statusCode = 403;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+    });
+    upstream = mock.server;
+    ({ proxy, url: proxyUrl } = await startProxyAgainst(mock.url));
+  });
+
+  afterAll(async () => {
+    await proxy.stop();
+    await stopServer(upstream);
+  });
+
+  it('returns HTTP 401', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('body.error.type === "authentication_error"', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    const body = await res.json() as { error: { type: string } };
+    expect(body.error.type).toBe('authentication_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E3 — upstream returns 200 — passthrough regression guard
+// ---------------------------------------------------------------------------
+
+describe('E3: upstream 200 → proxy passes response through intact', () => {
+  let upstream: Server;
+  let proxy: CodeMieProxy;
+  let proxyUrl: string;
+
+  const UPSTREAM_BODY = { id: 'msg_01', type: 'message', content: [] };
+
+  beforeAll(async () => {
+    const mock = await startMockUpstream((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(UPSTREAM_BODY));
+    });
+    upstream = mock.server;
+    ({ proxy, url: proxyUrl } = await startProxyAgainst(mock.url));
+  });
+
+  afterAll(async () => {
+    await proxy.stop();
+    await stopServer(upstream);
+  });
+
+  it('passes through HTTP 200', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes through the upstream JSON body intact', async () => {
+    const res = await fetch(`${proxyUrl}/v1/messages`, { method: 'POST' });
+    const body = await res.json();
+    expect(body).toMatchObject(UPSTREAM_BODY);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `SessionExpiryHandlerPlugin` that detects upstream 401/403 responses and sets `context.metadata.sessionExpired = true` via the `onResponseHeaders` hook, preventing the raw 401 body from reaching Bun/JSC and causing the `undefined is not an object (evaluating '_.input_tokens')` crash
- Modifies `sso.proxy.ts` to drain the 401 body after session expiry is detected, attempt SSO re-authentication (`attemptSSOReauth`), retry the original request with fresh cookies on success, or fall back to a clean Anthropic `authentication_error` JSON response
- JWT auth method bypasses re-auth entirely and goes straight to the clean error response
- Registers the plugin at priority 20 in the plugin registry (before `SSOSessionSyncPlugin` at priority 100)
- Adds first e2e tests for the proxy: real `CodeMieProxy` + real mock upstream HTTP server, zero `vi.mock()`, covering upstream 401/403/200 scenarios
- Adds `npm run test:e2e` script and wires it into the `ci` script and the Ubuntu GitHub Actions job

Closes EPMCDME-12317

## Changes

| File | Change |
|------|--------|
| `src/providers/plugins/sso/proxy/plugins/session-expiry-handler.plugin.ts` | New — detection plugin |
| `src/providers/plugins/sso/proxy/plugins/__tests__/session-expiry-handler.plugin.test.ts` | New — 13 unit tests (S1–S5, S8) |
| `src/providers/plugins/sso/proxy/plugins/index.ts` | Register `SessionExpiryHandlerPlugin` |
| `src/providers/plugins/sso/proxy/sso.proxy.ts` | Add `upstreamStatusCode` propagation, session-expiry short-circuit, `attemptSSOReauth`, `sendSessionExpiredResponse` |
| `src/providers/plugins/sso/proxy/__tests__/sso.proxy.session-expiry.test.ts` | New — 9 unit tests (S6, S7) |
| `tests/e2e/sso/session-expiry.e2e.test.ts` | New — 9 e2e tests (E1/E2/E3), zero mocks |
| `package.json` | Add `test:e2e` script, wire into `ci` |
| `.github/workflows/ci.yml` | Add e2e step to `test-ubuntu` job |

## Test plan

- [x] `npm run test:unit` — 104 files, 1708 passed, 1 skipped
- [x] `npm run test:e2e` — 1 file, 9 passed
- [x] Unit: `SessionExpiryHandlerPlugin` sets `sessionExpired=true` on 401/403, no-op on 200/500/absent
- [x] Unit: `sendSessionExpiredResponse` returns HTTP 401 with valid Anthropic `authentication_error` JSON
- [x] Unit: `attemptSSOReauth` returns `false` immediately for `authMethod === 'jwt'`
- [x] E2E: upstream 401 → proxy 401 + `authentication_error` JSON (no Bun/JSC crash)
- [x] E2E: upstream 403 → same
- [x] E2E: upstream 200 → passthrough intact