### PR TITLE
fix(cli): add "code" bin entry for npx package resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "bin": {
     "codemie": "./bin/codemie.js",
+    "code": "./bin/codemie.js",
     "codemie-code": "./bin/agent-executor.js",
     "codemie-claude": "./bin/codemie-claude.js",
     "codemie-claude-acp": "./bin/codemie-claude-acp.js",


### PR DESCRIPTION
## Summary
Adds a `\"code\"` entry to the `bin` field in `package.json` so that `npx @codemieai/code` can resolve which executable to run. Previously, npm/npx would fail with \"could not determine executable to run\" (or fall back to looking for `code` in PATH) because the package exposes multiple binaries but none matched the unscoped package name `code`.

## Changes
- Added `\"code\": \"./bin/codemie.js\"` to the `bin` field in `package.json`

## Impact
- Before: `npx @codemieai/code setup` → `npm error could not determine executable to run` / `sh: code: command not found`
- After: `npx @codemieai/code setup` works as documented in the README

## Checklist
- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes