### PR TITLE
feat: rename default import folder to "Claude Desktop"

### DIFF
--- a/src/providers/plugins/sso/session/processors/conversations/constants.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/constants.ts
@@ -29,7 +29,7 @@ export const CODEMIE_ASSISTANT_ID =
 export const CONVERSATIONS_API_PATH = 'v1/conversations';
 
 /** Default folder name for imported conversations */
-export const DEFAULT_CONVERSATION_FOLDER = 'Claude Imports';
+export const DEFAULT_CONVERSATION_FOLDER = 'Claude Desktop';
 
 // ============================================================================
 // HTTP Status Codes


### PR DESCRIPTION
Renames the default folder for imported Claude Desktop conversations from **Claude Imports** to **Claude Desktop** (`DEFAULT_CONVERSATION_FOLDER`).

Part of the UI improvements for Claude Desktop imported chats. Applies to new imports; existing chats keep the old folder name.

Jira: https://jiraeu.epam.com/browse/EPMCDME-12380