### PR TITLE
fix(config): prevent migration 004/005 from creating empty config on fresh installs

### DIFF
--- a/src/migrations/004-skills-assistants-top-level.migration.ts
+++ b/src/migrations/004-skills-assistants-top-level.migration.ts
@@ -12,13 +12,13 @@ class SkillsAssistantsTopLevelMigration implements Migration {
     let migrated = false;
 
     const hasGlobal = await ConfigLoader.hasGlobalConfig();
-    if (!hasGlobal) return { success: true, migrated: false, reason: 'no-existing-config' };
-
-    const globalConfig = await ConfigLoader.loadMultiProviderConfig();
-    const migratedGlobal = this.migrate(globalConfig);
-    if (migratedGlobal !== globalConfig) {
-      await ConfigLoader.saveMultiProviderConfig(migratedGlobal);
-      migrated = true;
+    if (hasGlobal) {
+      const globalConfig = await ConfigLoader.loadMultiProviderConfig();
+      const migratedGlobal = this.migrate(globalConfig);
+      if (migratedGlobal !== globalConfig) {
+        await ConfigLoader.saveMultiProviderConfig(migratedGlobal);
+        migrated = true;
+      }
     }
 
     const hasLocal = await ConfigLoader.hasProjectConfig(workingDir);

--- a/src/migrations/004-skills-assistants-top-level.migration.ts
+++ b/src/migrations/004-skills-assistants-top-level.migration.ts
@@ -11,6 +11,9 @@ class SkillsAssistantsTopLevelMigration implements Migration {
     const workingDir = process.cwd();
     let migrated = false;
 
+    const hasGlobal = await ConfigLoader.hasGlobalConfig();
+    if (!hasGlobal) return { success: true, migrated: false, reason: 'no-existing-config' };
+
     const globalConfig = await ConfigLoader.loadMultiProviderConfig();
     const migratedGlobal = this.migrate(globalConfig);
     if (migratedGlobal !== globalConfig) {

--- a/src/migrations/005-skill-slug-format.migration.ts
+++ b/src/migrations/005-skill-slug-format.migration.ts
@@ -18,24 +18,27 @@ class SkillSlugFormatMigration implements Migration {
     const workingDir = process.cwd();
     let migrated = false;
 
-    const globalConfig = await ConfigLoader.loadMultiProviderConfig();
+    const hasGlobal = await ConfigLoader.hasGlobalConfig();
+    if (hasGlobal) {
+      const globalConfig = await ConfigLoader.loadMultiProviderConfig();
 
-    const hasProfileLevelSkills = Object.values(globalConfig.profiles).some(
-      p => (p as any).codemieSkills?.length > 0
-    );
-    if (hasProfileLevelSkills && !globalConfig.codemieSkills?.length) {
-      throw new ConfigurationError(
-        '005-skill-slug-format migration requires migration 004 (move-skills-to-top-level) to have run first. ' +
-        'Skills are still stored inside profiles rather than at the top-level config.'
+      const hasProfileLevelSkills = Object.values(globalConfig.profiles).some(
+        p => (p as any).codemieSkills?.length > 0
       );
-    }
+      if (hasProfileLevelSkills && !globalConfig.codemieSkills?.length) {
+        throw new ConfigurationError(
+          '005-skill-slug-format migration requires migration 004 (move-skills-to-top-level) to have run first. ' +
+          'Skills are still stored inside profiles rather than at the top-level config.'
+        );
+      }
 
-    const globalSkillsDir = path.join(os.homedir(), '.claude', 'skills');
-    const { config: migratedGlobal, changed: globalChanged } =
-      await this.migrateSkillSlugs(globalConfig, StorageScope.GLOBAL, globalSkillsDir);
-    if (globalChanged) {
-      await ConfigLoader.saveMultiProviderConfig(migratedGlobal);
-      migrated = true;
+      const globalSkillsDir = path.join(os.homedir(), '.claude', 'skills');
+      const { config: migratedGlobal, changed: globalChanged } =
+        await this.migrateSkillSlugs(globalConfig, StorageScope.GLOBAL, globalSkillsDir);
+      if (globalChanged) {
+        await ConfigLoader.saveMultiProviderConfig(migratedGlobal);
+        migrated = true;
+      }
     }
 
     const hasLocal = await ConfigLoader.hasProjectConfig(workingDir);


### PR DESCRIPTION
## Summary

- **Jira:** https://jiraeu.epam.com/browse/EPMCDME-12693
- **Root cause**: Migration 004 called `ConfigLoader.loadMultiProviderConfig()` unconditionally. On fresh installs (e.g. Docker containers) with no global config, it returns an empty skeleton `{version:2, profiles:{}}`, which migration then saves to disk. On next startup, `ConfigLoader.load()` finds `profiles: {}` and throws `'No profiles configured'`.
- **Fix 1** (004): wrap global config processing in `if (hasGlobal)` — skips global part when no config exists, but still processes local project config if present.
- **Fix 2** (005): apply the same `hasGlobalConfig` guard for consistency — prevents 005 from running against an empty skeleton on fresh installs.

## Code review findings

4 findings were surfaced during review. 2 fixed in this PR, 2 deferred.

### Fixed in this PR
| # | File | Finding |
|---|------|---------|
| 1 | `004-skills-assistants-top-level.migration.ts` | Early return skipped local config migration when no global config existed — replaced with conditional block |
| 2 | `005-skill-slug-format.migration.ts` | No `hasGlobalConfig` guard — added for consistency with 004 |

### Deferred (separate ticket)
| # | File | Finding |
|---|------|---------|
| 3 | `runner.ts` | Runner permanently records skipped migrations (`migrated:false`) as applied — migration never re-runs after user creates config post-install |
| 4 | `utils/config.ts` | `hasGlobalConfig` reads the config file, then `loadMultiProviderConfig` reads it again — redundant double I/O with TOCTOU window |

## Test plan

- [ ] Fresh Docker container with `--jwt-token`: no `codemie-cli.config.json` created, no `'No profiles configured'` error
- [ ] Existing install with global config: migration 004/005 still runs and migrates skills/assistants to top-level as before
- [ ] Project with local config only (no global): local config is still migrated by 004/005
- [ ] Both global and local config present: both are migrated as before