### PR TITLE
fix(config): highlight codemie setup command in error message

### DIFF
--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -296,7 +296,7 @@ export class AgentCLI {
       // Show user-friendly error message in console first
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`\n✗ Failed to run ${this.adapter.displayName}\n`));
-      console.error(chalk.white(errorMessage));
+      console.error(errorMessage);
       console.error('');
 
       // Log detailed error for debugging

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -202,7 +202,7 @@ export class ConfigLoader {
         }
         const availableProfiles = Object.keys(rawConfig.profiles);
         if (availableProfiles.length === 0) {
-          throw new Error('No profiles configured. Run: codemie setup');
+          throw new Error(`No profiles configured. Run: ${chalk.cyan('codemie setup')}`);
         }
         throw new Error(
           `Profile "${profile}" not found. Available profiles: ${availableProfiles.join(', ')}`


### PR DESCRIPTION
## Summary
When no profiles are configured, the error message now renders `codemie setup` in cyan so users immediately see the exact command they need to run.

## Changes
- `src/utils/config.ts`: wrap `codemie setup` in `chalk.cyan()` in the \"No profiles configured\" error
- `src/agents/core/AgentCLI.ts`: remove `chalk.white()` wrapper around `errorMessage` so chalk codes from the error string are preserved when printed

## Test Plan
- [ ] Run `codemie-code` with no profiles configured — verify `codemie setup` appears in cyan
- [ ] Verify no regression in other error messages