### PR TITLE
chore(agents): bump Claude Code version to 2.1.156

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -30,17 +30,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_SUPPORTED_VERSION = '2.1.114';
+const CLAUDE_SUPPORTED_VERSION = '2.1.156';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.114 → minimum = 2.1.104
+ * e.g. supported = 2.1.156 → minimum = 2.1.146
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.104';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.146';
 
 /**
  * Claude Code installer URLs


### PR DESCRIPTION
## Summary
- Bump `CLAUDE_SUPPORTED_VERSION` from `2.1.114` to `2.1.156`
- Bump `CLAUDE_MINIMUM_SUPPORTED_VERSION` from `2.1.104` to `2.1.146`
- Maintains the documented 10-patch-version gap invariant

## Test plan
- [x] `npm run lint` — passes (zero warnings)
- [x] `npm run build` — passes (tsc + plugin asset copy)
- [x] `npm test` — 2022 passed, 1 pre-existing failure (unrelated `skills.test.ts` telemetry env-var test)