### PR TITLE
feat(proxy): self-heal Claude Desktop proxy after sleep

### DIFF
--- a/src/bin/proxy-daemon.ts
+++ b/src/bin/proxy-daemon.ts
@@ -15,6 +15,7 @@ import { ClaudeDesktopTelemetryAdapter } from '../telemetry/clients/claude-deskt
 import { DesktopTelemetryRuntime } from '../telemetry/runtime/DesktopTelemetryRuntime.js';
 import { getDirname } from '../utils/paths.js';
 import { logger } from '../utils/logger.js';
+import { ProxyWatcher } from '../cli/commands/proxy/watcher.js';
 
 function readCliVersion(): string {
   try {
@@ -86,19 +87,42 @@ const config: ProxyConfig = {
   syncCodeMieUrl,
 };
 
-const proxy = new CodeMieProxy(config);
+let proxy = new CodeMieProxy(config);
 let telemetryRuntime: DesktopTelemetryRuntime | undefined;
+let watcher: ProxyWatcher | undefined;
+let currentState: Record<string, unknown> = {};
 
-async function writeStateAtomic(state: object): Promise<void> {
+async function persistState(patch: Record<string, unknown>): Promise<void> {
+  currentState = { ...currentState, ...patch };
   const tmp = stateFile + '.tmp';
-  await writeFile(tmp, JSON.stringify(state, null, 2), 'utf-8');
+  await writeFile(tmp, JSON.stringify(currentState, null, 2), 'utf-8');
   await rename(tmp, stateFile!);
 }
 
 async function cleanup(): Promise<void> {
+  watcher?.stop();
   try { await telemetryRuntime?.stop(); } catch { /* ignore */ }
   try { await proxy.stop(); } catch { /* ignore */ }
   try { await unlink(stateFile!); } catch { /* ignore */ }
+}
+
+async function restartProxy(): Promise<void> {
+  try {
+    await proxy.stop();
+  } catch (error) {
+    logger.warn(`[proxy-daemon] proxy.stop() during restart failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  // Pin to the port we already bound so Claude Desktop's URL stays valid.
+  config.pinnedPort = true;
+  proxy = new CodeMieProxy(config);
+  const { url } = await proxy.start();
+  await persistState({
+    url,
+    health: 'ok',
+    healthReason: undefined,
+    lastHealthyAt: new Date().toISOString(),
+    lastRecoveryAt: new Date().toISOString(),
+  });
 }
 
 process.on('SIGTERM', async () => { await cleanup(); process.exit(0); });
@@ -106,6 +130,12 @@ process.on('SIGINT',  async () => { await cleanup(); process.exit(0); });
 
 try {
   const { port: actualPort, url } = await proxy.start();
+
+  // Pin future restarts to the port we actually bound. The initial bind may
+  // have fallen back to a random port if 4001 was busy; recovery must reuse
+  // whatever URL was written to the Desktop config.
+  config.port = actualPort;
+  config.pinnedPort = true;
 
   if (config.telemetryMode === 'claude-desktop') {
     telemetryRuntime = new DesktopTelemetryRuntime(
@@ -125,7 +155,8 @@ try {
     await telemetryRuntime.start();
   }
 
-  await writeStateAtomic({
+  const nowIso = new Date().toISOString();
+  await persistState({
     pid: process.pid,
     port: actualPort,
     url,
@@ -138,8 +169,31 @@ try {
     telemetryMode,
     syncApiUrl: config.syncApiUrl,
     syncCodeMieUrl: config.syncCodeMieUrl,
-    startedAt: new Date().toISOString(),
+    startedAt: nowIso,
+    health: 'ok',
+    lastHealthyAt: nowIso,
   });
+
+  // Background self-healing watcher: deep-checks every 30s, restarts in-process
+  // on the same pinned port, gives up (records unhealthy) after 3 failures or
+  // on an unrecoverable expired session.
+  watcher = new ProxyWatcher(
+    { port: actualPort, gatewayKey, intervalMs: 30000, maxRestartAttempts: 3 },
+    {
+      restart: restartProxy,
+      onHealthy: async () => {
+        await persistState({
+          health: 'ok',
+          healthReason: undefined,
+          lastHealthyAt: new Date().toISOString(),
+        });
+      },
+      onGiveUp: async (reason) => {
+        await persistState({ health: 'unhealthy', healthReason: reason });
+      },
+    }
+  );
+  watcher.start();
 
   logger.debug(`[proxy-daemon] Started on ${url} (profile: ${profile})`);
 } catch (error) {

--- a/src/cli/commands/proxy/__tests__/health-check.test.ts
+++ b/src/cli/commands/proxy/__tests__/health-check.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkProxyHealth } from '../health-check.js';
+
+vi.mock('@/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const HEALTH = (url: unknown): boolean => String(url).endsWith('/health');
+const MODELS = (url: unknown): boolean => String(url).includes('/v1/llm_models');
+
+describe('checkProxyHealth', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('shallow: returns healthy when /health responds 200', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k' });
+
+    expect(result).toEqual({ healthy: true, level: 'shallow', code: 'ok' });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe('http://127.0.0.1:4001/health');
+  });
+
+  it('shallow: dead-socket when the /health fetch rejects (proxy not listening)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(
+      new Error('connect ECONNREFUSED')
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k' });
+
+    expect(result.healthy).toBe(false);
+    expect(result.level).toBe('shallow');
+    expect(result.code).toBe('dead-socket');
+    expect(result.reason).toContain('ECONNREFUSED');
+  });
+
+  it('shallow: dead-socket when /health returns a non-2xx status', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k' });
+
+    expect(result).toMatchObject({ healthy: false, level: 'shallow', code: 'dead-socket' });
+    expect(result.reason).toContain('503');
+  });
+
+  it('deep: healthy when /health and /v1/llm_models both succeed, with Bearer auth', async () => {
+    const fetchSpy = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      if (MODELS(url)) return { ok: true, status: 200, json: async () => [] };
+      throw new Error(`unexpected url ${String(url)}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'my-key', deep: true });
+
+    expect(result).toEqual({ healthy: true, level: 'deep', code: 'ok' });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const modelsCall = fetchSpy.mock.calls.find(([u]) => MODELS(u));
+    expect(modelsCall).toBeDefined();
+    const init = modelsCall![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer my-key');
+  });
+
+  it('deep: unauthorized when /v1/llm_models returns 401', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      return { ok: false, status: 401 };
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result.healthy).toBe(false);
+    expect(result.level).toBe('deep');
+    expect(result.code).toBe('unauthorized');
+    expect(result.reason).toContain('SSO session expired');
+  });
+
+  it('deep: unauthorized when /v1/llm_models returns 403', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      return { ok: false, status: 403 };
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result.code).toBe('unauthorized');
+  });
+
+  it('deep: upstream-error when /v1/llm_models returns a 5xx', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      return { ok: false, status: 500 };
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result).toMatchObject({ healthy: false, level: 'deep', code: 'upstream-error' });
+    expect(result.reason).toContain('500');
+  });
+
+  it('deep: upstream-error when the models fetch throws', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      throw new Error('socket hang up');
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result).toMatchObject({ healthy: false, level: 'deep', code: 'upstream-error' });
+    expect(result.reason).toContain('socket hang up');
+  });
+
+  it('does not perform the deep call when deep is not requested', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: false });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(MODELS(fetchSpy.mock.calls[0][0])).toBe(false);
+  });
+});

--- a/src/cli/commands/proxy/__tests__/watcher.test.ts
+++ b/src/cli/commands/proxy/__tests__/watcher.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ProxyWatcher, WatcherCallbacks } from '../watcher.js';
+import type { ProxyHealthResult } from '../health-check.js';
+import { checkProxyHealth } from '../health-check.js';
+
+vi.mock('@/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../health-check.js', () => ({
+  checkProxyHealth: vi.fn(),
+}));
+
+const mockedHealth = vi.mocked(checkProxyHealth);
+
+const HEALTHY: ProxyHealthResult = { healthy: true, level: 'deep', code: 'ok' };
+const UPSTREAM_DOWN: ProxyHealthResult = {
+  healthy: false, level: 'deep', code: 'upstream-error', reason: 'Upstream model discovery returned 500',
+};
+const UNAUTHORIZED: ProxyHealthResult = {
+  healthy: false, level: 'deep', code: 'unauthorized', reason: 'SSO session expired — run `codemie proxy connect desktop` to re-login.',
+};
+
+function makeCallbacks(): WatcherCallbacks & {
+  restart: ReturnType<typeof vi.fn>;
+  onHealthy: ReturnType<typeof vi.fn>;
+  onGiveUp: ReturnType<typeof vi.fn>;
+} {
+  return {
+    restart: vi.fn().mockResolvedValue(undefined),
+    onHealthy: vi.fn().mockResolvedValue(undefined),
+    onGiveUp: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('ProxyWatcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedHealth.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports healthy and never restarts while the proxy is healthy', async () => {
+    mockedHealth.mockResolvedValue(HEALTHY);
+    const cb = makeCallbacks();
+    const watcher = new ProxyWatcher({ port: 4001, gatewayKey: 'k', intervalMs: 1000 }, cb);
+
+    watcher.start();
+    // Drive several ticks.
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    watcher.stop();
+
+    expect(cb.onHealthy).toHaveBeenCalled();
+    expect(cb.restart).not.toHaveBeenCalled();
+    expect(cb.onGiveUp).not.toHaveBeenCalled();
+  });
+
+  it('restarts up to maxRestartAttempts, then gives up, when upstream stays down', async () => {
+    mockedHealth.mockResolvedValue(UPSTREAM_DOWN);
+    const cb = makeCallbacks();
+    const watcher = new ProxyWatcher(
+      { port: 4001, gatewayKey: 'k', intervalMs: 1000, maxRestartAttempts: 3 },
+      cb
+    );
+
+    watcher.start();
+    // Advance generously past 3 restart cycles (interval + backoff each) and the give-up tick.
+    for (let i = 0; i < 30; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    watcher.stop();
+
+    expect(cb.restart).toHaveBeenCalledTimes(3);
+    expect(cb.onGiveUp).toHaveBeenCalledTimes(1);
+    expect(cb.onGiveUp.mock.calls[0][0]).toContain('did not recover after 3 restart attempts');
+  });
+
+  it('gives up immediately on an unauthorized failure without restarting', async () => {
+    mockedHealth.mockResolvedValue(UNAUTHORIZED);
+    const cb = makeCallbacks();
+    const watcher = new ProxyWatcher({ port: 4001, gatewayKey: 'k', intervalMs: 1000 }, cb);
+
+    watcher.start();
+    await vi.advanceTimersByTimeAsync(1000);
+    // Further time must not produce more activity (watcher stopped itself).
+    await vi.advanceTimersByTimeAsync(5000);
+    watcher.stop();
+
+    expect(cb.restart).not.toHaveBeenCalled();
+    expect(cb.onGiveUp).toHaveBeenCalledTimes(1);
+    expect(cb.onGiveUp.mock.calls[0][0]).toContain('SSO session expired');
+  });
+
+  it('recovers and resets attempts when health returns after a restart', async () => {
+    // First tick unhealthy → triggers a restart; subsequent ticks healthy.
+    mockedHealth
+      .mockResolvedValueOnce(UPSTREAM_DOWN)
+      .mockResolvedValue(HEALTHY);
+    const cb = makeCallbacks();
+    const watcher = new ProxyWatcher(
+      { port: 4001, gatewayKey: 'k', intervalMs: 1000, maxRestartAttempts: 3 },
+      cb
+    );
+
+    watcher.start();
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    watcher.stop();
+
+    expect(cb.restart).toHaveBeenCalledTimes(1);
+    expect(cb.onHealthy).toHaveBeenCalled();
+    expect(cb.onGiveUp).not.toHaveBeenCalled();
+  });
+
+  it('stops cleanly: no checks fire after stop()', async () => {
+    mockedHealth.mockResolvedValue(HEALTHY);
+    const cb = makeCallbacks();
+    const watcher = new ProxyWatcher({ port: 4001, gatewayKey: 'k', intervalMs: 1000 }, cb);
+
+    watcher.start();
+    watcher.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(mockedHealth).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/proxy/daemon-manager.ts
+++ b/src/cli/commands/proxy/daemon-manager.ts
@@ -19,6 +19,13 @@ export interface DaemonState {
   syncApiUrl?: string;
   syncCodeMieUrl?: string;
   startedAt: string;
+  // Health tracking (written by the daemon's watcher; all optional and
+  // backward-compatible — absent means "unknown / assume ok").
+  health?: 'ok' | 'unhealthy';
+  healthReason?: string;
+  lastHealthyAt?: string;
+  lastRecoveryAt?: string;
+  recoveryAttempts?: number;
 }
 
 const DEFAULT_STATE_FILE = join(getCodemieHome(), 'proxy-daemon.json');
@@ -142,21 +149,36 @@ export async function stopDaemon(): Promise<void> {
   const state = await readState(stateFile);
   if (!state) return;
 
-  if (isProcessAlive(state.pid)) {
-    process.kill(state.pid, 'SIGTERM');
-    for (let i = 0; i < 50; i++) {
-      await new Promise<void>(r => setTimeout(r, 100));
-      if (!isProcessAlive(state.pid)) {
-        await clearState(stateFile);
-        return;
-      }
-    }
-
-    throw new ToolExecutionError(
-      'proxy-daemon',
-      `Daemon pid ${state.pid} did not stop within 5 seconds`
-    );
+  if (!isProcessAlive(state.pid)) {
+    await clearState(stateFile);
+    return;
   }
 
+  // 1. Graceful: SIGTERM, wait up to 5s.
+  process.kill(state.pid, 'SIGTERM');
+  for (let i = 0; i < 50; i++) {
+    await new Promise<void>(r => setTimeout(r, 100));
+    if (!isProcessAlive(state.pid)) {
+      await clearState(stateFile);
+      return;
+    }
+  }
+
+  // 2. Escalate: SIGKILL so a wedged daemon can never block the next connect.
+  logger.warn(
+    '[daemon-manager] Daemon ignored SIGTERM; escalating to SIGKILL',
+    ...sanitizeLogArgs({ pid: state.pid })
+  );
+  try {
+    process.kill(state.pid, 'SIGKILL');
+  } catch {
+    // Already gone between the check and the signal — fine.
+  }
+  for (let i = 0; i < 20; i++) {
+    await new Promise<void>(r => setTimeout(r, 100));
+    if (!isProcessAlive(state.pid)) break;
+  }
+
+  // 3. Always clear state — the SIGKILL'd process won't run its own cleanup.
   await clearState(stateFile);
 }

--- a/src/cli/commands/proxy/health-check.ts
+++ b/src/cli/commands/proxy/health-check.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared proxy health checks.
+ *
+ * - shallow: hit the pre-auth `/health` endpoint → confirms the socket is alive.
+ * - deep: shallow + one authenticated upstream call (`/v1/llm_models`) through
+ *   the gateway → also confirms the SSO session/token is still valid.
+ *
+ * Consumed by `proxy status`, `proxy connect desktop`, and the in-daemon
+ * ProxyWatcher. Never throws — always resolves to a typed result.
+ */
+import { logger } from '../../../utils/logger.js';
+
+export type ProxyHealthLevel = 'shallow' | 'deep';
+
+export type ProxyHealthCode =
+  | 'ok'
+  | 'dead-socket'
+  | 'unauthorized'
+  | 'upstream-error';
+
+export interface ProxyHealthResult {
+  healthy: boolean;
+  level: ProxyHealthLevel;
+  code: ProxyHealthCode;
+  reason?: string;
+}
+
+export interface ProxyHealthOptions {
+  port: number;
+  gatewayKey: string;
+  deep?: boolean;
+  host?: string;
+}
+
+const SHALLOW_TIMEOUT_MS = 1500;
+const DEEP_TIMEOUT_MS = 6000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkProxyHealth(
+  opts: ProxyHealthOptions
+): Promise<ProxyHealthResult> {
+  const host = opts.host ?? '127.0.0.1';
+  const base = `http://${host}:${opts.port}`;
+
+  // 1. Shallow liveness
+  try {
+    const res = await fetchWithTimeout(`${base}/health`, { method: 'GET' }, SHALLOW_TIMEOUT_MS);
+    if (!res.ok) {
+      return {
+        healthy: false,
+        level: 'shallow',
+        code: 'dead-socket',
+        reason: `Health endpoint returned ${res.status}`,
+      };
+    }
+  } catch (error) {
+    return {
+      healthy: false,
+      level: 'shallow',
+      code: 'dead-socket',
+      reason: `Proxy not responding on ${base}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (!opts.deep) {
+    return { healthy: true, level: 'shallow', code: 'ok' };
+  }
+
+  // 2. Deep: authenticated upstream call via the gateway
+  try {
+    const res = await fetchWithTimeout(
+      `${base}/v1/llm_models?include_all=true`,
+      { method: 'GET', headers: { Authorization: `Bearer ${opts.gatewayKey}` } },
+      DEEP_TIMEOUT_MS
+    );
+    if (res.status === 401 || res.status === 403) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'unauthorized',
+        reason: 'SSO session expired — run `codemie proxy connect desktop` to re-login.',
+      };
+    }
+    if (!res.ok) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'upstream-error',
+        reason: `Upstream model discovery returned ${res.status}`,
+      };
+    }
+    return { healthy: true, level: 'deep', code: 'ok' };
+  } catch (error) {
+    logger.debug('[proxy-health] Deep check failed', error);
+    return {
+      healthy: false,
+      level: 'deep',
+      code: 'upstream-error',
+      reason: `Upstream check failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -16,6 +16,7 @@ import {
   stopDaemon,
 } from './daemon-manager.js';
 import { writeDesktopConfig } from './connectors/desktop.js';
+import { checkProxyHealth } from './health-check.js';
 import { printDesktopInspection } from './inspect-desktop.js';
 
 const DEFAULT_DAEMON_PORT = 4001;
@@ -190,7 +191,8 @@ export function createProxyCommand(): Command {
   proxy
     .command('status')
     .description('Show proxy daemon status')
-    .action(async () => {
+    .option('--deep', 'Also verify upstream/auth reachability (slower)')
+    .action(async (opts) => {
       const { running, state } = await checkStatus();
       if (!running || !state) {
         console.log('Status: stopped');
@@ -204,11 +206,29 @@ export function createProxyCommand(): Command {
           ? `${Math.floor(uptimeSec / 60)}m ${uptimeSec % 60}s`
           : `${Math.floor(uptimeSec / 3600)}h ${Math.floor((uptimeSec % 3600) / 60)}m`;
 
-      console.log(`Status:  ${chalk.green('running')}`);
+      const health = await checkProxyHealth({
+        port: state.port,
+        gatewayKey: state.gatewayKey,
+        deep: Boolean(opts.deep),
+      });
+
+      if (health.healthy) {
+        const label = health.level === 'deep' ? 'running, healthy (upstream OK)' : 'running, healthy';
+        console.log(`Status:  ${chalk.green(label)}`);
+      } else {
+        console.log(`Status:  ${chalk.yellow('running but UNHEALTHY')}`);
+        console.log(`  Reason:  ${health.reason ?? state.healthReason ?? 'unknown'}`);
+      }
+
       console.log(`  URL:     ${state.url}`);
       console.log(`  Port:    ${state.port}`);
       console.log(`  Profile: ${state.profile}`);
       console.log(`  Uptime:  ${uptime}`);
+
+      // Surface a recorded give-up reason even when a fresh ping happens to pass.
+      if (state.health === 'unhealthy' && state.healthReason && health.healthy) {
+        console.log(chalk.yellow(`  Note:    last recorded issue — ${state.healthReason}`));
+      }
     });
 
   // ── proxy connect ────────────────────────────────────────────────────────────
@@ -220,14 +240,36 @@ export function createProxyCommand(): Command {
     .description('Configure Claude Desktop (3P) to use the local proxy')
     .option('--profile <name>', 'Profile whose credentials to use for Claude Desktop proxy')
     .option('--verbose', 'Show detailed connection info (URLs, config paths) for debugging')
+    .option('--force', 'Stop any existing proxy and start a fresh one, even if it looks healthy')
     .action(async (opts) => {
       const verbose: boolean = Boolean(opts.verbose);
       let startedInThisRun = false;
       try {
+        const force: boolean = Boolean(opts.force);
         let { running, state } = await checkStatus();
 
-        if (running && state?.telemetryMode !== 'claude-desktop') {
-          console.log('Restarting proxy in Claude Desktop mode...');
+        const wrongMode = running && state?.telemetryMode !== 'claude-desktop';
+        let unhealthy = false;
+        if (running && state && state.telemetryMode === 'claude-desktop' && !force) {
+          const health = await checkProxyHealth({
+            port: state.port,
+            gatewayKey: state.gatewayKey,
+            deep: true,
+          });
+          unhealthy = !health.healthy;
+          if (unhealthy) {
+            console.log(
+              chalk.yellow(`Existing proxy is unhealthy (${health.reason ?? 'unknown'}). Restarting...`)
+            );
+          }
+        }
+
+        if (running && (wrongMode || unhealthy || force)) {
+          if (force) {
+            console.log('Forcing a fresh proxy restart...');
+          } else if (wrongMode) {
+            console.log('Restarting proxy in Claude Desktop mode...');
+          }
           await stopDaemon();
           running = false;
           state = null;

--- a/src/cli/commands/proxy/watcher.ts
+++ b/src/cli/commands/proxy/watcher.ts
@@ -1,0 +1,124 @@
+/**
+ * ProxyWatcher — runs inside the proxy daemon.
+ *
+ * Periodically deep-checks the proxy. On failure it restarts the proxy
+ * IN-PROCESS on the same pinned port (Approach A). Unauthorized failures
+ * (expired SSO session) cannot be fixed without an interactive login, so the
+ * watcher gives up and lets the daemon record an unhealthy state instead of
+ * looping forever. A large gap between timer ticks is treated as a sleep/wake
+ * event and triggers an immediate re-check.
+ */
+import { logger } from '../../../utils/logger.js';
+import { checkProxyHealth, ProxyHealthResult } from './health-check.js';
+
+export interface WatcherCallbacks {
+  /** Tear down the current proxy and re-listen on the same pinned port. */
+  restart: () => Promise<void>;
+  /** Called when a check passes (record lastHealthyAt / clear reason). */
+  onHealthy: (result: ProxyHealthResult) => Promise<void>;
+  /** Called when recovery is impossible or exhausted (record unhealthy + reason). */
+  onGiveUp: (reason: string) => Promise<void>;
+}
+
+export interface WatcherOptions {
+  port: number;
+  gatewayKey: string;
+  intervalMs?: number;        // default 30000
+  maxRestartAttempts?: number; // default 3
+}
+
+export class ProxyWatcher {
+  private timer: NodeJS.Timeout | null = null;
+  private stopped = false;
+  private checking = false;
+  private restartAttempts = 0;
+  private lastTick = Date.now();
+  private readonly intervalMs: number;
+  private readonly maxRestartAttempts: number;
+
+  constructor(
+    private readonly opts: WatcherOptions,
+    private readonly callbacks: WatcherCallbacks
+  ) {
+    this.intervalMs = opts.intervalMs ?? 30000;
+    this.maxRestartAttempts = opts.maxRestartAttempts ?? 3;
+  }
+
+  start(): void {
+    this.lastTick = Date.now();
+    this.timer = setInterval(() => { void this.tick(); }, this.intervalMs);
+    // Do not keep the event loop alive solely for the watcher.
+    this.timer.unref?.();
+    logger.debug(`[proxy-watcher] Started (interval ${this.intervalMs}ms, port ${this.opts.port})`);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    if (this.stopped || this.checking) return;
+    this.checking = true;
+    try {
+      const now = Date.now();
+      const drift = now - this.lastTick - this.intervalMs;
+      this.lastTick = now;
+      if (drift > this.intervalMs) {
+        logger.info(
+          `[proxy-watcher] Detected ~${Math.round(drift / 1000)}s gap (likely sleep/wake) — checking now`
+        );
+      }
+
+      const result = await checkProxyHealth({
+        port: this.opts.port,
+        gatewayKey: this.opts.gatewayKey,
+        deep: true,
+      });
+
+      if (result.healthy) {
+        this.restartAttempts = 0;
+        await this.callbacks.onHealthy(result);
+        return;
+      }
+
+      logger.warn(`[proxy-watcher] Proxy unhealthy: ${result.reason ?? 'unknown'}`);
+
+      // Expired session cannot be recovered without interactive login.
+      if (result.code === 'unauthorized') {
+        await this.callbacks.onGiveUp(result.reason ?? 'SSO session expired');
+        this.stop();
+        return;
+      }
+
+      if (this.restartAttempts >= this.maxRestartAttempts) {
+        await this.callbacks.onGiveUp(
+          `Proxy did not recover after ${this.maxRestartAttempts} restart attempts. ` +
+          `Last reason: ${result.reason ?? 'unknown'}`
+        );
+        this.stop();
+        return;
+      }
+
+      this.restartAttempts++;
+      const backoffMs = Math.min(this.intervalMs, 1000 * 2 ** (this.restartAttempts - 1));
+      logger.info(
+        `[proxy-watcher] Restart attempt ${this.restartAttempts}/${this.maxRestartAttempts} after ${backoffMs}ms`
+      );
+      await new Promise<void>((r) => setTimeout(r, backoffMs));
+      try {
+        await this.callbacks.restart();
+        logger.info('[proxy-watcher] Proxy restarted on the same port');
+      } catch (error) {
+        logger.error('[proxy-watcher] Restart failed', error);
+      }
+    } catch (error) {
+      logger.error('[proxy-watcher] Tick failed', error);
+    } finally {
+      this.checking = false;
+    }
+  }
+}

--- a/src/providers/plugins/sso/proxy/proxy-types.ts
+++ b/src/providers/plugins/sso/proxy/proxy-types.ts
@@ -34,6 +34,12 @@ export interface ProxyConfig {
   telemetryMode?: 'none' | 'claude-desktop';
   telemetryPollIntervalMs?: number;
   telemetryInactivityTimeoutMs?: number;
+  /**
+   * When true, the server retries the SAME configured port on EADDRINUSE
+   * (with short backoff) instead of falling back to a random port. Used by
+   * the daemon's in-process restart so Claude Desktop's fixed URL keeps working.
+   */
+  pinnedPort?: boolean;
 }
 
 /**

--- a/src/providers/plugins/sso/proxy/sso.proxy.ts
+++ b/src/providers/plugins/sso/proxy/sso.proxy.ts
@@ -44,6 +44,7 @@ export class CodeMieProxy {
   private httpClient: ProxyHTTPClient;
   private interceptors: ProxyInterceptor[] = [];
   private actualPort: number = 0;
+  private startedAt: string = '';
 
   constructor(private config: ProxyConfig) {
     // Initialize HTTP client with streaming support
@@ -139,11 +140,28 @@ export class CodeMieProxy {
         });
       });
 
+      let eaddrinuseRetries = 0;
+      const maxEaddrinuseRetries = 5;
       this.server.on('error', (error: any) => {
         if (error.code === 'EADDRINUSE') {
-          // Try a different random port
-          this.actualPort = 0; // Let system assign
-          this.server?.listen(this.actualPort, bindHost);
+          if (this.config.pinnedPort) {
+            // Recovery path: the daemon must reclaim the SAME port so Claude
+            // Desktop's fixed gateway URL keeps working. Retry with backoff
+            // instead of silently moving to a random port.
+            if (eaddrinuseRetries >= maxEaddrinuseRetries) {
+              this.server?.close();
+              reject(new NetworkError(
+                `Port ${this.actualPort} still in use after ${maxEaddrinuseRetries} retries`
+              ));
+              return;
+            }
+            eaddrinuseRetries++;
+            setTimeout(() => this.server?.listen(this.actualPort, bindHost), 200);
+          } else {
+            // Initial-bind path: a random fallback port is acceptable.
+            this.actualPort = 0; // Let system assign
+            this.server?.listen(this.actualPort, bindHost);
+          }
         } else {
           reject(error);
         }
@@ -157,6 +175,7 @@ export class CodeMieProxy {
 
         // Propagate actual port to config so plugins (e.g., MCP auth) get the real port
         this.config.port = this.actualPort;
+        this.startedAt = new Date().toISOString();
 
         const gatewayUrl = `http://${bindHost}:${this.actualPort}`;
         logger.debug(`Proxy started: ${gatewayUrl}`);
@@ -185,6 +204,11 @@ export class CodeMieProxy {
     // 2. Stop server
     if (this.server) {
       await new Promise<void>((resolve) => {
+        // Force-drain keep-alive sockets (e.g. Claude Desktop's persistent
+        // connection) first; otherwise server.close() does not invoke its
+        // callback until those connections idle out, which would hang the
+        // daemon's in-process restart indefinitely.
+        this.server!.closeAllConnections?.();
         this.server!.close(() => {
           logger.debug('[CodeMieProxy] Stopped');
           resolve();
@@ -214,6 +238,20 @@ export class CodeMieProxy {
     res: ServerResponse
   ): Promise<void> {
     const startTime = Date.now();
+
+    // Liveness probe — answered before auth and before any plugin hook.
+    // No upstream call, no token required. Used by `proxy status`, `connect`,
+    // and the in-daemon ProxyWatcher to detect a dead socket.
+    if (req.method === 'GET' && (req.url === '/health' || req.url === '/healthz')) {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        status: 'ok',
+        port: this.actualPort,
+        startedAt: this.startedAt,
+      }));
+      return;
+    }
 
     try {
       // 1. Build context


### PR DESCRIPTION
## Summary
Makes the Claude Desktop proxy self-healing. Previously `proxy status` reported "running" based only on a PID-alive check, so after laptop sleep the daemon could be alive but the proxy dead — and re-running `connect` against that stale daemon errored, forcing a manual `stop` + `connect`. This adds a real health check, an in-daemon watcher that restarts the proxy in-process on the same port, and a health-aware `connect`.

## Changes
- **`/health` endpoint** (`sso.proxy.ts`): pre-auth `GET /health` liveness probe + `startedAt` tracking.
- **Pinned-port mode** (`proxy-types.ts`, `sso.proxy.ts`): on recovery, retry the *same* port on `EADDRINUSE` instead of silently falling back to a random one (which broke Desktop's fixed URL). Drains keep-alive sockets on `stop()` so the in-process restart can't hang.
- **Health-check module** (`health-check.ts`, new): shared shallow `/health` probe + deep authenticated `/v1/llm_models` probe; typed result (`ok | dead-socket | unauthorized | upstream-error`).
- **ProxyWatcher** (`watcher.ts`, new): deep-checks every 30s, detects sleep/wake via timer drift, restarts in-process on the pinned port with backoff, gives up (records `health: unhealthy` + reason) after 3 attempts or on an unrecoverable expired session.
- **Daemon wiring** (`proxy-daemon.ts`): in-process `restartProxy`, merging `persistState`, watcher lifecycle.
- **Health-aware `connect desktop`** (`index.ts`): reuse if healthy, auto-restart if not; new `--force`.
- **Honest `status`** (`index.ts`): reports real health; new `--deep`; surfaces recorded failure reason.
- **SIGKILL fallback** (`daemon-manager.ts`): a wedged daemon can no longer block the next `connect`.

## Test Plan
- [x] Unit tests added for `health-check` (9) and `ProxyWatcher` (5)
- [x] Full unit suite green: 1764 passed, 1 skipped
- [x] `npm run build` clean; no ESLint findings in changed files
- [ ] Manual: connect → curl /health → simulate sleep (kill listener) → confirm watcher rebinds port 4001 → `--force` / SIGKILL paths

## Checklist
- [x] Code follows style guide (ESM `.js` imports, typed errors, no secret logging)
- [x] Unit tests pass
- [x] No ESLint warnings in changed files (pre-existing script-file findings unrelated)
- [x] Reviewed by code-review agent; correctness findings addressed (keep-alive drain, server-leak-on-reject, typed error)

Note: spec/plan/summary live under the gitignored `docs/superpowers/` and are intentionally not committed.

Generated with AI