### PR TITLE
fix: prevent error message leakage and add GCM-capable decrypt in standalone scripts

### DIFF
--- a/src/agents/plugins/claude/plugin/skills/codemie-analytics/scripts/analytics-cli.js
+++ b/src/agents/plugins/claude/plugin/skills/codemie-analytics/scripts/analytics-cli.js
@@ -125,16 +125,20 @@ function getAESKey() {
 }
 
 function decrypt(text) {
-  const colonIndex = text.indexOf(':');
-  if (colonIndex === -1) return null;
-  const ivHex = text.slice(0, colonIndex);
-  const encryptedHex = text.slice(colonIndex + 1);
-  const iv = Buffer.from(ivHex, 'hex');
+  const parts = text.split(':');
+  if (parts.length < 2) return null;
   const key = getAESKey();
+  if (parts.length === 3) {
+    const iv = Buffer.from(parts[0], 'hex');
+    const authTag = Buffer.from(parts[1], 'hex');
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    return decipher.update(parts[2], 'hex', 'utf8') + decipher.final('utf8');
+  }
+  // Legacy CBC format: iv:encrypted (backward compat for existing stored credentials)
+  const iv = Buffer.from(parts[0], 'hex');
   const decipher = createDecipheriv('aes-256-cbc', key, iv);
-  let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
-  decrypted += decipher.final('utf8');
-  return decrypted;
+  return decipher.update(parts[1], 'hex', 'utf8') + decipher.final('utf8');
 }
 
 function readEncryptedFile(filePath) {

--- a/src/agents/plugins/claude/plugin/statusline.mjs
+++ b/src/agents/plugins/claude/plugin/statusline.mjs
@@ -20,10 +20,18 @@ const ENCRYPTION_KEY = (() => {
 })();
 
 function decrypt(text) {
-  const [ivHex, encHex] = text.split(':');
-  const iv = Buffer.from(ivHex, 'hex');
+  const parts = text.split(':');
+  if (parts.length === 3) {
+    const iv = Buffer.from(parts[0], 'hex');
+    const authTag = Buffer.from(parts[1], 'hex');
+    const d = crypto.createDecipheriv('aes-256-gcm', ENCRYPTION_KEY, iv);
+    d.setAuthTag(authTag);
+    return d.update(parts[2], 'hex', 'utf8') + d.final('utf8');
+  }
+  // Legacy CBC format: iv:encrypted (backward compat for existing stored credentials)
+  const iv = Buffer.from(parts[0], 'hex');
   const d = crypto.createDecipheriv('aes-256-cbc', ENCRYPTION_KEY, iv);
-  return d.update(encHex, 'hex', 'utf8') + d.final('utf8');
+  return d.update(parts[1], 'hex', 'utf8') + d.final('utf8');
 }
 
 function urlHash(rawUrl) {

--- a/src/providers/plugins/sso/proxy/proxy-errors.ts
+++ b/src/providers/plugins/sso/proxy/proxy-errors.ts
@@ -102,7 +102,7 @@ export function normalizeError(error: unknown, context?: Record<string, unknown>
 
     // Generic error
     return new ProxyError(
-      error.message,
+      'An internal server error occurred',
       500,
       'INTERNAL_ERROR',
       {
@@ -114,7 +114,7 @@ export function normalizeError(error: unknown, context?: Record<string, unknown>
 
   // Unknown error type
   return new ProxyError(
-    String(error),
+    'An unexpected error occurred',
     500,
     'UNKNOWN_ERROR',
     { originalError: String(error), ...context }


### PR DESCRIPTION
## Summary

Two unrelated security fixes flagged by Snyk SAST, bundled in this branch.

---

### Fix 1 — Raw error messages leaking in HTTP responses (EPMCDME-12206, EPMCDME-12207)

Raw error strings (`error.message` / `String(error)`) were flowing through `normalizeError()`
into the public-facing `message` field of `ProxyError`, which `toJSON()` serializes directly
into HTTP responses.

- `normalizeError()` in `proxy-errors.ts`: replaced raw error content for `INTERNAL_ERROR` and
  `UNKNOWN_ERROR` cases with safe generic strings
- Real error content is preserved in `details.originalError` — excluded from `toJSON()` — so
  internal logging is unaffected
- `NetworkError` and `TimeoutError` messages unchanged (operational info, not flagged)

Before: `{ "error": { "message": "Cannot read property 'x' of undefined", ... } }` leaked to client
After:  `{ "error": { "message": "An internal server error occurred", ... } }`

---

### Fix 2 — AES-256-CBC without integrity in standalone scripts (EPMCDME-12554, EPMCDME-12555)

Two standalone scripts (`analytics-cli.js`, `statusline.mjs`) read locally-stored credential
files using AES-256-CBC only. The main `CredentialStore` (`src/utils/security.ts`) already
migrated its writes to AES-256-GCM, but these scripts were never updated:

1. **Security:** CBC mode provides no integrity check — tampered ciphertext decrypts silently.
2. **Functional:** Scripts couldn't read GCM-format credentials, causing silent auth failures
   on fresh installs.

Both `decrypt` functions now mirror the dual-format pattern in `security.ts:519-540`:
- 3-part string (`iv:authTag:encrypted`) → AES-256-GCM with auth tag verification
- 2-part string (`iv:encrypted`) → legacy AES-256-CBC for backward compat

---

## Tickets

- EPMCDME-12206, EPMCDME-12207 — proxy error leakage
- EPMCDME-12554 — `analytics-cli.js` CBC-only decrypt
- EPMCDME-12555 — `statusline.mjs` CBC-only decryptges (or clearly documented)