### PR TITLE
fix(agents): fix reasoning model routing for gpt-5.4 and gpt-5.5

### DIFF
--- a/src/agents/plugins/codemie-code.plugin.ts
+++ b/src/agents/plugins/codemie-code.plugin.ts
@@ -272,6 +272,7 @@ export const CodeMieCodePluginMetadata: AgentMetadata = {
       const proxyBaseUrl = provider !== 'ollama' && !isBedrock && !isLiteLLM ? baseUrl : undefined;
       const ollamaBaseUrl = resolveOllamaBaseUrl(baseUrl, provider);
       const activeProvider = determineActiveProvider(provider);
+      const effectiveProvider = modelConfig.use_responses_api ? 'openai' : activeProvider;
       const timeout = providerOptions?.timeout ?? parseInt(env.CODEMIE_TIMEOUT || '600') * 1000;
       const modelId = isBedrock
         ? toBedrockModelId(modelConfig.id, env.AWS_REGION || env.CODEMIE_AWS_REGION)
@@ -290,7 +291,7 @@ export const CodeMieCodePluginMetadata: AgentMetadata = {
         proxyBaseUrl,
         litellmBaseUrl: isLiteLLM ? baseUrl : undefined,
         litellmApiKey: isLiteLLM ? env.CODEMIE_API_KEY : undefined,
-        ollamaBaseUrl, activeProvider, modelId, timeout, providerOptions,
+        ollamaBaseUrl, activeProvider: effectiveProvider, modelId, timeout, providerOptions,
         chatModels, responsesApiModels, responsesApiBaseUrl
       });
 

--- a/src/agents/plugins/opencode/opencode-dynamic-models.ts
+++ b/src/agents/plugins/opencode/opencode-dynamic-models.ts
@@ -16,36 +16,9 @@
 import type { LlmModel } from '../../../providers/plugins/sso/sso.http-client.js';
 import { fetchCodeMieLlmModels } from '../../../providers/plugins/sso/sso.http-client.js';
 import type { OpenCodeModelConfig } from './opencode-model-configs.js';
-import { OPENCODE_MODEL_CONFIGS } from './opencode-model-configs.js';
+import { OPENCODE_MODEL_CONFIGS, isResponsesApiModel } from './opencode-model-configs.js';
 import { CodeMieSSO } from '../../../providers/plugins/sso/sso.auth.js';
 import { logger } from '../../../utils/logger.js';
-
-// ── Responses-API detection ──────────────────────────────────────────────────
-//
-// The /v1/llm_models endpoint does not expose a "mode" field, so we maintain
-// an explicit list of model-name patterns that require OpenAI Responses API
-// (POST /v1/responses) instead of Chat Completions (POST /v1/chat/completions).
-//
-// Naming conventions observed in CodeMie deployments:
-//   Responses API  →  gpt-5-2-*, gpt-5.2-*, gpt-5.4*, gpt-5-4-*, gpt-5.x-codex-*, gpt-5-x-codex-*
-//   Chat Completions → gpt-4*, gpt-5-<year>-*, o1/o3/o4*, gemini-*, claude-*, …
-//
-// Update this list whenever new Responses-API-only models are deployed.
-
-const RESPONSES_API_MODEL_PATTERNS: RegExp[] = [
-  /^gpt-5-2-/,        // gpt-5-2-2025-12-11 (and future gpt-5-2-YYYY-* variants)
-  /^gpt-5\.2-/,       // gpt-5.2-chat
-  /^gpt-5\.4/,        // gpt-5.4, gpt-5.4-2026-03-05, future gpt-5.4-* variants
-  /^gpt-5-4-/,        // hyphenated variant: gpt-5-4-2026-03-05
-  /^gpt-5-1-codex/,   // gpt-5-1-codex-2025-11-13
-  /^gpt-5\.1-codex/,  // gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max
-  /^gpt-5-3-codex/,   // hyphenated variant of gpt-5.3-codex
-  /^gpt-5\.3-codex/,  // gpt-5.3-codex-2026-02-24
-];
-
-function isResponsesApiModel(id: string): boolean {
-  return RESPONSES_API_MODEL_PATTERNS.some(p => p.test(id));
-}
 
 // ── Family detection ─────────────────────────────────────────────────────────
 

--- a/src/agents/plugins/opencode/opencode-dynamic-models.ts
+++ b/src/agents/plugins/opencode/opencode-dynamic-models.ts
@@ -27,7 +27,7 @@ import { logger } from '../../../utils/logger.js';
 // (POST /v1/responses) instead of Chat Completions (POST /v1/chat/completions).
 //
 // Naming conventions observed in CodeMie deployments:
-//   Responses API  →  gpt-5-2-*, gpt-5.2-*, gpt-5.x-codex-*, gpt-5-x-codex-*
+//   Responses API  →  gpt-5-2-*, gpt-5.2-*, gpt-5.4*, gpt-5-4-*, gpt-5.x-codex-*, gpt-5-x-codex-*
 //   Chat Completions → gpt-4*, gpt-5-<year>-*, o1/o3/o4*, gemini-*, claude-*, …
 //
 // Update this list whenever new Responses-API-only models are deployed.
@@ -35,6 +35,8 @@ import { logger } from '../../../utils/logger.js';
 const RESPONSES_API_MODEL_PATTERNS: RegExp[] = [
   /^gpt-5-2-/,        // gpt-5-2-2025-12-11 (and future gpt-5-2-YYYY-* variants)
   /^gpt-5\.2-/,       // gpt-5.2-chat
+  /^gpt-5\.4/,        // gpt-5.4, gpt-5.4-2026-03-05, future gpt-5.4-* variants
+  /^gpt-5-4-/,        // hyphenated variant: gpt-5-4-2026-03-05
   /^gpt-5-1-codex/,   // gpt-5-1-codex-2025-11-13
   /^gpt-5\.1-codex/,  // gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max
   /^gpt-5-3-codex/,   // hyphenated variant of gpt-5.3-codex

--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -228,6 +228,66 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
     }
   },
 
+  'gpt-5.4': {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    displayName: 'GPT-5.4',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+    attachment: true,
+    temperature: false,
+    structured_output: true,
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text']
+    },
+    knowledge: '2025-08-31',
+    release_date: '2026-03-05',
+    last_updated: '2026-03-05',
+    open_weights: false,
+    use_responses_api: true,
+    cost: {
+      input: 1.75,
+      output: 14,
+      cache_read: 0.175
+    },
+    limit: {
+      context: 400000,
+      output: 128000
+    }
+  },
+
+  'gpt-5.4-2026-03-05': {
+    id: 'gpt-5.4-2026-03-05',
+    name: 'GPT-5.4 (Mar 2026)',
+    displayName: 'GPT-5.4 (Mar 2026)',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+    attachment: true,
+    temperature: false,
+    structured_output: true,
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text']
+    },
+    knowledge: '2025-08-31',
+    release_date: '2026-03-05',
+    last_updated: '2026-03-05',
+    open_weights: false,
+    use_responses_api: true,
+    cost: {
+      input: 1.75,
+      output: 14,
+      cache_read: 0.175
+    },
+    limit: {
+      context: 400000,
+      output: 128000
+    }
+  },
+
   // ── Claude Models ──────────────────────────────────────────────────
   'claude-4-5-sonnet': {
     id: 'claude-4-5-sonnet',

--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -54,6 +54,41 @@ export interface OpenCodeModelConfig {
   };
 }
 
+// ── Responses-API detection ──────────────────────────────────────────────────
+//
+// Single source of truth for which model IDs require OpenAI Responses API
+// (POST /v1/responses) instead of Chat Completions (POST /v1/chat/completions).
+//
+// Used by:
+//  - convertApiModelToOpenCodeConfig() in opencode-dynamic-models.ts (dynamic catalogue)
+//  - getModelConfig() below (unknown-model fallback)
+//
+// Update this list whenever new Responses-API-only models are deployed.
+// Naming conventions:
+//   Responses API  → gpt-5-2-*, gpt-5.2-*, gpt-5.4*, gpt-5-4-*, gpt-5.5*, gpt-5-5-*, gpt-5.x-codex-*, ...
+//   Chat Completions → gpt-4*, gpt-5-<year>-*, o1/o3/o4*, gemini-*, claude-*, …
+
+export const RESPONSES_API_MODEL_PATTERNS: RegExp[] = [
+  /^gpt-5-2-/,        // gpt-5-2-2025-12-11 (and future gpt-5-2-YYYY-* variants)
+  /^gpt-5\.2-/,       // gpt-5.2-chat
+  /^gpt-5\.4/,        // gpt-5.4, gpt-5.4-2026-03-05, future gpt-5.4-* variants
+  /^gpt-5-4-/,        // hyphenated variant: gpt-5-4-2026-03-05
+  /^gpt-5\.5/,        // gpt-5.5, gpt-5.5-2026-04-24, future gpt-5.5-* variants
+  /^gpt-5-5-/,        // hyphenated variant: gpt-5-5-2026-04-24
+  /^gpt-5-1-codex/,   // gpt-5-1-codex-2025-11-13
+  /^gpt-5\.1-codex/,  // gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max
+  /^gpt-5-3-codex/,   // hyphenated variant of gpt-5.3-codex
+  /^gpt-5\.3-codex/,  // gpt-5.3-codex-2026-02-24
+];
+
+/**
+ * Returns true if the model ID requires the OpenAI Responses API.
+ * Used both for dynamic model catalogue classification and for unknown-model fallback.
+ */
+export function isResponsesApiModel(id: string): boolean {
+  return RESPONSES_API_MODEL_PATTERNS.some(p => p.test(id));
+}
+
 export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
   'gpt-5-2-2025-12-11': {
     id: 'gpt-5-2-2025-12-11',
@@ -275,6 +310,66 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
     knowledge: '2025-08-31',
     release_date: '2026-03-05',
     last_updated: '2026-03-05',
+    open_weights: false,
+    use_responses_api: true,
+    cost: {
+      input: 1.75,
+      output: 14,
+      cache_read: 0.175
+    },
+    limit: {
+      context: 400000,
+      output: 128000
+    }
+  },
+
+  'gpt-5.5': {
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
+    displayName: 'GPT-5.5',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+    attachment: true,
+    temperature: false,
+    structured_output: true,
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text']
+    },
+    knowledge: '2025-11-30',
+    release_date: '2026-04-24',
+    last_updated: '2026-04-24',
+    open_weights: false,
+    use_responses_api: true,
+    cost: {
+      input: 1.75,
+      output: 14,
+      cache_read: 0.175
+    },
+    limit: {
+      context: 400000,
+      output: 128000
+    }
+  },
+
+  'gpt-5.5-2026-04-24': {
+    id: 'gpt-5.5-2026-04-24',
+    name: 'GPT-5.5 (Apr 2026)',
+    displayName: 'GPT-5.5 (Apr 2026)',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+    attachment: true,
+    temperature: false,
+    structured_output: true,
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text']
+    },
+    knowledge: '2025-11-30',
+    release_date: '2026-04-24',
+    last_updated: '2026-04-24',
     open_weights: false,
     use_responses_api: true,
     cost: {
@@ -708,6 +803,7 @@ export function getModelConfig(modelId: string): OpenCodeModelConfig {
     attachment: familyDefaults.attachment ?? false,
     temperature: familyDefaults.temperature ?? true,
     structured_output: familyDefaults.structured_output,
+    ...(isResponsesApiModel(modelId) && { use_responses_api: true }),
     modalities: familyDefaults.modalities ?? { input: ['text'], output: ['text'] },
     knowledge: today,
     release_date: today,

--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -89,6 +89,44 @@ export function isResponsesApiModel(id: string): boolean {
   return RESPONSES_API_MODEL_PATTERNS.some(p => p.test(id));
 }
 
+// ── Shared base configs for model families ───────────────────────────────────
+
+/** Shared fields for gpt-5.4 and gpt-5.4-2026-03-05 (only id/name/displayName differ) */
+const GPT_5_4_BASE = {
+  family: 'gpt-5',
+  tool_call: true,
+  reasoning: true,
+  attachment: true,
+  temperature: false,
+  structured_output: true,
+  modalities: { input: ['text', 'image'], output: ['text'] },
+  knowledge: '2025-08-31',
+  release_date: '2026-03-05',
+  last_updated: '2026-03-05',
+  open_weights: false,
+  use_responses_api: true,
+  cost: { input: 1.75, output: 14, cache_read: 0.175 },
+  limit: { context: 400000, output: 128000 }
+} satisfies Partial<OpenCodeModelConfig>;
+
+/** Shared fields for gpt-5.5 and gpt-5.5-2026-04-24 (only id/name/displayName differ) */
+const GPT_5_5_BASE = {
+  family: 'gpt-5',
+  tool_call: true,
+  reasoning: true,
+  attachment: true,
+  temperature: false,
+  structured_output: true,
+  modalities: { input: ['text', 'image'], output: ['text'] },
+  knowledge: '2025-11-30',
+  release_date: '2026-04-24',
+  last_updated: '2026-04-24',
+  open_weights: false,
+  use_responses_api: true,
+  cost: { input: 1.75, output: 14, cache_read: 0.175 },
+  limit: { context: 400000, output: 128000 }
+} satisfies Partial<OpenCodeModelConfig>;
+
 export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
   'gpt-5-2-2025-12-11': {
     id: 'gpt-5-2-2025-12-11',
@@ -264,123 +302,31 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
   },
 
   'gpt-5.4': {
+    ...GPT_5_4_BASE,
     id: 'gpt-5.4',
     name: 'GPT-5.4',
     displayName: 'GPT-5.4',
-    family: 'gpt-5',
-    tool_call: true,
-    reasoning: true,
-    attachment: true,
-    temperature: false,
-    structured_output: true,
-    modalities: {
-      input: ['text', 'image'],
-      output: ['text']
-    },
-    knowledge: '2025-08-31',
-    release_date: '2026-03-05',
-    last_updated: '2026-03-05',
-    open_weights: false,
-    use_responses_api: true,
-    cost: {
-      input: 1.75,
-      output: 14,
-      cache_read: 0.175
-    },
-    limit: {
-      context: 400000,
-      output: 128000
-    }
   },
 
   'gpt-5.4-2026-03-05': {
+    ...GPT_5_4_BASE,
     id: 'gpt-5.4-2026-03-05',
     name: 'GPT-5.4 (Mar 2026)',
     displayName: 'GPT-5.4 (Mar 2026)',
-    family: 'gpt-5',
-    tool_call: true,
-    reasoning: true,
-    attachment: true,
-    temperature: false,
-    structured_output: true,
-    modalities: {
-      input: ['text', 'image'],
-      output: ['text']
-    },
-    knowledge: '2025-08-31',
-    release_date: '2026-03-05',
-    last_updated: '2026-03-05',
-    open_weights: false,
-    use_responses_api: true,
-    cost: {
-      input: 1.75,
-      output: 14,
-      cache_read: 0.175
-    },
-    limit: {
-      context: 400000,
-      output: 128000
-    }
   },
 
   'gpt-5.5': {
+    ...GPT_5_5_BASE,
     id: 'gpt-5.5',
     name: 'GPT-5.5',
     displayName: 'GPT-5.5',
-    family: 'gpt-5',
-    tool_call: true,
-    reasoning: true,
-    attachment: true,
-    temperature: false,
-    structured_output: true,
-    modalities: {
-      input: ['text', 'image'],
-      output: ['text']
-    },
-    knowledge: '2025-11-30',
-    release_date: '2026-04-24',
-    last_updated: '2026-04-24',
-    open_weights: false,
-    use_responses_api: true,
-    cost: {
-      input: 1.75,
-      output: 14,
-      cache_read: 0.175
-    },
-    limit: {
-      context: 400000,
-      output: 128000
-    }
   },
 
   'gpt-5.5-2026-04-24': {
+    ...GPT_5_5_BASE,
     id: 'gpt-5.5-2026-04-24',
     name: 'GPT-5.5 (Apr 2026)',
     displayName: 'GPT-5.5 (Apr 2026)',
-    family: 'gpt-5',
-    tool_call: true,
-    reasoning: true,
-    attachment: true,
-    temperature: false,
-    structured_output: true,
-    modalities: {
-      input: ['text', 'image'],
-      output: ['text']
-    },
-    knowledge: '2025-11-30',
-    release_date: '2026-04-24',
-    last_updated: '2026-04-24',
-    open_weights: false,
-    use_responses_api: true,
-    cost: {
-      input: 1.75,
-      output: 14,
-      cache_read: 0.175
-    },
-    limit: {
-      context: 400000,
-      output: 128000
-    }
   },
 
   // ── Claude Models ──────────────────────────────────────────────────

--- a/src/agents/plugins/opencode/opencode.plugin.ts
+++ b/src/agents/plugins/opencode/opencode.plugin.ts
@@ -95,6 +95,7 @@ export const OpenCodePluginMetadata: AgentMetadata = {
       // - bedrock: uses OpenCode's built-in amazon-bedrock provider (AWS env vars set by provider hook)
       // - all others: route through codemie-proxy (SSO/proxy)
       const activeProvider = provider === 'ollama' ? 'ollama' : (isBedrock ? 'amazon-bedrock' : 'codemie-proxy');
+      const effectiveProvider = modelConfig.use_responses_api ? 'openai' : activeProvider;
       const timeout = providerOptions?.timeout ?? parseInt(env.CODEMIE_TIMEOUT || '600') * 1000;
 
       // Always enable openai CUSTOM_LOADER when Responses API models exist.
@@ -149,7 +150,7 @@ export const OpenCodePluginMetadata: AgentMetadata = {
             }
           }
         },
-        model: `${activeProvider}/${isBedrock ? toBedrockModelId(modelConfig.id, env.AWS_REGION || env.CODEMIE_AWS_REGION) : modelConfig.id}`
+        model: `${effectiveProvider}/${isBedrock ? toBedrockModelId(modelConfig.id, env.AWS_REGION || env.CODEMIE_AWS_REGION) : modelConfig.id}`
       };
 
       // --- Hooks injection ---

--- a/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
@@ -10,6 +10,11 @@
  * as reasoning models and inject `reasoningSummary`, `reasoning` (object), etc.
  * LiteLLM/Azure rejects these with: "Unknown parameter: 'reasoningSummary'"
  *
+ * IMPORTANT: `reasoningSummary` must NOT be stripped for Responses API requests
+ * (/v1/responses). It is a valid and required parameter there — without it the
+ * model returns no reasoning output, making the `/thinking` toggle a no-op for
+ * GPT-5.4 and other Responses API models.
+ *
  * Scope: Only enabled for codemie-code and codemie-opencode agents (which use
  * AI SDKs that inject these params). Other agents (claude, gemini) handle their
  * own request formatting and don't need this sanitization.
@@ -20,15 +25,25 @@ import { ProxyContext } from '../proxy-types.js';
 import { logger } from '../../../../../utils/logger.js';
 
 /**
- * Parameters to strip from request bodies before forwarding to upstream.
- * These are injected by AI SDKs for "reasoning models" but may not be
- * supported by all LLM proxies (LiteLLM, Azure OpenAI, etc.)
+ * Parameters to strip only for Chat Completions requests (/v1/chat/completions).
+ * These are injected by AI SDKs for "reasoning models" but are rejected by
+ * LiteLLM/Azure when sent to the Chat Completions endpoint.
+ *
+ * NOTE: These params are intentionally NOT stripped for Responses API requests
+ * (/v1/responses), where `reasoningSummary: "auto"` is required to receive
+ * reasoning output in the response stream (needed for the `/thinking` feature).
  */
-const UNSUPPORTED_PARAMS = [
+const CHAT_COMPLETIONS_UNSUPPORTED_PARAMS = [
   'reasoningSummary',    // @ai-sdk/openai-compatible injects this for reasoning models
   'reasoning_summary',   // Snake-case variant
   'reasoning',           // Full reasoning object from OpenAI Responses API
 ];
+
+/**
+ * Parameters that are always unsupported regardless of API path.
+ * Currently empty — extend here if future params need universal stripping.
+ */
+const ALWAYS_UNSUPPORTED_PARAMS: string[] = [];
 
 /** Agents that use AI SDKs which inject unsupported reasoning params */
 const ALLOWED_AGENTS = ['codemie-code', 'codemie-opencode'];
@@ -61,8 +76,15 @@ class RequestSanitizerInterceptor implements ProxyInterceptor {
       const bodyStr = context.requestBody.toString('utf-8');
       const body = JSON.parse(bodyStr);
 
+      // Responses API (/v1/responses) supports reasoningSummary and must not have it stripped.
+      // Chat Completions (/v1/chat/completions) and any other path use the restricted set.
+      const isResponsesApi = context.url?.includes('/v1/responses') || context.url === '/responses';
+      const paramsToStrip = isResponsesApi
+        ? ALWAYS_UNSUPPORTED_PARAMS
+        : CHAT_COMPLETIONS_UNSUPPORTED_PARAMS;
+
       const stripped: string[] = [];
-      for (const param of UNSUPPORTED_PARAMS) {
+      for (const param of paramsToStrip) {
         if (param in body) {
           delete body[param];
           stripped.push(param);

--- a/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
@@ -39,12 +39,6 @@ const CHAT_COMPLETIONS_UNSUPPORTED_PARAMS = [
   'reasoning',           // Full reasoning object from OpenAI Responses API
 ];
 
-/**
- * Parameters that are always unsupported regardless of API path.
- * Currently empty — extend here if future params need universal stripping.
- */
-const ALWAYS_UNSUPPORTED_PARAMS: string[] = [];
-
 /** Agents that use AI SDKs which inject unsupported reasoning params */
 const ALLOWED_AGENTS = ['codemie-code', 'codemie-opencode'];
 
@@ -79,9 +73,7 @@ class RequestSanitizerInterceptor implements ProxyInterceptor {
       // Responses API (/v1/responses) supports reasoningSummary and must not have it stripped.
       // Chat Completions (/v1/chat/completions) and any other path use the restricted set.
       const isResponsesApi = context.url?.includes('/v1/responses') || context.url === '/responses';
-      const paramsToStrip = isResponsesApi
-        ? ALWAYS_UNSUPPORTED_PARAMS
-        : CHAT_COMPLETIONS_UNSUPPORTED_PARAMS;
+      const paramsToStrip = isResponsesApi ? [] : CHAT_COMPLETIONS_UNSUPPORTED_PARAMS;
 
       const stripped: string[] = [];
       for (const param of paramsToStrip) {

--- a/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
@@ -72,7 +72,7 @@ class RequestSanitizerInterceptor implements ProxyInterceptor {
 
       // Responses API (/v1/responses) supports reasoningSummary and must not have it stripped.
       // Chat Completions (/v1/chat/completions) and any other path use the restricted set.
-      const isResponsesApi = context.url?.includes('/v1/responses') || context.url === '/responses';
+      const isResponsesApi = context.url === '/v1/responses';
       const paramsToStrip = isResponsesApi ? [] : CHAT_COMPLETIONS_UNSUPPORTED_PARAMS;
 
       const stripped: string[] = [];


### PR DESCRIPTION
## Summary

Adds gpt-5.5 model support with correct routing to OpenAI Responses API and consolidates Responses API model detection into a single source of truth.

## Changes

- Added `gpt-5.5` and `gpt-5.5-2026-04-24` static entries with `use_responses_api: true` in `opencode-model-configs.ts`
- Moved `RESPONSES_API_MODEL_PATTERNS` and `isResponsesApiModel()` from `opencode-dynamic-models.ts` to `opencode-model-configs.ts` (single source of truth)
- Fixed `getModelConfig()` fallback to apply `isResponsesApiModel()` so unknown future models are auto-routed correctly
- Removed duplicate pattern array from `opencode-dynamic-models.ts`

## Impact

Before: gpt-5.5 was routed to `/v1/chat/completions` — no reasoning output, tool calls crashed with `reasoning_effort not supported` error.
After: gpt-5.5 routes to `/v1/responses` — reasoning blocks visible in CLI, tool calls work correctly.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)