### PR TITLE
fix(proxy): sync plugin-bundled skills on proxy startup

### DIFF
--- a/src/cli/commands/proxy/__tests__/index.test.ts
+++ b/src/cli/commands/proxy/__tests__/index.test.ts
@@ -41,6 +41,10 @@ vi.mock('../../../../cli/commands/skills/setup/sync.js', () => ({
   syncRegisteredSkills: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../../../cli/commands/skills/setup/sync-plugin.js', () => ({
+  syncPluginSkills: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('proxy connect desktop', () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -101,12 +105,13 @@ describe('proxy connect desktop', () => {
     );
   });
 
-  it('calls syncRegisteredSkills with the active profile name when starting the daemon', async () => {
+  it('calls syncRegisteredSkills and syncPluginSkills when starting the daemon', async () => {
     const { ConfigLoader } = await import('../../../../utils/config.js');
     const { ProviderRegistry } = await import('../../../../providers/index.js');
     const { CodeMieSSO } = await import('../../../../providers/plugins/sso/sso.auth.js');
     const { checkStatus, spawnDaemon } = await import('../daemon-manager.js');
     const { syncRegisteredSkills } = await import('../../../../cli/commands/skills/setup/sync.js');
+    const { syncPluginSkills } = await import('../../../../cli/commands/skills/setup/sync-plugin.js');
     const { writeDesktopConfig } = await import('../connectors/desktop.js');
     const { createProxyCommand } = await import('../index.js');
 
@@ -138,6 +143,7 @@ describe('proxy connect desktop', () => {
     await command.parseAsync(['connect', 'desktop', '--profile', 'test-profile'], { from: 'user' });
 
     expect(syncRegisteredSkills).toHaveBeenCalledWith('test-profile', process.cwd());
+    expect(syncPluginSkills).toHaveBeenCalledOnce();
   });
 });
 
@@ -162,11 +168,12 @@ describe('proxy start', () => {
     exitSpy.mockRestore();
   });
 
-  it('calls syncRegisteredSkills with the active profile name after credentials are verified', async () => {
+  it('calls syncRegisteredSkills and syncPluginSkills after credentials are verified', async () => {
     const { ConfigLoader } = await import('../../../../utils/config.js');
     const { CodeMieSSO } = await import('../../../../providers/plugins/sso/sso.auth.js');
     const { checkStatus, spawnDaemon } = await import('../daemon-manager.js');
     const { syncRegisteredSkills } = await import('../../../../cli/commands/skills/setup/sync.js');
+    const { syncPluginSkills } = await import('../../../../cli/commands/skills/setup/sync-plugin.js');
     const { createProxyCommand } = await import('../index.js');
 
     vi.mocked(checkStatus).mockResolvedValue({ running: false, state: null });
@@ -189,5 +196,6 @@ describe('proxy start', () => {
     await command.parseAsync(['start'], { from: 'user' });
 
     expect(syncRegisteredSkills).toHaveBeenCalledWith('test-profile', process.cwd());
+    expect(syncPluginSkills).toHaveBeenCalledOnce();
   });
 });

--- a/src/cli/commands/proxy/__tests__/index.test.ts
+++ b/src/cli/commands/proxy/__tests__/index.test.ts
@@ -37,6 +37,10 @@ vi.mock('../../../../providers/plugins/sso/sso.auth.js', () => ({
   CodeMieSSO: vi.fn(),
 }));
 
+vi.mock('../../../../cli/commands/skills/setup/sync.js', () => ({
+  syncRegisteredSkills: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('proxy connect desktop', () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -95,5 +99,95 @@ describe('proxy connect desktop', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '  Run: codemie profile login --url https://codemie.lab.epam.com/code-assistant-api'
     );
+  });
+
+  it('calls syncRegisteredSkills with the active profile name when starting the daemon', async () => {
+    const { ConfigLoader } = await import('../../../../utils/config.js');
+    const { ProviderRegistry } = await import('../../../../providers/index.js');
+    const { CodeMieSSO } = await import('../../../../providers/plugins/sso/sso.auth.js');
+    const { checkStatus, spawnDaemon } = await import('../daemon-manager.js');
+    const { syncRegisteredSkills } = await import('../../../../cli/commands/skills/setup/sync.js');
+    const { writeDesktopConfig } = await import('../connectors/desktop.js');
+    const { createProxyCommand } = await import('../index.js');
+
+    vi.mocked(checkStatus).mockResolvedValue({ running: false, state: null });
+    vi.mocked(ConfigLoader.load).mockResolvedValue({
+      name: 'test-profile',
+      provider: 'ai-run-sso',
+      baseUrl: 'https://example.com/api',
+      codeMieUrl: 'https://example.com',
+    } as Awaited<ReturnType<typeof ConfigLoader.load>>);
+    vi.mocked(ProviderRegistry.getProvider).mockReturnValue({
+      name: 'ai-run-sso',
+      authType: 'sso',
+    } as ReturnType<typeof ProviderRegistry.getProvider>);
+    vi.mocked(CodeMieSSO).mockImplementation(function MockCodeMieSSO() {
+      return { getStoredCredentials: vi.fn().mockResolvedValue({ token: 'tok' }) };
+    } as unknown as typeof CodeMieSSO);
+    vi.mocked(spawnDaemon).mockResolvedValue({
+      url: 'http://localhost:4001',
+      profile: 'test-profile',
+      port: 4001,
+      gatewayKey: 'gk',
+      startedAt: new Date().toISOString(),
+      telemetryMode: 'claude-desktop',
+    } as Awaited<ReturnType<typeof spawnDaemon>>);
+    vi.mocked(writeDesktopConfig).mockResolvedValue('/path/to/config');
+
+    const command = createProxyCommand();
+    await command.parseAsync(['connect', 'desktop', '--profile', 'test-profile'], { from: 'user' });
+
+    expect(syncRegisteredSkills).toHaveBeenCalledWith('test-profile', process.cwd());
+  });
+});
+
+describe('proxy start', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit:${code}`);
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('calls syncRegisteredSkills with the active profile name after credentials are verified', async () => {
+    const { ConfigLoader } = await import('../../../../utils/config.js');
+    const { CodeMieSSO } = await import('../../../../providers/plugins/sso/sso.auth.js');
+    const { checkStatus, spawnDaemon } = await import('../daemon-manager.js');
+    const { syncRegisteredSkills } = await import('../../../../cli/commands/skills/setup/sync.js');
+    const { createProxyCommand } = await import('../index.js');
+
+    vi.mocked(checkStatus).mockResolvedValue({ running: false, state: null });
+    vi.mocked(ConfigLoader.load).mockResolvedValue({
+      name: 'test-profile',
+      provider: 'ai-run-sso',
+      baseUrl: 'https://example.com/api',
+    } as Awaited<ReturnType<typeof ConfigLoader.load>>);
+    vi.mocked(CodeMieSSO).mockImplementation(function MockCodeMieSSO() {
+      return { getStoredCredentials: vi.fn().mockResolvedValue({ token: 'tok' }) };
+    } as unknown as typeof CodeMieSSO);
+    vi.mocked(spawnDaemon).mockResolvedValue({
+      url: 'http://localhost:4001',
+      profile: 'test-profile',
+      port: 4001,
+      startedAt: new Date().toISOString(),
+    } as Awaited<ReturnType<typeof spawnDaemon>>);
+
+    const command = createProxyCommand();
+    await command.parseAsync(['start'], { from: 'user' });
+
+    expect(syncRegisteredSkills).toHaveBeenCalledWith('test-profile', process.cwd());
   });
 });

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../utils/errors.js';
 import { logger } from '../../../utils/logger.js';
 import { sanitizeLogArgs } from '../../../utils/security.js';
+import { syncRegisteredSkills } from '../skills/setup/sync.js';
 import {
   checkStatus,
   readState,
@@ -158,6 +159,8 @@ export function createProxyCommand(): Command {
 
       await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
 
+      syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
+
       console.log('Starting proxy daemon...');
       const daemonState = await spawnDaemon({
         targetUrl: config.baseUrl,
@@ -277,6 +280,7 @@ export function createProxyCommand(): Command {
             })
           );
           await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
+          syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
           state = await spawnDaemon({
             targetUrl: config.baseUrl,
             provider: config.provider ?? 'ai-run-sso',

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -160,8 +160,11 @@ export function createProxyCommand(): Command {
 
       await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
 
-      syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
-      syncPluginSkills().catch(() => {});
+      const cwd = process.cwd();
+      await Promise.allSettled([
+        syncRegisteredSkills(config.name ?? 'default', cwd),
+        syncPluginSkills(),
+      ]);
 
       console.log('Starting proxy daemon...');
       const daemonState = await spawnDaemon({
@@ -282,8 +285,11 @@ export function createProxyCommand(): Command {
             })
           );
           await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
-          syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
-          syncPluginSkills().catch(() => {});
+          const cwd = process.cwd();
+          await Promise.allSettled([
+            syncRegisteredSkills(config.name ?? 'default', cwd),
+            syncPluginSkills(),
+          ]);
           state = await spawnDaemon({
             targetUrl: config.baseUrl,
             provider: config.provider ?? 'ai-run-sso',

--- a/src/cli/commands/proxy/index.ts
+++ b/src/cli/commands/proxy/index.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from '../../../utils/logger.js';
 import { sanitizeLogArgs } from '../../../utils/security.js';
 import { syncRegisteredSkills } from '../skills/setup/sync.js';
+import { syncPluginSkills } from '../skills/setup/sync-plugin.js';
 import {
   checkStatus,
   readState,
@@ -160,6 +161,7 @@ export function createProxyCommand(): Command {
       await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
 
       syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
+      syncPluginSkills().catch(() => {});
 
       console.log('Starting proxy daemon...');
       const daemonState = await spawnDaemon({
@@ -281,6 +283,7 @@ export function createProxyCommand(): Command {
           );
           await verifySsoCredentials(config.baseUrl, config.name ?? 'default');
           syncRegisteredSkills(config.name ?? 'default', process.cwd()).catch(() => {});
+          syncPluginSkills().catch(() => {});
           state = await spawnDaemon({
             targetUrl: config.baseUrl,
             provider: config.provider ?? 'ai-run-sso',

--- a/src/cli/commands/skills/setup/__tests__/sync-plugin.test.ts
+++ b/src/cli/commands/skills/setup/__tests__/sync-plugin.test.ts
@@ -1,0 +1,76 @@
+/**
+ * syncPluginSkills tests
+ * @group unit
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../../agents/plugins/claude/claude.plugin-installer.js', () => ({
+  ClaudePluginInstaller: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    access: vi.fn(),
+    readdir: vi.fn(),
+    readFile: vi.fn(),
+    mkdir: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+describe('syncPluginSkills', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('installs plugin and copies SKILL.md files with resolved CLAUDE_PLUGIN_ROOT', async () => {
+    const { ClaudePluginInstaller } = await import('../../../../../agents/plugins/claude/claude.plugin-installer.js');
+    const fs = (await import('fs/promises')).default;
+    const { syncPluginSkills } = await import('../sync-plugin.js');
+
+    const mockTargetPath = '/home/user/.codemie/claude-plugin';
+
+    vi.mocked(ClaudePluginInstaller).mockImplementation(function MockInstaller() {
+      return {
+        install: vi.fn().mockResolvedValue({ success: true, targetPath: mockTargetPath }),
+      };
+    } as unknown as typeof ClaudePluginInstaller);
+
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+    vi.mocked(fs.readdir).mockResolvedValue([
+      { name: 'msgraph', isDirectory: () => true },
+    ] as any);
+    vi.mocked(fs.readFile).mockResolvedValue(
+      '# Skill\nnode ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js status'
+    );
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+    await syncPluginSkills();
+
+    expect(fs.writeFile).toHaveBeenCalledOnce();
+    const [, writtenContent] = vi.mocked(fs.writeFile).mock.calls[0];
+    expect(writtenContent).toContain(`${mockTargetPath}/skills/msgraph/scripts/msgraph.js status`);
+    expect(writtenContent).not.toContain('${CLAUDE_PLUGIN_ROOT}');
+  });
+
+  it('silently returns when plugin install fails', async () => {
+    const { ClaudePluginInstaller } = await import('../../../../../agents/plugins/claude/claude.plugin-installer.js');
+    const fs = (await import('fs/promises')).default;
+    const { syncPluginSkills } = await import('../sync-plugin.js');
+
+    vi.mocked(ClaudePluginInstaller).mockImplementation(function MockInstaller() {
+      return {
+        install: vi.fn().mockResolvedValue({ success: false, targetPath: '' }),
+      };
+    } as unknown as typeof ClaudePluginInstaller);
+
+    await expect(syncPluginSkills()).resolves.toBeUndefined();
+    expect(fs.readdir).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/skills/setup/sync-plugin.ts
+++ b/src/cli/commands/skills/setup/sync-plugin.ts
@@ -40,11 +40,12 @@ export async function syncPluginSkills(): Promise<void> {
     const entries = await fs.readdir(skillsSourceDir, { withFileTypes: true });
     const claudeSkillsDir = path.join(os.homedir(), '.claude', 'skills');
 
+    const resolvedBase = path.resolve(skillsSourceDir);
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
 
       const resolvedSkillDir = path.resolve(skillsSourceDir, entry.name);
-      if (!resolvedSkillDir.startsWith(skillsSourceDir + path.sep)) continue;
+      if (!resolvedSkillDir.startsWith(resolvedBase + path.sep)) continue;
 
       const sourceMd = path.join(resolvedSkillDir, 'SKILL.md');
       try {

--- a/src/cli/commands/skills/setup/sync-plugin.ts
+++ b/src/cli/commands/skills/setup/sync-plugin.ts
@@ -1,0 +1,62 @@
+/**
+ * Plugin Skills Sync
+ *
+ * Installs the Claude plugin bundle and copies each bundled skill's SKILL.md
+ * to ~/.claude/skills/ with ${CLAUDE_PLUGIN_ROOT} resolved to the real path.
+ * This mirrors what --plugin-dir does in the CLI path, making plugin skills
+ * (e.g. msgraph) available when using the proxy.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { ClaudePluginInstaller } from '../../../../agents/plugins/claude/claude.plugin-installer.js';
+import { ClaudePluginMetadata } from '../../../../agents/plugins/claude/claude.plugin.js';
+import { logger } from '../../../../utils/logger.js';
+
+/**
+ * Ensure the Claude plugin bundle is installed and sync its bundled skill files
+ * to ~/.claude/skills/ so they are available without --plugin-dir.
+ * Fire-and-forget — never throws.
+ */
+export async function syncPluginSkills(): Promise<void> {
+  try {
+    const installer = new ClaudePluginInstaller(ClaudePluginMetadata);
+    const result = await installer.install();
+    if (!result.success) {
+      logger.debug('[plugin-skills-sync] Plugin install failed, skipping skill sync');
+      return;
+    }
+
+    const pluginRoot = result.targetPath;
+    const skillsSourceDir = path.join(pluginRoot, 'skills');
+
+    try {
+      await fs.access(skillsSourceDir);
+    } catch {
+      return;
+    }
+
+    const entries = await fs.readdir(skillsSourceDir, { withFileTypes: true });
+    const claudeSkillsDir = path.join(os.homedir(), '.claude', 'skills');
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const sourceMd = path.join(skillsSourceDir, entry.name, 'SKILL.md');
+      try {
+        let content = await fs.readFile(sourceMd, 'utf-8');
+        content = content.replaceAll('${CLAUDE_PLUGIN_ROOT}', pluginRoot);
+
+        const targetDir = path.join(claudeSkillsDir, entry.name);
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.writeFile(path.join(targetDir, 'SKILL.md'), content, 'utf-8');
+        logger.debug(`[plugin-skills-sync] Synced plugin skill: ${entry.name}`);
+      } catch {
+        logger.debug(`[plugin-skills-sync] Skipping ${entry.name}`);
+      }
+    }
+  } catch (error) {
+    logger.debug('[plugin-skills-sync] Sync failed', { error });
+  }
+}

--- a/src/cli/commands/skills/setup/sync-plugin.ts
+++ b/src/cli/commands/skills/setup/sync-plugin.ts
@@ -43,7 +43,10 @@ export async function syncPluginSkills(): Promise<void> {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
 
-      const sourceMd = path.join(skillsSourceDir, entry.name, 'SKILL.md');
+      const resolvedSkillDir = path.resolve(skillsSourceDir, entry.name);
+      if (!resolvedSkillDir.startsWith(skillsSourceDir + path.sep)) continue;
+
+      const sourceMd = path.join(resolvedSkillDir, 'SKILL.md');
       try {
         let content = await fs.readFile(sourceMd, 'utf-8');
         content = content.replaceAll('${CLAUDE_PLUGIN_ROOT}', pluginRoot);


### PR DESCRIPTION
## Summary

Skills bundled in the CLI plugin (e.g. `msgraph`) were invisible when using `codemie proxy start` or `codemie proxy connect desktop`, even though the same skills work with `codemie cli`.

Root cause: `--plugin-dir ~/.codemie/claude-plugin` is prepended to Claude Code's args by `sso.template.ts enrichArgs` only in the CLI agent path. In the proxy path that flag is never passed, so Claude Code never loads the plugin skill files.

A previous commit on this branch fixed platform-registered skills (`syncRegisteredSkills`). This commit fixes plugin-bundled skills.

## Changes

- **`src/cli/commands/skills/setup/sync-plugin.ts`** (new) — `syncPluginSkills()` installs the Claude plugin bundle via `ClaudePluginInstaller` and copies each bundled `SKILL.md` to `~/.claude/skills/{name}/SKILL.md` with `${CLAUDE_PLUGIN_ROOT}` resolved to the actual installation path.
- **`src/cli/commands/proxy/index.ts`** — calls `syncPluginSkills().catch(() => {})` fire-and-forget alongside `syncRegisteredSkills()` in both `proxy start` and `proxy connect desktop` startup paths.
- **`src/cli/commands/skills/setup/__tests__/sync-plugin.test.ts`** (new) — unit tests for `syncPluginSkills`.
- **`src/cli/commands/proxy/__tests__/index.test.ts`** — mock and assertions for `syncPluginSkills` in both proxy commands.

## Impact

After `codemie proxy start` or `codemie proxy connect desktop`:
- Plugin-bundled skills (msgraph, codemie-analytics, etc.) are written to `~/.claude/skills/` with resolved absolute paths.
- Skills are available to Claude Code without `--plugin-dir`.

## Checklist

- [x] Self-reviewed
- [x] 5 new/updated tests — all passing (`npm run test:unit`: 105 files, 1755 tests)
- [x] Pre-commit hooks passed (lint, typecheck, secrets scan)
- [x] No breaking changes