### PR TITLE
fix(agents): treat bare positional args as run task in codemie-code

### DIFF
--- a/src/agents/plugins/codemie-code.plugin.ts
+++ b/src/agents/plugins/codemie-code.plugin.ts
@@ -392,6 +392,13 @@ export const CodeMieCodePluginMetadata: AgentMetadata = {
         });
         return ['run', ...otherArgs, taskValue];
       }
+
+      // Bare positional args without a subcommand or --task are treated as a direct message.
+      // Without this, the underlying binary interprets the first arg as a directory to chdir into.
+      if (args.length > 0) {
+        return ['run', ...args];
+      }
+
       return args;
     },
 


### PR DESCRIPTION
## Summary

When a user runs `codemie-code "some prompt"` (passing a bare string argument without any flags), OpenCode receives it as a positional argument and misinterprets it as a working directory path, producing:

```
Error: Failed to change directory to C:\Users\...\some prompt
```

This fix makes `enrichArgs` detect bare positional arguments and prepend the `run` subcommand so they are routed correctly as a one-shot task.

## Changes

- `src/agents/plugins/codemie-code.plugin.ts`: Added a third case to `enrichArgs` — when the first argument is not a known subcommand and does not start with `-`, prefix args with `run` so `opencode run "<prompt>"` is executed instead of `opencode "<prompt>"`

## Impact

**Before:**
```
codemie-code "What's inside the folder?"
→ opencode "What's inside the folder?"
→ Error: Failed to change directory to ...\What's inside the folder?
```

**After:**
```
codemie-code "What's inside the folder?"
→ opencode run "What's inside the folder?"
→ ✅ Executes as a one-shot task
```

Existing flows (`--task`, explicit subcommands like `run`/`chat`) are unaffected.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)