### PR TITLE
fix(agents): pass --version to downstream binary and suppress banners in non-TTY mode

### DIFF
--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -62,7 +62,6 @@ export class AgentCLI {
     this.program
       .name(programName)
       .description(`CodeMie ${this.adapter.displayName} - ${this.adapter.description}`)
-      .version(this.version)
       .option('-s, --silent', 'Enable silent mode')
       .option('--status', 'Enable status bar (shows model, context usage, git branch, and cost)')
       .option('--profile <name>', 'Use specific provider profile')
@@ -158,9 +157,10 @@ export class AgentCLI {
         process.exit(1);
       }
 
-      // Auto-enable silent mode in non-interactive mode (--task flag present)
-      // This suppresses welcome/goodbye messages and interactive prompts
-      const isNonInteractiveMode = !!options.task;
+      // Auto-enable silent mode in non-interactive mode:
+      //   - --task flag is present (explicit single-task invocation)
+      //   - stdout is not a TTY (piped, redirected, or CI environment)
+      const isNonInteractiveMode = !!options.task || !process.stdout.isTTY;
       const shouldBeSilent = options.silent || isNonInteractiveMode;
 
       // Apply silent mode from CLI flag or auto-detected non-interactive mode
@@ -524,6 +524,21 @@ export class AgentCLI {
    * Run the CLI
    */
   async run(argv: string[]): Promise<void> {
+    // Intercept --version / -V before Commander handles it.
+    // We delegate to the downstream agent binary so the user sees the actual
+    // installed agent version rather than the CodeMie wrapper version.
+    const args = argv.slice(2); // strip node + script
+    if (args.includes('--version') || args.includes('-V')) {
+      const agentVersion = await this.adapter.getVersion();
+      if (agentVersion !== null) {
+        console.log(agentVersion);
+      } else {
+        // Fallback: print CodeMie wrapper version when agent version is unavailable
+        console.log(this.version);
+      }
+      process.exit(0);
+    }
+
     await this.program.parseAsync(argv);
   }
 }


### PR DESCRIPTION
## Summary

In order to use `codemie-*` agents with wrappers like https://github.com/pingdotgg/t3code

## Changes

- `--version` option is passed to the downstream binary, so the upstream tool can understand the real version of the harness.
- suppress banners in non-TTY mode. Mostly for `codemie-claude` binary triggered via Claude SDK

## Impact

<!-- Optional: Show before/after examples for user-facing changes -->

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
