### PR TITLE
fix(skills): sanitize XSS sinks in msgraph.js OAuth callback

### DIFF
--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -155,6 +155,16 @@ function saveCache(data) {
   fs.writeFileSync(CACHE_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
 }
 
+// ── HTML helpers ──────────────────────────────────────────────────────────────
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 // ── PKCE helpers ──────────────────────────────────────────────────────────────
 function generatePKCE() {
   const verifier  = crypto.randomBytes(32).toString('base64url');
@@ -206,8 +216,8 @@ function startLocalServer() {
                </body></html>`
             : `<!DOCTYPE html><html><head><title>Login failed</title></head><body style="font-family:sans-serif;padding:40px">
                 <h2 style="color:#d13438">&#10007; Authentication failed</h2>
-                <p><strong>${error || 'Unknown error'}</strong></p>
-                <p>${desc || ''}</p>
+                <p><strong>${error ? escapeHtml(error) : 'Unknown error'}</strong></p>
+                <p>${desc ? escapeHtml(desc) : ''}</p>
                </body></html>`;
 
           response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });


### PR DESCRIPTION
## Summary

Fixes reflected XSS vulnerability (CWE-79) detected by SnykSAST in the Microsoft Graph OAuth PKCE callback handler. Unsanitized `error` and `error_description` URL query parameters were directly interpolated into an HTML response rendered in the user's browser.

Closes EPMCDME-12208

## Changes

- Added `escapeHtml` helper in `msgraph.js` that encodes `&`, `<`, `>`, `"`, `'`
- Applied escaping to both XSS sinks: `error` (line 219) and `error_description` / `desc` (line 220) before HTML interpolation in the OAuth error page

## Impact

Before: `?error=<script>alert(1)</script>` would execute in the browser
After: rendered as safe escaped text — `&lt;script&gt;alert(1)&lt;/script&gt;`

## Checklist

- [ ] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)