### PR TITLE
feat(providers): derive credential TTL from JWT exp instead of hardcoded 24h

### DIFF
--- a/src/providers/plugins/sso/__tests__/sso.auth.test.ts
+++ b/src/providers/plugins/sso/__tests__/sso.auth.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for deriveExpiresAt — JWT exp extraction from cookie dict.
+ * @group unit
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveExpiresAt } from '../sso.auth.js';
+
+function makeJwt(exp: number): string {
+  const payload = { sub: 'uid', email: 'u@test.com', exp, iss: 'codemie-local' };
+  const b64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `eyJhbGciOiJSUzI1NiJ9.${b64}.fakesig`;
+}
+
+describe('deriveExpiresAt', () => {
+  it('returns JWT exp * 1000 when codemie_access_token is a valid JWT with exp', () => {
+    const exp = Math.floor(Date.now() / 1000) + 7 * 24 * 3600; // 1 week
+    const jwt = makeJwt(exp);
+
+    const result = deriveExpiresAt({ codemie_access_token: jwt });
+
+    expect(result).toBe(exp * 1000);
+  });
+
+  it('falls back to ~24h when codemie_access_token is malformed', () => {
+    const before = Date.now();
+
+    const result = deriveExpiresAt({ codemie_access_token: 'not.a.valid.jwt.at.all' });
+
+    const after = Date.now();
+    const expected24h = before + 24 * 60 * 60 * 1000;
+    expect(result).toBeGreaterThanOrEqual(expected24h - 1000);
+    expect(result).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000 + 1000);
+  });
+
+  it('falls back to ~24h when codemie_access_token cookie is absent', () => {
+    const before = Date.now();
+
+    const result = deriveExpiresAt({});
+
+    const after = Date.now();
+    const expected24h = before + 24 * 60 * 60 * 1000;
+    expect(result).toBeGreaterThanOrEqual(expected24h - 1000);
+    expect(result).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000 + 1000);
+  });
+});

--- a/src/providers/plugins/sso/sso.auth.ts
+++ b/src/providers/plugins/sso/sso.auth.ts
@@ -36,6 +36,30 @@ function normalizeToBase(url: string): string {
 }
 
 /**
+ * Derive credential expiresAt from codemie_access_token JWT exp claim.
+ * Falls back to 24h when the cookie is absent or the JWT cannot be decoded.
+ */
+export function deriveExpiresAt(cookies: Record<string, string>): number {
+  const DEFAULT_TTL = 24 * 60 * 60 * 1000;
+  if (cookies.codemie_access_token) {
+    try {
+      const parts = cookies.codemie_access_token.split('.');
+      if (parts.length === 3) {
+        const payload = JSON.parse(
+          Buffer.from(parts[1], 'base64').toString('utf8'),
+        );
+        if (payload.exp && typeof payload.exp === 'number') {
+          return payload.exp * 1000;
+        }
+      }
+    } catch {
+      // malformed JWT — fall through to default
+    }
+  }
+  return Date.now() + DEFAULT_TTL;
+}
+
+/**
  * CodeMie SSO Authentication
  *
  * Provides browser-based SSO authentication for CodeMie provider

--- a/src/providers/plugins/sso/sso.auth.ts
+++ b/src/providers/plugins/sso/sso.auth.ts
@@ -120,7 +120,7 @@ export class CodeMieSSO {
         const credentials: SSOCredentials = {
           cookies: result.cookies,
           apiUrl: result.apiUrl,
-          expiresAt: Date.now() + (24 * 60 * 60 * 1000) // 24 hours
+          expiresAt: deriveExpiresAt(result.cookies),
         };
 
         const store = CredentialStore.getInstance();


### PR DESCRIPTION
## Summary

Replaces the hardcoded 24-hour TTL for provider credentials with a `deriveExpiresAt` helper that reads the actual expiry from the JWT `exp` claim. This makes credential lifetimes accurate for tokens that expire sooner or later than 24 hours.

## Changes

- Exported `deriveExpiresAt` helper in `src/providers/` for JWT exp-based credential TTL calculation
- Updated `authenticate()` in providers to use `deriveExpiresAt` instead of hardcoded 24h TTL

## Impact

Credentials now expire at the correct time based on the actual JWT token, preventing premature expiry or stale credentials being used past their actual validity window.

## Checklist

- [ ] Self-reviewed
- [ ] Manual testing performed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)