### PR TITLE
fix(analytics): resolve Claude Desktop sessions showing sandbox path as repository name

### DIFF
--- a/src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.ts
@@ -63,7 +63,7 @@ export function aggregateDeltas(
   const deltasByBranch = new Map<string, MetricDelta[]>();
 
   for (const delta of deltas) {
-    const branch = delta.gitBranch || 'unknown';
+    const branch = delta.gitBranch || '';
 
     if (!deltasByBranch.has(branch)) {
       deltasByBranch.set(branch, []);

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
@@ -350,7 +350,7 @@ export class MetricsSender {
       llm_model: session.model || 'unknown', // From profile config
       repository,
       session_id: session.sessionId,
-      branch: branch || 'unknown',
+      branch: branch || '',
       ...(session.project && { project: session.project }),
 
       // Session metadata
@@ -489,7 +489,7 @@ export class MetricsSender {
       llm_model: session.model || 'unknown',
       repository,
       session_id: session.sessionId,
-      branch: branch || 'unknown',
+      branch: branch || '',
       ...(session.project && { project: session.project }),
 
       // Session metadata

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-sync-processor.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-sync-processor.ts
@@ -183,7 +183,7 @@ export class MetricsSyncProcessor implements SessionProcessor {
 
       for (const metric of metrics) {
         const branchDeltas = pendingDeltas.filter((delta) =>
-          (delta.gitBranch || 'unknown') === metric.attributes.branch
+          (delta.gitBranch || '') === metric.attributes.branch
         );
 
         try {

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -14,6 +14,7 @@ import {
   matchesPathStructure,
   validatePathDepth,
   getDirname,
+  extractRepository,
 } from '../paths.js';
 
 // Test-only helper functions
@@ -251,6 +252,71 @@ describe('Path Utilities - Cross-Platform', () => {
 
       expect(findDirectoryIndex(path, '.claude')).toBe(3);
       expect(getFilename(path)).toBe('file.jsonl');
+    });
+  });
+
+  describe('extractRepository', () => {
+    describe('normal project paths — unchanged', () => {
+      it('should return last two segments for a standard project path', () => {
+        expect(extractRepository('/Users/alice/projects/codemie-code')).toBe('projects/codemie-code');
+      });
+
+      it('should return last two segments for a deeply nested path', () => {
+        expect(extractRepository('/home/user/work/epam/codemie-ui')).toBe('epam/codemie-ui');
+      });
+
+      it('should return single segment when path has only one meaningful part', () => {
+        expect(extractRepository('/myrepo')).toBe('myrepo');
+      });
+
+      it('should handle Windows-style paths', () => {
+        expect(extractRepository('C:\\Users\\alice\\projects\\codemie-code')).toBe('projects/codemie-code');
+      });
+    });
+
+    describe('Claude Desktop sandbox paths — return Claude Desktop', () => {
+      it('should detect real Desktop sandbox path observed in logs', () => {
+        const path = '/Users/mykola/Library/Application Support/Claude-3p/local-agent-mode-sessions/759182a5-1458-46d1-92e3-d6b6bc1262bd/00000000-0000-4000-8000-000000000001/local_2d5f3a0f-6a50-4778-ac55-9ffbca0446da/outputs';
+        expect(extractRepository(path)).toBe('Claude Desktop');
+      });
+
+      it('should detect sandbox path with different UUID', () => {
+        const path = '/Users/alice/Library/Application Support/Claude-3p/local-agent-mode-sessions/abc/def/local_7fb4c6a0-a7b9-4121-960c-035d0e4830ff/outputs';
+        expect(extractRepository(path)).toBe('Claude Desktop');
+      });
+
+      it('should detect sandbox path ending at the local_<uuid> directory itself', () => {
+        const path = '/some/path/local_74f67be8-ddc7-44c4-a911-1d6cd034ec9d';
+        expect(extractRepository(path)).toBe('Claude Desktop');
+      });
+
+      it('should detect sandbox path with a project subfolder inside outputs', () => {
+        const path = '/Users/alice/Library/Application Support/Claude-3p/local-agent-mode-sessions/s/u/local_95002bb5-744b-4b94-b87b-711c0ebf7a47/outputs/my-project';
+        expect(extractRepository(path)).toBe('Claude Desktop');
+      });
+
+      it('should be case-insensitive for hex digits', () => {
+        const path = '/some/path/local_2D5F3A0F-6A50-4778-AC55-9FFBCA0446DA/outputs';
+        expect(extractRepository(path)).toBe('Claude Desktop');
+      });
+    });
+
+    describe('false-positive guard — must NOT match legitimate project names', () => {
+      it('should NOT match a project named local_ with only 8 hex chars (no UUID dashes)', () => {
+        expect(extractRepository('/home/alice/work/local_deadbeef')).toBe('work/local_deadbeef');
+      });
+
+      it('should NOT match local_cafebabe (8 hex, no dashes)', () => {
+        expect(extractRepository('/home/alice/projects/local_cafebabe/src')).toBe('local_cafebabe/src');
+      });
+
+      it('should NOT match a directory starting with local_ but containing non-hex chars', () => {
+        expect(extractRepository('/home/alice/local_myproject/src')).toBe('local_myproject/src');
+      });
+
+      it('should NOT match a UUID-like name that lacks the local_ prefix', () => {
+        expect(extractRepository('/home/alice/2d5f3a0f-6a50-4778-ac55-9ffbca0446da/outputs')).toBe('2d5f3a0f-6a50-4778-ac55-9ffbca0446da/outputs');
+      });
     });
   });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -375,14 +375,26 @@ export function getCodemiePath(...paths: string[]): string {
   return path.join(getCodemieHome(), ...paths);
 }
 
+// Matches Claude Desktop sandbox session directories: local_<8-hex-chars>
+const CLAUDE_DESKTOP_SANDBOX_RE = /(?:^|\/)local_[0-9a-f]{8}(?:[^/]*)(?:\/|$)/i;
+
 /**
  * Extract parent/repo format from a working directory path.
+ * Returns 'Claude Desktop' for sandbox paths used by Claude Desktop sessions.
  *
  * @example
  * extractRepository('/Users/john/projects/codemie-code')
  * // Returns: 'projects/codemie-code'
+ *
+ * @example
+ * extractRepository('/.../.../local_7fb4c6a0-c9f0-4b3e-8c1a-2d5e6f7a8b9c/outputs')
+ * // Returns: 'Claude Desktop'
  */
 export function extractRepository(workingDirectory: string): string {
+  if (CLAUDE_DESKTOP_SANDBOX_RE.test(normalizePathSeparators(workingDirectory))) {
+    return 'Claude Desktop';
+  }
+
   const parts = splitPath(workingDirectory);
   const filtered = parts.filter(p => p.length > 0);
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -375,8 +375,12 @@ export function getCodemiePath(...paths: string[]): string {
   return path.join(getCodemieHome(), ...paths);
 }
 
-// Matches Claude Desktop sandbox session directories: local_<8-hex-chars>
-const CLAUDE_DESKTOP_SANDBOX_RE = /(?:^|\/)local_[0-9a-f]{8}(?:[^/]*)(?:\/|$)/i;
+// Matches Claude Desktop sandbox session directories.
+// Real path format observed in logs:
+//   .../local-agent-mode-sessions/<session-uuid>/<uuid>/local_<full-uuid>/outputs
+// The local_ segment always contains a full UUID (8-4-4-4-12 hex groups with dashes).
+// Matching the full UUID format avoids false positives on user directories named local_<8hex>.
+const CLAUDE_DESKTOP_SANDBOX_RE = /\/local_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\/|$)/i;
 
 /**
  * Extract parent/repo format from a working directory path.
@@ -387,7 +391,7 @@ const CLAUDE_DESKTOP_SANDBOX_RE = /(?:^|\/)local_[0-9a-f]{8}(?:[^/]*)(?:\/|$)/i;
  * // Returns: 'projects/codemie-code'
  *
  * @example
- * extractRepository('/.../.../local_7fb4c6a0-c9f0-4b3e-8c1a-2d5e6f7a8b9c/outputs')
+ * extractRepository('/Users/john/Library/Application Support/Claude-3p/local-agent-mode-sessions/<s>/<u>/local_2d5f3a0f-6a50-4778-ac55-9ffbca0446da/outputs')
  * // Returns: 'Claude Desktop'
  */
 export function extractRepository(workingDirectory: string): string {


### PR DESCRIPTION
## Summary

Claude Desktop sessions were showing `local_<uuid>/outputs` (the macOS sandbox path) as the repository name in CodeMie analytics, and sessions without a detectable git branch were showing `unknown` as a branch entry instead of nothing.

Two targeted fixes:

1. **`extractRepository()`** — detect Claude Desktop sandbox paths via regex and return `'Claude Desktop'` instead of the raw path.
2. **Branch fallback** — replace `|| 'unknown'` with `|| ''` in all 4 metric call sites so the backend's Python falsy-filter removes branchless sessions from the `branches` list entirely.

---

## Changes

| File | What changed |
|---|---|
| `src/utils/paths.ts` | Added `CLAUDE_DESKTOP_SANDBOX_RE` regex guard in `extractRepository()` |
| `src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.ts` | Branch grouping fallback `''` (was `'unknown'`) |
| `src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts` | Branch attribute fallback `''` in `sendSessionStart` + `sendSessionEnd` |
| `src/providers/plugins/sso/session/processors/metrics/metrics-sync-processor.ts` | Branch match fallback `''` for delta-to-metric correlation |

---

## Spec

Full technical spec including root cause analysis, data flow for all scenarios, backend compatibility notes, and non-goals:

[claude-desktop-analytics-repository-fix.md](https://github.com/user-attachments/files/28110400/claude-desktop-analytics-repository-fix.md)


---

## QA Guide

Step-by-step instructions for reproducing and verifying all 7 scenarios (Desktop no folder, Desktop with folder, CLI on main, CLI on feature branch, CLI no remote, global terminal):

[qa-guide-claude-desktop-analytics-repository-fix.md](https://github.com/user-attachments/files/28110404/qa-guide-claude-desktop-analytics-repository-fix.md)



---

## Screenshots

<img width="1944" height="1254" alt="img" src="https://github.com/user-attachments/assets/c75da888-8f5c-4067-8d59-90bbd881a479" />


---

Resolves EPMCDME-12308