### PR TITLE
fix(agents): dedupe duplicate-uuid messages in Claude Desktop transcripts

### DIFF
--- a/src/agents/plugins/claude/claude.session.ts
+++ b/src/agents/plugins/claude/claude.session.ts
@@ -157,10 +157,28 @@ export class ClaudeSessionAdapter implements SessionAdapter {
    * Extracts both raw messages (for conversations) and metrics (for metrics processor).
    * CRITICAL: Discovers and parses ALL sub-agent files to avoid duplicate file reading.
    */
+  /**
+   * Collapse records that repeat the same `uuid`, keeping the LAST occurrence.
+   * Claude Desktop (3p) re-writes the user message after session init/status
+   * events; the later copy sits right before the assistant reply and is the real
+   * turn-start. Keeping it (and dropping the earlier echo) lets turn-splitting
+   * pair user+assistant correctly. Messages without a uuid are kept; this is a
+   * no-op for well-formed transcripts (each uuid appears once).
+   */
+  private dedupeByUuid(messages: ClaudeMessage[]): ClaudeMessage[] {
+    const lastIndex = new Map<string, number>();
+    messages.forEach((message, index) => {
+      if (message.uuid) lastIndex.set(message.uuid, index);
+    });
+    return messages.filter(
+      (message, index) => !message.uuid || lastIndex.get(message.uuid) === index
+    );
+  }
+
   async parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession> {
     try {
-      // Read main session JSONL file
-      const messages = await readJSONL<ClaudeMessage>(filePath);
+      // Read main session JSONL file (collapse any duplicate-uuid records)
+      const messages = this.dedupeByUuid(await readJSONL<ClaudeMessage>(filePath));
 
       // Handle empty files gracefully (new sessions, in-progress, corrupted files)
       if (messages.length === 0) {
@@ -223,7 +241,9 @@ export class ClaudeSessionAdapter implements SessionAdapter {
 
       for (const subagentFile of subagentFiles) {
         try {
-          const subagentMessages = await readJSONL<ClaudeMessage>(subagentFile.filePath);
+          const subagentMessages = this.dedupeByUuid(
+            await readJSONL<ClaudeMessage>(subagentFile.filePath)
+          );
           subagents.push({
             agentId: subagentFile.agentId,
             filePath: subagentFile.filePath,


### PR DESCRIPTION
**Jira:** [EPMCDME-12729](https://jiraeu.epam.com/browse/EPMCDME-12729) — Claude Desktop imported chat is displayed incorrectly after sync via CodeMie proxy.

## Problem
Imported Claude Desktop chats showed a broken first turn in the CodeMie UI: a phantom/empty assistant bubble (`Processed in: s / -`, "?" avatar) and the user message effectively duplicated. Stored history looked like:

```
User      history_index=0   "<text>"
User      history_index=1   "<same text>"   <- duplicate
Assistant history_index=1   "<reply>"
```

## Root cause
Claude Desktop (3p, `local-agent-mode-sessions`) records the **first user message twice with the *same* `uuid`** — once as an echo, then `system` `init`/`status` events, then the real copy right before the assistant reply:

```
user      uuid=A   (echo)
system    init
system    status
user      uuid=A   (real turn-start, identical uuid/content)
assistant uuid=B
```

The incremental conversation processor splits turns on user/system boundaries and had no uuid de-duplication, so it emitted the user under **two** `history_index` values (0 and 1). Verified this is *not* a backend or frontend issue:
- Backend `_append_new_messages` keys by `(history_index, role)` and faithfully stores what the CLI sends — it cannot and does not merge two different indices.
- A Claude **Code** session (no init/status echo) has zero duplicate uuids and renders cleanly.

So the duplication originates in the CLI consuming the duplicated source records.

## Fix
De-duplicate records by `uuid` at the single parsing boundary — `ClaudeSessionAdapter.parseSessionFile()` (and sub-agent files) — **keeping the LAST occurrence**:
- The later copy sits right before the assistant reply and is the real turn-start; keeping it (and dropping the earlier echo) lets turn-splitting pair user+assistant correctly → clean `User@0 / Assistant@0`.
- Keeping the *first* copy instead would orphan the assistant (the init/status systems break the turn), losing the reply — so order matters.
- Applied at the parse boundary so every consumer (conversations **and** metrics) sees each message once.
- No-op for well-formed transcripts (each uuid appears once), so Claude Code and normal sessions are unaffected.

This intentionally does **not** touch the fragile incremental turn-state machine (earlier attempts that did broke sync).

## Verification
- `tsc --noEmit` clean; eslint clean.
- Session integration suite green: 84 passed / 1 skipped.
- Live: re-imported a fresh Claude Desktop session through the local proxy — stored history is now `User@0 + Assistant@0` with full content, no duplicate and no phantom bubble.

Replaces the earlier draft #348 (which tried to special-case incomplete turns in `transformMessages` and destabilised sync).
