### PR TITLE
feat(cli): add postinstall script to auto-configure PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "postinstall": "node scripts/postinstall.mjs",
     "build": "tsc && tsc-alias && npm run copy-plugin",
     "copy-plugin": "node scripts/copy-plugins.js",
     "prepare:install-artifacts": "node scripts/prepare-install-artifacts.mjs",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, appendFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function getNpmBinDir() {
+  try {
+    const prefix = execSync('npm config get prefix', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    return join(prefix, 'bin');
+  } catch {
+    return null;
+  }
+}
+
+function getShellRcFile() {
+  const shell = process.env.SHELL ?? '';
+  const home = homedir();
+  if (shell.includes('zsh')) return join(home, '.zshrc');
+  if (shell.includes('bash')) {
+    const bashProfile = join(home, '.bash_profile');
+    return existsSync(bashProfile) ? bashProfile : join(home, '.bashrc');
+  }
+  return null;
+}
+
+function isInPath(dir) {
+  return (process.env.PATH ?? '').split(':').includes(dir);
+}
+
+function alreadyInRcFile(rcFile, dir) {
+  if (!existsSync(rcFile)) return false;
+  return readFileSync(rcFile, 'utf8').includes(dir);
+}
+
+const npmBin = getNpmBinDir();
+if (!npmBin) process.exit(0);
+
+if (isInPath(npmBin)) process.exit(0);
+
+const rcFile = getShellRcFile();
+if (!rcFile) {
+  console.log(`\n⚠️  Add to PATH manually:\n   export PATH="${npmBin}:$PATH"\n`);
+  process.exit(0);
+}
+
+if (alreadyInRcFile(rcFile, npmBin)) process.exit(0);
+
+appendFileSync(rcFile, `\n# Added by @codemieai/code\nexport PATH="${npmBin}:$PATH"\n`);
+
+console.log(`\n✓ Added ${npmBin} to PATH in ${rcFile}`);
+console.log(`  Run: source ${rcFile}\n`);


### PR DESCRIPTION
## Summary

- Adds `scripts/postinstall.mjs` — runs automatically after `npm install` via the `postinstall` lifecycle hook
- Detects the npm bin directory via `npm config get prefix`
- Checks if the bin directory is already in `PATH` or already written to the shell rc file
- If not, appends `export PATH="<npmBin>:$PATH"` to `.zshrc`, `.bash_profile`, or `.bashrc`
- Prints a friendly message prompting the user to `source` the rc file

## Test plan

- [x] Install package in a fresh environment where npm bin is not in PATH — verify rc file is updated and message is printed
- [x] Install again — verify script exits without duplicating the PATH entry
- [x] Test on zsh and bash shells
- [x] Verify no changes when npm bin is already in PATH

🤖 Generated with [Claude Code](https://claude.ai/claude-code)