### PR TITLE
fix: skip incomplete turn to prevent duplicate user message in imported history

### DIFF
--- a/src/agents/plugins/claude/session/processors/claude.conversations-processor.ts
+++ b/src/agents/plugins/claude/session/processors/claude.conversations-processor.ts
@@ -336,6 +336,20 @@ export class ConversationsProcessor implements SessionProcessor {
         sessionFilePath
       );
 
+      // Skip an incomplete turn — a new user message whose assistant reply hasn't been
+      // recorded yet. Emitting it now would advance the history index for a user-only
+      // turn; once the assistant arrives the same turn is re-emitted under the next
+      // index, leaving a duplicate user message in the stored history. Leave the sync
+      // state untouched so the complete turn is emitted once on a later pass.
+      if (!history.some((h: any) => h.role === 'Assistant')) {
+        return {
+          history: [],
+          isTurnContinuation: false,
+          lastProcessedMessageUuid: syncState.lastSyncedMessageUuid || '',
+          currentHistoryIndex: syncState.lastSyncedHistoryIndex
+        };
+      }
+
       for (let i = turnEndIndex - 1; i >= firstUserIndex; i--) {
         if (messages[i].uuid) {
           lastProcessedMessageUuid = messages[i].uuid;


### PR DESCRIPTION
DRAFT — root-cause fix for duplicated user messages in imported Claude Desktop conversations. Opened as draft pending review/coordination.

### Problem
Imported conversations could store the same user turn twice — under `history_index` 0 and 1 (assistant reply only at index 1) — producing a phantom/duplicate user message in the CodeMie UI.

### Root cause
`claude.conversations-processor.ts` syncs one turn per invocation and keeps `lastSyncedHistoryIndex` as a counter bumped on each new-user-message detection. If a sync fires while a turn is still incomplete (user present, assistant reply not yet recorded), it emits a user-only turn at index N and advances the counter; when the assistant reply later arrives, the same turn is detected as new again and re-emitted as `User(N+1) + Assistant(N+1)`, leaving the earlier `User(N)` behind.

### Fix
In the new-user branch of `transformMessages`, skip an incomplete turn: if the built turn has no `Assistant` entry, return empty and leave the sync state untouched, so the complete turn is emitted exactly once on a later pass. Aligns with the expected fixtures (turns are emitted as complete user+assistant pairs).

### Validation
- `tsc --noEmit` clean, eslint clean.
- Session integration suite green: 84 passed / 1 skipped (incl. `incremental-conversation-processing`).

Note: this only prevents NEW duplicates; chats already imported with duplicated data keep it until re-imported. The UI side (MR !1375) hides the resulting empty/phantom bubble.

Jira: https://jiraeu.epam.com/browse/EPMCDME-12380
Related: folder-rename PR #345