### PR TITLE
feat(analytics): richer HTML report — efficiency widgets, session & project drill-down modals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ MCP directories
 docs/superpowers
 .codemie
 .claude/telemetry
+
+# local runtime / tooling artifacts (never part of a PR)
+.ai-run/
+.superpowers/
+.playwright-mcp/
+codemie-analytics-*.html

--- a/src/cli/commands/analytics/report/client/app.js
+++ b/src/cli/commands/analytics/report/client/app.js
@@ -284,7 +284,13 @@
       };
     }).sort(function (a, b) { return b.sessions - a.sessions; }).slice(0, 8);
     pc._body.innerHTML = tableHTML(['Project', 'Sessions', 'Files', 'Lines +', 'Lines −', 'Net lines'],
-      rows.map(function (r) { return ['<span title="' + esc(r.p) + '">' + esc(shortPath(r.p)) + '</span>', fmtNum(r.sessions), tdNum(r.files), tdNum('+' + fmtNum(r.added)), tdNum('−' + fmtNum(r.removed)), tdNum(r.net)]; }));
+      rows.map(function (r) { return ['<span class="proj-link" data-proj-open="' + esc(r.p) + '" title="' + esc(r.p) + '">' + esc(shortPath(r.p)) + '</span>', fmtNum(r.sessions), tdNum(r.files), tdNum('+' + fmtNum(r.added)), tdNum('−' + fmtNum(r.removed)), tdNum(r.net)]; }));
+    pc._body.addEventListener('click', function (ev) {
+      var span = ev.target.closest('[data-proj-open]');
+      if (!span) return;
+      var path = span.getAttribute('data-proj-open');
+      openProjectModal(path, proj.get(path) || []);
+    });
     host.appendChild(pc);
   };
 
@@ -369,7 +375,7 @@
         + '<td class="td-number">−' + fmtNum(sum(ss, function (s) { return s.linesRemoved; })) + '</td>';
     };
     rows.forEach(function (r, i) {
-      html += '<tr class="clickable" data-proj="' + i + '"><td>▸ ' + esc(shortPath(r.p)) + '</td><td class="td-number">' + fmtNum(r.ss.length) + '</td><td class="td-number">' + fmtNum(sum(r.ss, function (s) { return s.turns; })) + '</td>' + crudCells(r.ss) + '<td class="td-number">' + fmtNum(sum(r.ss, function (s) { return s.netLines; })) + '</td><td class="td-number">' + successRate(r.ss) + '%</td><td class="td-number">' + fmtUSD(sum(r.ss, function (s) { return s.costUSD; })) + '</td></tr>';
+      html += '<tr class="clickable" data-proj="' + i + '" data-proj-path="' + esc(r.p) + '"><td>▸ <span class="proj-link" data-proj-open="' + esc(r.p) + '">' + esc(shortPath(r.p)) + '</span></td><td class="td-number">' + fmtNum(r.ss.length) + '</td><td class="td-number">' + fmtNum(sum(r.ss, function (s) { return s.turns; })) + '</td>' + crudCells(r.ss) + '<td class="td-number">' + fmtNum(sum(r.ss, function (s) { return s.netLines; })) + '</td><td class="td-number">' + successRate(r.ss) + '%</td><td class="td-number">' + fmtUSD(sum(r.ss, function (s) { return s.costUSD; })) + '</td></tr>';
       // branch sub-rows (hidden)
       var byBranch = groupBy(r.ss, function (s) { return s.branch || '(none)'; });
       byBranch.forEach(function (bss, b) {
@@ -379,6 +385,12 @@
     html += '</tbody></table>';
     wrap.innerHTML = html;
     wrap.addEventListener('click', function (ev) {
+      var open = ev.target.closest('[data-proj-open]');
+      if (open) {
+        var path = open.getAttribute('data-proj-open');
+        openProjectModal(path, byProj.get(path) || []);
+        return;
+      }
       var tr = ev.target.closest('tr[data-proj]');
       if (!tr) return;
       var id = tr.getAttribute('data-proj');
@@ -886,7 +898,7 @@
     });
     return wrap;
   }
-  function openSessionModal(s) {
+  function openSessionModal(s, onBack) {
     if (!s) return;
     closeSessionModal();
     var ov = el('div', 'modal-overlay'); ov.id = 'session-modal';
@@ -895,6 +907,14 @@
     // header — every interpolation through esc(); title is arbitrary user text (XSS vector).
     var head = el('div', 'modal-head');
     var htxt = el('div');
+    // onBack (optional): when this modal was reached from another modal (e.g. the project
+    // sessions list), render a Back affordance that returns there instead of just closing.
+    if (onBack) {
+      var back = el('button', 'modal-back', '← Back');
+      back.setAttribute('aria-label', 'Back to project');
+      back.addEventListener('click', function () { closeSessionModal(); onBack(); });
+      htxt.appendChild(back);
+    }
     htxt.appendChild(el('div', 'modal-title', esc(truncStr(firstWords(sessTitle(s), 10), 120))));
     var metaBits = [s.agentName, (s.models && s.models[0]) || null, shortPath(s.project), s.branch].filter(Boolean);
     htxt.appendChild(el('div', 'modal-meta', metaBits.map(function (b) { return esc(b); }).join('  ·  ')));
@@ -985,6 +1005,71 @@
     ov.addEventListener('click', function (ev) { if (ev.target === ov) closeSessionModal(); });
     modalEsc = function (ev) { if (ev.key === 'Escape') closeSessionModal(); };
     document.addEventListener('keydown', modalEsc);
+    document.body.appendChild(ov);
+  }
+
+  // ---- project-sessions modal --------------------------------------------
+  var projModalEsc = null;
+  function closeProjectModal() {
+    if (projModalEsc) { document.removeEventListener('keydown', projModalEsc); projModalEsc = null; }
+    var ov = document.getElementById('project-modal'); if (ov && ov.parentNode) ov.parentNode.removeChild(ov);
+  }
+  function openProjectModal(projectPath, sessions) {
+    closeProjectModal();
+    var sorted = sessions.slice().sort(function (a, b) { return b.startTime - a.startTime; });
+    var ov = el('div', 'modal-overlay'); ov.id = 'project-modal';
+    var modal = el('div', 'modal');
+
+    var head = el('div', 'modal-head');
+    var htxt = el('div');
+    htxt.appendChild(el('div', 'modal-title', esc(shortPath(projectPath))));
+    htxt.appendChild(el('div', 'modal-meta', esc(projectPath)));
+    head.appendChild(htxt);
+    var close = el('button', 'modal-close', '✕'); close.setAttribute('aria-label', 'Close'); close.addEventListener('click', closeProjectModal);
+    head.appendChild(close);
+    modal.appendChild(head);
+
+    var body = el('div', 'modal-body');
+    var totalCost = sum(sessions, function (s) { return s.costUSD || 0; });
+    var totalTurns = sum(sessions, function (s) { return s.turns || 0; });
+    var netLines = sum(sessions, function (s) { return s.netLines || 0; });
+    body.appendChild(statsEl([
+      ['Sessions', fmtNum(sessions.length)],
+      ['Total cost', fmtUSD(totalCost)],
+      ['Turns', fmtNum(totalTurns)],
+      ['Net lines', (netLines >= 0 ? '+' : '') + fmtNum(netLines)]
+    ]));
+
+    var tbl = el('div', 'table-wrapper proj-sessions');
+    tbl.innerHTML = tableHTML(
+      ['Session', 'Date', 'Turns', 'Cost', ''],
+      sorted.map(function (s) {
+        return [
+          // Truncate to a short preview (~12 words / 100 chars): keeps the table compact and
+          // avoids exposing the full first-prompt text in the project list.
+          esc(truncStr(firstWords(sessTitle(s), 12), 100)),
+          esc(fmtWhen(s.startTime)),
+          fmtNum(s.turns || 0),
+          fmtUSD(s.costUSD || 0),
+          '<button class="btn-open" data-open-session="' + esc(s.sessionId) + '">Open ↗</button>'
+        ];
+      }),
+      [false, false, true, true, false]
+    );
+    tbl.addEventListener('click', function (ev) {
+      var btn = ev.target.closest('[data-open-session]');
+      if (!btn) return;
+      var sid = btn.getAttribute('data-open-session');
+      closeProjectModal();
+      // Pass an onBack closure so the session modal can return to this project list.
+      openSessionModal(SESSION_BY_ID[sid], function () { openProjectModal(projectPath, sessions); });
+    });
+    body.appendChild(tbl);
+    modal.appendChild(body);
+    ov.appendChild(modal);
+    ov.addEventListener('click', function (ev) { if (ev.target === ov) closeProjectModal(); });
+    projModalEsc = function (ev) { if (ev.key === 'Escape') closeProjectModal(); };
+    document.addEventListener('keydown', projModalEsc);
     document.body.appendChild(ov);
   }
 

--- a/src/cli/commands/analytics/report/template.html
+++ b/src/cli/commands/analytics/report/template.html
@@ -123,7 +123,49 @@
     .empty { color: var(--color-text-muted); padding: 40px; text-align: center; }
     .search-input { width: 280px; }
     .clickable { cursor: pointer; }
+    .btn-open { background: var(--color-bg-btn-primary, #20222e); color: var(--color-primary, #7C5CFC); border: none; border-radius: 4px; padding: 2px 8px; font-size: 11px; cursor: pointer; white-space: nowrap; }
+    .btn-open:hover { background: var(--color-bg-btn-primary-h, #262941); }
+    .proj-link { color: var(--color-primary, #7C5CFC); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
     .drill { background: var(--color-bg-secondary); }
+    /* back affordance shown in the session modal when reached from the project sessions list */
+    .modal-back { background: transparent; border: none; color: var(--color-primary, #7C5CFC); cursor: pointer; font-size: 12px; padding: 0; margin: 0 0 6px; }
+    .modal-back:hover { text-decoration: underline; }
+    /* project sessions modal table — let the Session column absorb width and wrap, while the
+       metric columns size to their content. Prevents the table from forcing horizontal scroll. */
+    .proj-sessions .table td:not(:first-child), .proj-sessions .table th:not(:first-child) { white-space: nowrap; width: 1%; }
+    .proj-sessions .table td:first-child { white-space: normal; word-break: break-word; }
+
+    /* session-detail modal */
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.62); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal, 50); padding: 24px; }
+    .modal { background: var(--color-bg-card); border: 1px solid var(--color-border-structural); border-radius: var(--radius-xl, 12px); box-shadow: var(--shadow-lg); width: 100%; max-width: 880px; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; }
+    .modal-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--color-border-structural); }
+    .modal-title { font-size: 15px; font-weight: 700; color: var(--color-text-primary); margin: 0 0 3px; }
+    .modal-meta { font-size: 12px; color: var(--color-text-muted); text-transform: capitalize; }
+    .modal-close { background: transparent; border: 1px solid var(--color-border-structural); color: var(--color-text-muted); border-radius: 8px; height: 30px; width: 30px; cursor: pointer; font-size: 12px; flex-shrink: 0; }
+    .modal-close:hover { color: var(--color-text-primary); background: var(--color-bg-tertiary); }
+    .modal-body { padding: 18px 20px; overflow-y: auto; }
+    .modal-body .card { margin-bottom: 14px; }
+    /* light, borderless stat grid (replaces the heavy box-in-box KPIs) */
+    .modal-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(96px, 1fr)); gap: 14px 16px; }
+    .mstat .mlabel { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 3px; white-space: nowrap; }
+    .mstat .mval { font-size: 18px; font-weight: 700; color: var(--color-text-primary); white-space: nowrap; line-height: 1.2; }
+    .mstat .mval-sm { font-size: 13px; font-weight: 600; }
+    .mstat .msub { font-size: 11px; color: var(--color-text-muted); margin-top: 2px; }
+    .modal-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+    .modal-chips .chip { background: var(--color-bg-tertiary); border-radius: 999px; padding: 3px 10px; font-size: 12px; color: var(--color-text-primary); }
+    .modal-chips .chip b { color: var(--color-text-muted); font-weight: 600; margin-left: 3px; }
+    .dispatch-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 18px; }
+    .dispatch-col h4 { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--color-text-muted); margin: 0 0 8px; }
+    .grid-3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; align-items: stretch; }
+    /* dispatch timeline (Gantt) */
+    .timeline { display: flex; flex-direction: column; gap: 6px; }
+    .tl-row { display: flex; align-items: center; gap: 12px; }
+    .tl-label { width: 168px; flex-shrink: 0; font-size: 12px; color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tl-label-strong { font-weight: 700; }
+    .tl-track { position: relative; flex: 1; height: 22px; background: var(--color-bg-tertiary); border-radius: 5px; overflow: hidden; }
+    .tl-bar { position: absolute; top: 0; height: 100%; min-width: 3px; border-radius: 5px; display: flex; align-items: center; padding: 0 8px; box-sizing: border-box; }
+    .tl-bar-text { font-size: 10.5px; color: #fff; font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 600; }
+    .tl-dur { width: 58px; flex-shrink: 0; text-align: right; font-size: 11px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
 
     /* session-detail modal */
     .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.62); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal, 50); padding: 24px; }


### PR DESCRIPTION
## Summary

Expands the `codemie analytics --report` HTML output with deeper drill-down and more productivity-oriented widgets. The headline addition in the latest round: **project names on the Overview and Projects tabs are now clickable**, opening a project sessions modal that drills into the existing session-detail modal.

## What's included

### Clickable projects → session drill-down (latest)
- Project names on the **Overview** ("Top projects") and **Projects** tabs are clickable links (`data-proj-open`).
- Clicking a project opens a **project sessions modal**: summary stats (sessions, total cost, turns, net lines) + a per-session table (title, date, turns, cost, "Open ↗").
- "Open ↗" closes the project modal and opens the existing **session-detail modal**.
- On the Projects tab, the `▸` glyph still expands/collapses branches — only the project name opens the modal (no regression).

### UX refinements
- Session column shows a ~12-word truncated preview (privacy + compact rows), not the full prompt.
- Project sessions table sizes metric columns to content and lets the Session column wrap — no more horizontal scroll; Date stays on one line.
- A **← Back** affordance returns from the session detail to the project list (only when reached via a project; direct Sessions-tab opens are unchanged).

### Earlier on this branch
- Session-detail modal with token/cost growth chart and dispatch timeline.
- Efficiency widgets, change metrics, and named-invocation (agent/skill/command) insights.
- Native-log dispatch extraction + cost enrichment improvements.

## Implementation notes
- All client behaviour lives in `src/cli/commands/analytics/report/client/app.js` (vanilla ES5 IIFE, no build step) + scoped CSS in `template.html`.
- New `openProjectModal`/`closeProjectModal` mirror the existing `openSessionModal`/`closeSessionModal` lifecycle; single-modal-at-a-time pattern preserved.
- All user-derived strings escaped via `esc()`.

## Verification
- `npm run lint` — passes (zero warnings).
- `npm run build` — passes.
- `npm test` — **2144 passed, 2 skipped, 1 failed**. The single failure (`tests/integration/cli-commands/skills.test.ts › injects DO_NOT_TRACK`) is a pre-existing, environment-dependent integration test unrelated to this branch (touches no skills/env-shim code here).
- Manual browser verification (Playwright) of the clickable-projects flow: truncation, no horizontal scroll, Back navigation all confirmed against a real generated report.

Generated with AI

Co-Authored-By: codemie-ai <codemie.ai@gmail.com>