### PR TITLE
feat: separate API errors from tool errors in metrics

### DIFF
--- a/src/agents/plugins/claude/session/processors/claude.metrics-processor.ts
+++ b/src/agents/plugins/claude/session/processors/claude.metrics-processor.ts
@@ -303,6 +303,10 @@ export class MetricsProcessor implements SessionProcessor {
 
       const recordId = messages[0].uuid;
 
+      const apiErrorMessage = completedMsg.isApiErrorMessage && completedMsg.message?.content?.[0]?.text
+        ? completedMsg.message.content[0].text
+        : undefined;
+
       const delta: Omit<MetricDelta, 'syncStatus' | 'syncAttempts'> = {
         recordId,
         sessionId,
@@ -311,7 +315,8 @@ export class MetricsProcessor implements SessionProcessor {
         gitBranch: completedMsg.gitBranch,
         ...(Object.keys(tools).length > 0 && { tools }),
         ...(Object.keys(toolStatus).length > 0 && { toolStatus }),
-        ...(completedMsg.message?.model && { models: [completedMsg.message.model] })
+        ...(completedMsg.message?.model && { models: [completedMsg.message.model] }),
+        ...(apiErrorMessage && { apiErrorMessage })
       };
 
       if (fileOperations.length > 0) {

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.ts
@@ -136,6 +136,7 @@ function buildSessionAttributes(
   let hadErrors = false;
   const errorToolSet = new Set<string>(); // deduped
   const errorMessages: string[] = [];
+  const apiErrors: string[] = [];
 
   // Aggregate all deltas
   for (const delta of deltas) {
@@ -189,17 +190,24 @@ function buildSessionAttributes(
     if (delta.apiErrorMessage) {
       hadErrors = true;
 
-      if (delta.toolStatus) {
-        for (const [toolName, status] of Object.entries(delta.toolStatus)) {
+      const hasToolErrors = delta.toolStatus &&
+        Object.values(delta.toolStatus).some(status => status.failure > 0);
+
+      if (hasToolErrors) {
+        for (const [toolName, status] of Object.entries(delta.toolStatus ?? {})) {
           if (status.failure > 0) {
             const clean = sanitizeToolNameForError(toolName);
             if (clean) errorToolSet.add(clean);
           }
         }
-      }
 
-      if (errorMessages.length < ERROR_MESSAGES_CAP) {
-        errorMessages.push(sanitizeErrorMessage(delta.apiErrorMessage));
+        if (errorMessages.length < ERROR_MESSAGES_CAP) {
+          errorMessages.push(sanitizeErrorMessage(delta.apiErrorMessage));
+        }
+      } else {
+        if (apiErrors.length < ERROR_MESSAGES_CAP) {
+          apiErrors.push(sanitizeErrorMessage(delta.apiErrorMessage));
+        }
       }
     }
   }
@@ -261,6 +269,7 @@ function buildSessionAttributes(
     const tools = [...errorToolSet].slice(0, ERROR_TOOLS_CAP);
     if (tools.length > 0) attributes.error_tools = tools;
     if (errorMessages.length > 0) attributes.error_messages = errorMessages;
+    if (apiErrors.length > 0) attributes.api_errors = apiErrors;
   }
 
   return attributes;

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-post-processor.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-post-processor.ts
@@ -46,6 +46,13 @@ export function postProcessMetric(
     if (!attrs.error_tools?.length) {
       delete attrs.error_tools;
       delete attrs.error_messages;
+    }
+
+    if (!attrs.api_errors?.length) {
+      delete attrs.api_errors;
+    }
+
+    if (!attrs.error_tools && !attrs.error_messages && !attrs.api_errors) {
       sanitized.attributes.had_errors = false;
     }
   }

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-types.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-types.ts
@@ -33,6 +33,7 @@ export interface SessionLifecycleAttributes extends MetricIdentity {
   had_errors: boolean;
   error_tools?: string[];    // unique tool names that errored (v2, replaces errors dict)
   error_messages?: string[]; // flat list of error messages (v2, replaces errors dict)
+  api_errors?: string[];     // API/infrastructure errors (e.g. model failures, not tool-related)
   schema_version?: number;   // 2 = v2 shape; absent/1 = legacy
 
   // MCP fields (optional, only at session start)
@@ -85,6 +86,7 @@ export interface ToolUsageAttributes extends MetricIdentity {
   had_errors: boolean;
   error_tools?: string[];    // unique tool names that errored (v2, replaces errors dict)
   error_messages?: string[]; // flat list of error messages (v2, replaces errors dict)
+  api_errors?: string[];     // API/infrastructure errors (e.g. model failures, not tool-related)
   schema_version?: number;   // 2 = v2 shape; absent/1 = legacy
 
   // Tool metrics — tool_counts is intentionally not emitted (backend/Elastic pipeline

--- a/tests/integration/metrics/metrics-post-processing.test.ts
+++ b/tests/integration/metrics/metrics-post-processing.test.ts
@@ -107,6 +107,7 @@ describe('Metrics Post-Processing Integration', () => {
     expect(metric.attributes.had_errors).toBe(false);
     expect((metric.attributes as any).error_tools).toBeUndefined();
     expect((metric.attributes as any).error_messages).toBeUndefined();
+    expect((metric.attributes as any).api_errors).toBeUndefined();
 
     // Check user prompts
     expect(metric.attributes.total_user_prompts).toBe(1);


### PR DESCRIPTION
## Problem

When API calls fail, Claude saves `<synthetic>` as model in session. Current code does not handle this and sets `had_errors: false`, so backend cannot filter out these sessions from analytics.

## Solution

- Add `api_errors` field to separate API/infrastructure errors from tool errors
- Tool errors (with failed tools in toolStatus) go to `error_messages` + `error_tools`
- API errors (no failed tools) go to `api_errors` only
- Post-processor preserves `api_errors` when tool errors are filtered

Backend filters by `had_errors: false`, so sessions with API errors are now excluded from analytics.