### PR TITLE
feat(kimi): add Kimi agent plugin with ACP support and Moonshot subscription provider

### DIFF
--- a/bin/codemie-kimi-acp.js
+++ b/bin/codemie-kimi-acp.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * Kimi Code ACP Agent Entry Point
+ * Direct entry point for codemie-kimi-acp command
+ */
+
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+
+const agent = AgentRegistry.getAgent('kimi-acp');
+if (!agent) {
+  console.error('✗ Kimi ACP agent not found in registry');
+  process.exit(1);
+}
+
+const cli = new AgentCLI(agent);
+await cli.run(process.argv);

--- a/bin/codemie-kimi.js
+++ b/bin/codemie-kimi.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * Kimi Code Agent Entry Point
+ * Direct entry point for codemie-kimi command
+ */
+
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+
+const agent = AgentRegistry.getAgent('kimi');
+if (!agent) {
+  console.error('✗ Kimi agent not found in registry');
+  process.exit(1);
+}
+
+const cli = new AgentCLI(agent);
+await cli.run(process.argv);

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -41,6 +41,7 @@ module.exports = {
         'deps', // Dependencies
         'tests', // Test infrastructure
         'skills', // Skills system
+        'kimi', // Kimi agent integration
       ],
     ],
     // Scope is completely optional (no warning)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@clack/core": "^0.5.0",
         "@clack/prompts": "^0.11.0",
         "@codemieai/codemie-opencode": "0.0.47",
+        "@iarna/toml": "^2.2.5",
         "@langchain/core": "^1.0.4",
         "@langchain/langgraph": "^1.0.2",
         "@langchain/openai": "^1.1.0",
@@ -44,6 +45,7 @@
         "zod": "^4.1.12"
       },
       "bin": {
+        "code": "bin/codemie.js",
         "codemie": "bin/codemie.js",
         "codemie-claude": "bin/codemie-claude.js",
         "codemie-claude-acp": "bin/codemie-claude-acp.js",
@@ -2271,6 +2273,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^0.11.0",
     "@codemieai/codemie-opencode": "0.0.47",
+    "@iarna/toml": "^2.2.5",
     "@langchain/core": "^1.0.4",
     "@langchain/langgraph": "^1.0.2",
     "@langchain/openai": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "codemie-gemini": "./bin/codemie-gemini.js",
     "codemie-opencode": "./bin/codemie-opencode.js",
     "codemie-codex": "./bin/codemie-codex.js",
+    "codemie-kimi": "./bin/codemie-kimi.js",
+    "codemie-kimi-acp": "./bin/codemie-kimi-acp.js",
     "codemie-mcp-proxy": "./bin/codemie-mcp-proxy.js",
     "proxy-daemon": "./bin/proxy-daemon.js"
   },

--- a/scripts/copy-plugins.js
+++ b/scripts/copy-plugins.js
@@ -25,6 +25,11 @@ const copyConfigs = [
     dest: join(rootDir, 'dist/agents/plugins/gemini/extension')
   },
   {
+    name: 'Kimi extension',
+    src: join(rootDir, 'src/agents/plugins/kimi/extension'),
+    dest: join(rootDir, 'dist/agents/plugins/kimi/extension')
+  },
+  {
     name: 'Top-level assets',
     src: join(rootDir, 'assets'),
     dest: join(rootDir, 'dist/assets')

--- a/scripts/verify-kimi-integration.mjs
+++ b/scripts/verify-kimi-integration.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * End-to-end verification script for the Kimi Code agent integration.
+ *
+ * This script:
+ *  - Creates an isolated temp directory and a fake `kimi` binary on PATH.
+ *  - Verifies `codemie-kimi --version` and `codemie-kimi health` work.
+ *  - Injects CodeMie lifecycle hooks into a temp Kimi config.toml.
+ *  - Parses a fake `wire.jsonl` session with `KimiSessionAdapter` and extracts
+ *    metrics with `KimiMetricsProcessor`.
+ */
+
+import { spawnSync } from 'child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { join, resolve } from 'path';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
+const distRoot = join(repoRoot, 'dist');
+
+// Load real built implementations from dist/.
+const { KimiPluginMetadata } = await import(
+  join(distRoot, 'agents/plugins/kimi/kimi.plugin.js')
+);
+const { KimiHookConfigInjector } = await import(
+  join(distRoot, 'agents/plugins/kimi/kimi.hook-config-injector.js')
+);
+const { KimiSessionAdapter } = await import(
+  join(distRoot, 'agents/plugins/kimi/kimi.session.js')
+);
+const { KimiMetricsProcessor } = await import(
+  join(distRoot, 'agents/plugins/kimi/session/processors/kimi.metrics-processor.js')
+);
+
+const PACKAGE_VERSION = '0.4.2';
+const SESSION_ID = 'verify-session-001';
+
+const sampleWire = `\
+{"type":"metadata","protocol_version":"1.4","created_at":1781363635367,"app_version":"0.14.2"}
+{"type":"config.update","profileName":"agent","systemPrompt":"You are a helpful coding assistant.","modelAlias":"kimi-code/kimi-for-coding","thinkingLevel":"high","time":1781368649422}
+{"type":"tools.set_active_tools","toolNames":["Read","Write","Edit","Bash","Glob"],"time":1781368649423}
+{"type":"turn.prompt","role":"user","content":"Please read src/index.ts and then update it.","time":1781368649424}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call-read-001","turnId":"0","step":1,"toolCallId":"tool_read_001","name":"Read","args":{"file_path":"/Users/alice/project/src/index.ts"},"description":"Read source file","display":{"kind":"brief","text":"Read src/index.ts"}},"time":1781368649425}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call-read-001","toolCallId":"tool_read_001","result":{"output":"export const version = '1.0.0';\\n","isError":false}},"time":1781368649426}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call-write-001","turnId":"0","step":2,"toolCallId":"tool_write_001","name":"Write","args":{"file_path":"/Users/alice/project/src/index.ts","content":"export const version = '1.1.0';\\n"},"description":"Write source file","display":{"kind":"brief","text":"Write src/index.ts"}},"time":1781368649427}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call-write-001","toolCallId":"tool_write_001","result":{"output":"File written successfully","isError":false}},"time":1781368649428}
+{"type":"context.append_loop_event","event":{"type":"display.render","uuid":"display-read-001","turnId":"0","step":1},"display":{"kind":"file_io","operation":"read","path":"/Users/alice/project/src/index.ts"},"time":1781368649429}
+{"type":"context.append_loop_event","event":{"type":"display.render","uuid":"display-write-001","turnId":"0","step":2},"display":{"kind":"file_io","operation":"write","path":"/Users/alice/project/src/index.ts","content":"export const version = '1.1.0';\\n"},"time":1781368649430}
+{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":14341,"output":570,"inputCacheRead":14336,"inputCacheCreation":0},"usageScope":"turn","time":1781368649431}
+`;
+
+function run(command, args, extraEnv = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    shell: false,
+    env: { ...process.env, ...extraEnv },
+  });
+
+  if (result.error) {
+    throw new Error(
+      `Failed to execute "${command} ${args.join(' ')}": ${result.error.message}`
+    );
+  }
+
+  return result;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+let tmpDir;
+
+try {
+  // 1. Prepare isolated temp directory with fake Kimi binary on PATH.
+  tmpDir = mkdtempSync(join(tmpdir(), 'codemie-kimi-verify-'));
+  const fakeBinDir = join(tmpDir, 'bin');
+  const fakeSessionDir = join(tmpDir, 'sessions', SESSION_ID, 'agents', 'main');
+  mkdirSync(fakeBinDir, { recursive: true });
+  mkdirSync(fakeSessionDir, { recursive: true });
+
+  const wirePath = join(fakeSessionDir, 'wire.jsonl');
+  writeFileSync(wirePath, sampleWire, 'utf-8');
+
+  const fakeKimiPath = join(fakeBinDir, 'kimi');
+  const fakeKimiScript = `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const home = process.env.KIMI_CODE_HOME || path.join(require('os').homedir(), '.kimi-code');
+const wireDir = path.join(home, 'sessions', '${SESSION_ID}', 'agents', 'main');
+const wirePath = path.join(wireDir, 'wire.jsonl');
+const sample = ${JSON.stringify(sampleWire)};
+fs.mkdirSync(wireDir, { recursive: true });
+fs.writeFileSync(wirePath, sample, 'utf-8');
+console.log('kimi 1.0.0');
+`;
+  writeFileSync(fakeKimiPath, fakeKimiScript, 'utf-8');
+  chmodSync(fakeKimiPath, 0o755);
+
+  const verificationEnv = {
+    KIMI_CODE_HOME: tmpDir,
+    PATH: `${fakeBinDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`,
+  };
+
+  // 2. Verify codemie-kimi --version.
+  const versionResult = run(
+    'node',
+    ['./bin/codemie-kimi.js', '--version'],
+    verificationEnv
+  );
+  assert(versionResult.status === 0, `codemie-kimi --version failed: ${versionResult.stderr}`);
+  assert(
+    versionResult.stdout.includes(PACKAGE_VERSION),
+    `Expected codemie-kimi --version to contain "${PACKAGE_VERSION}", got: ${versionResult.stdout}`
+  );
+  console.log(`✓ codemie-kimi --version: ${versionResult.stdout.trim()}`);
+
+  // 3. Verify the fake binary is discovered and reports its version via health.
+  const healthResult = run(
+    'node',
+    ['./bin/codemie-kimi.js', 'health'],
+    verificationEnv
+  );
+  assert(healthResult.status === 0, `codemie-kimi health failed: ${healthResult.stderr}`);
+  assert(
+    healthResult.stdout.includes('installed and ready'),
+    `Expected health output to report "installed and ready", got: ${healthResult.stdout}`
+  );
+  assert(
+    healthResult.stdout.includes('1.0.0'),
+    `Expected health output to contain fake kimi version "1.0.0", got: ${healthResult.stdout}`
+  );
+  console.log('✓ codemie-kimi health detected the fake kimi binary');
+
+  // 4. Trigger hook config injection and verify config.toml contents.
+  process.env.KIMI_CODE_HOME = tmpDir;
+  const injector = new KimiHookConfigInjector();
+  const injection = await injector.inject();
+  assert(
+    injection.success,
+    `Kimi hook config injection failed: ${injection.error ?? 'unknown error'}`
+  );
+
+  const configContent = readFileSync(injection.configPath, 'utf-8');
+  assert(
+    configContent.includes('command = "codemie hook"'),
+    `Expected ${injection.configPath} to contain 'command = "codemie hook"', got:\n${configContent}`
+  );
+  console.log('✓ config.toml contains command = "codemie hook"');
+
+  // 5. Verify the session wire.jsonl can be parsed and metrics extracted.
+  const adapter = new KimiSessionAdapter(KimiPluginMetadata);
+  const session = await adapter.parseSessionFile(wirePath, SESSION_ID);
+  assert(session.messages.length > 0, 'Expected parsed session to contain events');
+  assert(
+    session.metadata.model === 'kimi-code/kimi-for-coding',
+    `Expected model "kimi-code/kimi-for-coding", got ${session.metadata.model}`
+  );
+
+  const processor = new KimiMetricsProcessor();
+  const processingContext = {
+    apiBaseUrl: '',
+    cookies: '',
+    clientType: 'test',
+    version: '0.0.0',
+    dryRun: true,
+  };
+  const processingResult = await processor.process(session, processingContext);
+  assert(
+    processingResult.success,
+    `KimiMetricsProcessor failed: ${processingResult.message ?? 'unknown error'}`
+  );
+  assert(
+    (session.metrics?.tools?.Read ?? 0) >= 1,
+    `Expected at least one Read tool call, got: ${JSON.stringify(session.metrics?.tools)}`
+  );
+  assert(
+    (session.metrics?.tools?.Write ?? 0) >= 1,
+    `Expected at least one Write tool call, got: ${JSON.stringify(session.metrics?.tools)}`
+  );
+  assert(
+    (session.metrics?.fileOperations?.length ?? 0) >= 2,
+    `Expected at least two file operations, got: ${JSON.stringify(session.metrics?.fileOperations)}`
+  );
+  console.log('✓ KimiSessionAdapter and KimiMetricsProcessor work end-to-end');
+
+  console.log('Verification passed');
+} catch (error) {
+  console.error('Verification failed:', error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/verify-kimi-integration.mjs
+++ b/scripts/verify-kimi-integration.mjs
@@ -10,9 +10,13 @@
  *    metrics with `KimiMetricsProcessor`.
  */
 
+// This script is intentionally not covered by `npm run lint`, which only lints
+// TypeScript files under `src/` and `tests/`.
+
 import { spawnSync } from 'child_process';
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -25,6 +29,15 @@ import { join, resolve } from 'path';
 
 const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
 const distRoot = join(repoRoot, 'dist');
+
+// Pre-flight: ensure the dist build output is present before importing.
+const registryPath = join(distRoot, 'agents', 'registry.js');
+if (!existsSync(registryPath)) {
+  console.error(
+    `Error: Build output not found at ${registryPath}. Run "npm run build" first.`
+  );
+  process.exit(1);
+}
 
 // Load real built implementations from dist/.
 const { KimiPluginMetadata } = await import(
@@ -40,7 +53,8 @@ const { KimiMetricsProcessor } = await import(
   join(distRoot, 'agents/plugins/kimi/session/processors/kimi.metrics-processor.js')
 );
 
-const PACKAGE_VERSION = '0.4.2';
+const packageJsonPath = join(repoRoot, 'package.json');
+const PACKAGE_VERSION = JSON.parse(readFileSync(packageJsonPath, 'utf-8')).version;
 const SESSION_ID = 'verify-session-001';
 
 const sampleWire = `\
@@ -82,6 +96,28 @@ function assert(condition, message) {
 
 let tmpDir;
 
+function cleanup() {
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup; do not mask the original failure.
+    }
+  }
+}
+
+function cleanupAndExit(signal) {
+  cleanup();
+  process.exit(signal === 'SIGINT' ? 130 : 143);
+}
+
+const sigintHandler = () => cleanupAndExit('SIGINT');
+const sigtermHandler = () => cleanupAndExit('SIGTERM');
+process.once('SIGINT', sigintHandler);
+process.once('SIGTERM', sigtermHandler);
+
+const originalKimiCodeHome = process.env.KIMI_CODE_HOME;
+
 try {
   // 1. Prepare isolated temp directory with fake Kimi binary on PATH.
   tmpDir = mkdtempSync(join(tmpdir(), 'codemie-kimi-verify-'));
@@ -94,10 +130,19 @@ try {
   writeFileSync(wirePath, sampleWire, 'utf-8');
 
   const fakeKimiPath = join(fakeBinDir, 'kimi');
+  // The fake binary is an ES module: we provide a local package.json with
+  // "type": "module" so the extension-less file can use ESM syntax.
+  writeFileSync(
+    join(fakeBinDir, 'package.json'),
+    JSON.stringify({ type: 'module' }),
+    'utf-8'
+  );
   const fakeKimiScript = `#!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
-const home = process.env.KIMI_CODE_HOME || path.join(require('os').homedir(), '.kimi-code');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const home = process.env.KIMI_CODE_HOME || path.join(os.homedir(), '.kimi-code');
 const wireDir = path.join(home, 'sessions', '${SESSION_ID}', 'agents', 'main');
 const wirePath = path.join(wireDir, 'wire.jsonl');
 const sample = ${JSON.stringify(sampleWire)};
@@ -200,7 +245,12 @@ console.log('kimi 1.0.0');
   console.error('Verification failed:', error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 } finally {
-  if (tmpDir) {
-    rmSync(tmpDir, { recursive: true, force: true });
+  cleanup();
+  process.off('SIGINT', sigintHandler);
+  process.off('SIGTERM', sigtermHandler);
+  if (originalKimiCodeHome === undefined) {
+    delete process.env.KIMI_CODE_HOME;
+  } else {
+    process.env.KIMI_CODE_HOME = originalKimiCodeHome;
   }
 }

--- a/src/agents/__tests__/registry.test.ts
+++ b/src/agents/__tests__/registry.test.ts
@@ -12,8 +12,8 @@ describe('AgentRegistry', () => {
     it('should register all default agents', () => {
       const agentNames = AgentRegistry.getAgentNames();
 
-      // Should have all 6 default agents (codemie-code, claude, claude-acp, gemini, opencode, codex)
-      expect(agentNames).toHaveLength(6);
+      // Should have all 8 default agents (codemie-code, claude, claude-acp, gemini, opencode, codex, kimi, kimi-acp)
+      expect(agentNames).toHaveLength(8);
     });
 
     it('should register built-in agent', () => {
@@ -50,6 +50,20 @@ describe('AgentRegistry', () => {
       expect(agent).toBeDefined();
       expect(agent?.name).toBe('claude-acp');
     });
+
+    it('should register Kimi plugin', () => {
+      const agent = AgentRegistry.getAgent('kimi');
+
+      expect(agent).toBeDefined();
+      expect(agent?.name).toBe('kimi');
+    });
+
+    it('should register Kimi ACP plugin', () => {
+      const agent = AgentRegistry.getAgent('kimi-acp');
+
+      expect(agent).toBeDefined();
+      expect(agent?.name).toBe('kimi-acp');
+    });
   });
 
   describe('Agent Retrieval', () => {
@@ -62,7 +76,7 @@ describe('AgentRegistry', () => {
     it('should return all registered agents', () => {
       const agents = AgentRegistry.getAllAgents();
 
-      expect(agents).toHaveLength(6);
+      expect(agents).toHaveLength(8);
       expect(agents.every((agent) => agent.name)).toBe(true);
     });
 
@@ -75,6 +89,8 @@ describe('AgentRegistry', () => {
       expect(names).toContain('gemini');
       expect(names).toContain('opencode');
       expect(names).toContain('codex');
+      expect(names).toContain('kimi');
+      expect(names).toContain('kimi-acp');
     });
   });
 

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -15,6 +15,8 @@ import { GeminiPluginMetadata } from '../plugins/gemini/gemini.plugin.js';
 import { OpenCodePluginMetadata } from '../plugins/opencode/opencode.plugin.js';
 import {ClaudeAcpPluginMetadata} from "../plugins/claude/claude-acp.plugin.js";
 import { CodexPluginMetadata } from '../plugins/codex/codex.plugin.js';
+import { KimiPluginMetadata } from '../plugins/kimi/kimi.plugin.js';
+import { KimiAcpPluginMetadata } from '../plugins/kimi/kimi-acp.plugin.js';
 import { createAssistantsSetupCommand } from '../../cli/commands/assistants/setup/index.js';
 import { createSkillsSetupCommand } from '../../cli/commands/skills/setup/index.js';
 import type { TargetAgent } from '../../cli/commands/shared/agent-targets.js';
@@ -461,6 +463,8 @@ export class AgentCLI {
       'opencode': OpenCodePluginMetadata,
       'claude-acp': ClaudeAcpPluginMetadata,
       'codex': CodexPluginMetadata,
+      'kimi': KimiPluginMetadata,
+      'kimi-acp': KimiAcpPluginMetadata,
     };
     return metadataMap[this.adapter.name];
   }

--- a/src/agents/core/types.ts
+++ b/src/agents/core/types.ts
@@ -293,6 +293,13 @@ export interface AgentMetadata {
    * Defines where to find agents/commands/skills/hooks/rules for this agent
    */
   extensionsConfig?: AgentExtensionsConfig;
+
+  // === Hook Configuration ===
+  /**
+   * Hook event name mapping for agents whose native hook names differ
+   * from the internal names used by the hook router.
+   */
+  hookConfig?: AgentHookConfig;
 }
 
 /**
@@ -522,6 +529,39 @@ export interface HookTransformer {
    * Agent name for this transformer
    */
   readonly agentName: string;
+}
+
+/**
+ * Internal hook event names recognized by the hook router.
+ * These are the canonical event names used by CodeMie CLI hook handlers.
+ */
+export type InternalHookEventName =
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'PermissionRequest'
+  | 'Stop'
+  | 'UserPromptSubmit'
+  | 'SubagentStop'
+  | 'PreCompact';
+
+/**
+ * Agent-specific hook configuration.
+ */
+export interface AgentHookConfig {
+  /**
+   * Maps agent-native hook event names to internal hook event names.
+   * Keys are event names emitted by the agent; values are names used by the hook router.
+   *
+   * Valid internal values: SessionStart, SessionEnd, PermissionRequest, Stop,
+   * UserPromptSubmit, SubagentStop, PreCompact.
+   *
+   * @example
+   * eventNameMapping: {
+   *   'session_start': 'SessionStart',
+   *   'session_end': 'SessionEnd'
+   * }
+   */
+  eventNameMapping?: Record<string, InternalHookEventName>;
 }
 
 /**

--- a/src/agents/plugins/gemini/gemini.plugin.ts
+++ b/src/agents/plugins/gemini/gemini.plugin.ts
@@ -117,7 +117,7 @@ const metadata = {
       'AfterAgent': 'Stop',             // Gemini's AfterAgent = Claude's Stop
       'BeforeAgent': 'UserPromptSubmit', // Gemini's BeforeAgent = Claude's UserPromptSubmit
       'Notification': 'PermissionRequest'  // Gemini's Notification = Claude's PermissionRequest
-    }
+    } as const
   }
 };
 

--- a/src/agents/plugins/kimi/__tests__/fixtures/sample-wire.jsonl
+++ b/src/agents/plugins/kimi/__tests__/fixtures/sample-wire.jsonl
@@ -1,0 +1,11 @@
+{"type":"metadata","protocol_version":"1.4","created_at":1781363635367,"app_version":"0.14.2"}
+{"type":"config.update","profileName":"agent","systemPrompt":"You are a helpful coding assistant.","modelAlias":"kimi-code/kimi-for-coding","thinkingLevel":"high","time":1781368649422}
+{"type":"tools.set_active_tools","toolNames":["Read","Write","Edit","Bash","Glob"],"time":1781368649423}
+{"type":"turn.prompt","role":"user","content":"Please read src/index.ts and then update it.","time":1781368649424}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call-read-001","turnId":"0","step":1,"toolCallId":"tool_read_001","name":"Read","args":{"file_path":"/Users/alice/project/src/index.ts"},"description":"Read source file","display":{"kind":"brief","text":"Read src/index.ts"}},"time":1781368649425}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call-read-001","toolCallId":"tool_read_001","result":{"output":"export const version = '1.0.0';\n","isError":false}},"time":1781368649426}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call-write-001","turnId":"0","step":2,"toolCallId":"tool_write_001","name":"Write","args":{"file_path":"/Users/alice/project/src/index.ts","content":"export const version = '1.1.0';\n"},"description":"Write source file","display":{"kind":"brief","text":"Write src/index.ts"}},"time":1781368649427}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call-write-001","toolCallId":"tool_write_001","result":{"output":"File written successfully","isError":false}},"time":1781368649428}
+{"type":"context.append_loop_event","event":{"type":"display.render","uuid":"display-read-001","turnId":"0","step":1},"display":{"kind":"file_io","operation":"read","path":"/Users/alice/project/src/index.ts"},"time":1781368649429}
+{"type":"context.append_loop_event","event":{"type":"display.render","uuid":"display-write-001","turnId":"0","step":2},"display":{"kind":"file_io","operation":"write","path":"/Users/alice/project/src/index.ts","content":"export const version = '1.1.0';\n"},"time":1781368649430}
+{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":14341,"output":570,"inputCacheRead":14336,"inputCacheCreation":0},"usageScope":"turn","time":1781368649431}

--- a/src/agents/plugins/kimi/__tests__/fixtures/usage-only-model.jsonl
+++ b/src/agents/plugins/kimi/__tests__/fixtures/usage-only-model.jsonl
@@ -1,0 +1,3 @@
+{"type":"metadata","protocol_version":"1.4","created_at":1781363635367,"app_version":"0.14.2"}
+{"type":"turn.prompt","role":"user","content":"Hello","time":1781368649424}
+{"type":"usage.record","model":"kimi-code/fallback-model","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1781368649431}

--- a/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
@@ -9,12 +9,22 @@ import { homedir } from 'os';
 import { join, isAbsolute } from 'path';
 import type { AgentMetadata } from '../../core/types.js';
 
+// Mock fs before any imports, preserving real fs constants
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn()
+  };
+});
+
 // Mock fs/promises before any imports
 vi.mock('fs/promises');
 
 // Now import the module and mocks
 const { KimiExtensionInstaller } = await import('../kimi.extension-installer.js');
 const fsp = await import('fs/promises');
+const fs = await import('fs');
 
 const mockMetadata: AgentMetadata = {
   name: 'kimi',
@@ -105,6 +115,8 @@ describe('KimiExtensionInstaller', () => {
     it('should copy files for a new install', async () => {
       const mockVersion = '0.1.0';
 
+      fs.existsSync.mockReturnValue(false);
+
       vi.spyOn(fsp, 'readFile')
         .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })) // source version
         .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })); // verify manifest
@@ -125,6 +137,92 @@ describe('KimiExtensionInstaller', () => {
       expect(result.sourceVersion).toBe(mockVersion);
       expect(result.targetPath).toBe(expectedTargetPath);
       expect(fsp.cp).toHaveBeenCalled();
+    });
+
+    it('should update when versions differ', async () => {
+      const oldVersion = '0.0.1';
+      const newVersion = '0.1.0';
+
+      fs.existsSync.mockReturnValue(true);
+
+      vi.spyOn(fsp, 'readFile')
+        .mockResolvedValueOnce(JSON.stringify({ version: newVersion })) // source version
+        .mockResolvedValueOnce(JSON.stringify({ version: oldVersion })) // installed version
+        .mockResolvedValueOnce(JSON.stringify({ version: newVersion })); // verify manifest
+
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // source exists
+        .mockResolvedValueOnce(undefined) // target dir exists
+        .mockResolvedValueOnce(undefined) // manifest exists
+        .mockResolvedValueOnce(undefined) // SKILL.md exists
+        .mockResolvedValueOnce(undefined) // verify manifest
+        .mockResolvedValueOnce(undefined); // verify SKILL.md
+
+      vi.spyOn(fsp, 'mkdir').mockResolvedValue(undefined);
+      vi.spyOn(fsp, 'cp').mockResolvedValue(undefined);
+
+      const result = await installer.install();
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('updated');
+      expect(result.installedVersion).toBe(oldVersion);
+      expect(result.sourceVersion).toBe(newVersion);
+      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(fsp.cp).toHaveBeenCalled();
+    });
+  });
+
+  describe('getInstalledInfo', () => {
+    it('should report installed when both manifest.json and SKILL.md are readable', async () => {
+      const mockVersion = '0.1.0';
+
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // target dir exists
+        .mockResolvedValueOnce(undefined) // manifest.json exists
+        .mockResolvedValueOnce(undefined); // SKILL.md exists
+
+      vi.spyOn(fsp, 'readFile').mockResolvedValueOnce(
+        JSON.stringify({ version: mockVersion })
+      );
+
+      const info = await (
+        installer as unknown as {
+          getInstalledInfo(): Promise<{ installed: boolean; version: string | null } | null>;
+        }
+      ).getInstalledInfo();
+
+      expect(info).not.toBeNull();
+      expect(info?.installed).toBe(true);
+      expect(info?.version).toBe(mockVersion);
+    });
+
+    it('should report not installed when manifest.json is missing', async () => {
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // target dir exists
+        .mockRejectedValueOnce(new Error('Manifest not found')); // manifest.json missing
+
+      const info = await (
+        installer as unknown as {
+          getInstalledInfo(): Promise<{ installed: boolean; version: string | null } | null>;
+        }
+      ).getInstalledInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it('should report not installed when SKILL.md is missing', async () => {
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // target dir exists
+        .mockResolvedValueOnce(undefined) // manifest.json exists
+        .mockRejectedValueOnce(new Error('SKILL.md not found')); // SKILL.md missing
+
+      const info = await (
+        installer as unknown as {
+          getInstalledInfo(): Promise<{ installed: boolean; version: string | null } | null>;
+        }
+      ).getInstalledInfo();
+
+      expect(info).toBeNull();
     });
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
@@ -5,9 +5,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { homedir } from 'os';
 import { join, isAbsolute } from 'path';
 import type { AgentMetadata } from '../../core/types.js';
+import { getKimiUserSkillsDir } from '../kimi.paths.js';
 
 // Mock fs before any imports, preserving real fs constants
 vi.mock('fs', async () => {
@@ -37,17 +37,19 @@ const mockMetadata: AgentMetadata = {
 };
 
 describe('KimiExtensionInstaller', () => {
-  const expectedTargetPath = join(homedir(), '.kimi-code', 'skills', 'codemie-kimi');
+  const expectedTargetPath = (): string => join(getKimiUserSkillsDir(), 'codemie-kimi');
   let installer: KimiExtensionInstaller;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetAllMocks();
+    delete process.env.KIMI_CODE_HOME;
     installer = new KimiExtensionInstaller(mockMetadata);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.KIMI_CODE_HOME;
   });
 
   describe('getTargetPath', () => {
@@ -58,6 +60,12 @@ describe('KimiExtensionInstaller', () => {
 
     it('should return absolute path', () => {
       expect(isAbsolute(installer.getTargetPath())).toBe(true);
+    });
+
+    it('should respect KIMI_CODE_HOME environment variable', () => {
+      process.env.KIMI_CODE_HOME = '/tmp/kimi-test-home';
+      const targetPath = installer.getTargetPath();
+      expect(targetPath).toBe('/tmp/kimi-test-home/skills/codemie-kimi');
     });
   });
 
@@ -108,7 +116,7 @@ describe('KimiExtensionInstaller', () => {
       expect(result.action).toBe('already_exists');
       expect(result.sourceVersion).toBe(mockVersion);
       expect(result.installedVersion).toBe(mockVersion);
-      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(result.targetPath).toBe(expectedTargetPath());
       expect(fsp.cp).not.toHaveBeenCalled();
     });
 
@@ -135,7 +143,7 @@ describe('KimiExtensionInstaller', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('copied');
       expect(result.sourceVersion).toBe(mockVersion);
-      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(result.targetPath).toBe(expectedTargetPath());
       expect(fsp.cp).toHaveBeenCalled();
     });
 
@@ -167,7 +175,7 @@ describe('KimiExtensionInstaller', () => {
       expect(result.action).toBe('updated');
       expect(result.installedVersion).toBe(oldVersion);
       expect(result.sourceVersion).toBe(newVersion);
-      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(result.targetPath).toBe(expectedTargetPath());
       expect(fsp.cp).toHaveBeenCalled();
     });
   });

--- a/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for Kimi Extension Installer
+ *
+ * @group unit
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { AgentMetadata } from '../../core/types.js';
+import { KimiExtensionInstaller } from '../kimi.extension-installer.js';
+
+const mockMetadata: AgentMetadata = {
+  name: 'kimi',
+  displayName: 'Kimi Code CLI',
+  description: 'Test metadata for the Kimi extension installer',
+  npmPackage: null,
+  cliCommand: 'kimi',
+  envMapping: {},
+  supportedProviders: ['ai-run-sso']
+};
+
+describe('KimiExtensionInstaller', () => {
+  const installer = new KimiExtensionInstaller(mockMetadata);
+
+  describe('getTargetPath', () => {
+    it('should return correct target path in ~/.kimi-code/skills/', () => {
+      const targetPath = installer.getTargetPath();
+      expect(targetPath).toMatch(/.kimi-code\/skills\/codemie-kimi$/);
+    });
+  });
+
+  describe('getSourcePath', () => {
+    it('should return a path ending with /extension', () => {
+      const sourcePath = (installer as unknown as { getSourcePath(): string }).getSourcePath();
+      expect(sourcePath.endsWith('/extension')).toBe(true);
+    });
+  });
+
+  describe('getCriticalFiles', () => {
+    it('should include manifest.json and SKILL.md', () => {
+      const criticalFiles = (installer as unknown as { getCriticalFiles(): string[] }).getCriticalFiles();
+      expect(criticalFiles).toContain('manifest.json');
+      expect(criticalFiles).toContain('SKILL.md');
+    });
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.extension-installer.test.ts
@@ -4,9 +4,17 @@
  * @group unit
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { homedir } from 'os';
+import { join, isAbsolute } from 'path';
 import type { AgentMetadata } from '../../core/types.js';
-import { KimiExtensionInstaller } from '../kimi.extension-installer.js';
+
+// Mock fs/promises before any imports
+vi.mock('fs/promises');
+
+// Now import the module and mocks
+const { KimiExtensionInstaller } = await import('../kimi.extension-installer.js');
+const fsp = await import('fs/promises');
 
 const mockMetadata: AgentMetadata = {
   name: 'kimi',
@@ -19,19 +27,34 @@ const mockMetadata: AgentMetadata = {
 };
 
 describe('KimiExtensionInstaller', () => {
-  const installer = new KimiExtensionInstaller(mockMetadata);
+  const expectedTargetPath = join(homedir(), '.kimi-code', 'skills', 'codemie-kimi');
+  let installer: KimiExtensionInstaller;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+    installer = new KimiExtensionInstaller(mockMetadata);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   describe('getTargetPath', () => {
     it('should return correct target path in ~/.kimi-code/skills/', () => {
       const targetPath = installer.getTargetPath();
-      expect(targetPath).toMatch(/.kimi-code\/skills\/codemie-kimi$/);
+      expect(targetPath).toMatch(/\.kimi-code[\\/]skills[\\/]codemie-kimi$/);
+    });
+
+    it('should return absolute path', () => {
+      expect(isAbsolute(installer.getTargetPath())).toBe(true);
     });
   });
 
   describe('getSourcePath', () => {
-    it('should return a path ending with /extension', () => {
+    it('should return a path ending with the extension directory', () => {
       const sourcePath = (installer as unknown as { getSourcePath(): string }).getSourcePath();
-      expect(sourcePath.endsWith('/extension')).toBe(true);
+      expect(sourcePath).toMatch(/[\\/]extension$/);
     });
   });
 
@@ -40,6 +63,68 @@ describe('KimiExtensionInstaller', () => {
       const criticalFiles = (installer as unknown as { getCriticalFiles(): string[] }).getCriticalFiles();
       expect(criticalFiles).toContain('manifest.json');
       expect(criticalFiles).toContain('SKILL.md');
+    });
+  });
+
+  describe('install', () => {
+    it('should fail when the source directory is missing', async () => {
+      vi.spyOn(fsp, 'access').mockRejectedValueOnce(new Error('Source not found'));
+
+      const result = await installer.install();
+
+      expect(result.success).toBe(false);
+      expect(result.action).toBe('failed');
+      expect(result.error).toContain('Source path not found');
+    });
+
+    it('should report already_exists when the same version is installed', async () => {
+      const mockVersion = '0.1.0';
+
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // source exists
+        .mockResolvedValueOnce(undefined) // target dir exists
+        .mockResolvedValueOnce(undefined) // manifest exists
+        .mockResolvedValueOnce(undefined); // SKILL.md exists
+
+      vi.spyOn(fsp, 'readFile')
+        .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })) // source version
+        .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })); // installed version
+
+      vi.spyOn(fsp, 'cp');
+
+      const result = await installer.install();
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('already_exists');
+      expect(result.sourceVersion).toBe(mockVersion);
+      expect(result.installedVersion).toBe(mockVersion);
+      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(fsp.cp).not.toHaveBeenCalled();
+    });
+
+    it('should copy files for a new install', async () => {
+      const mockVersion = '0.1.0';
+
+      vi.spyOn(fsp, 'readFile')
+        .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })) // source version
+        .mockResolvedValueOnce(JSON.stringify({ version: mockVersion })); // verify manifest
+
+      vi.spyOn(fsp, 'access')
+        .mockResolvedValueOnce(undefined) // source exists
+        .mockRejectedValueOnce(new Error('Not installed')) // target dir missing
+        .mockResolvedValueOnce(undefined) // verify manifest
+        .mockResolvedValueOnce(undefined); // verify SKILL.md
+
+      vi.spyOn(fsp, 'mkdir').mockResolvedValue(undefined);
+      vi.spyOn(fsp, 'cp').mockResolvedValue(undefined);
+
+      const result = await installer.install();
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('copied');
+      expect(result.sourceVersion).toBe(mockVersion);
+      expect(result.targetPath).toBe(expectedTargetPath);
+      expect(fsp.cp).toHaveBeenCalled();
     });
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.hook-config-injector.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.hook-config-injector.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  HookInjectionResult,
+  KimiHookConfigInjector,
+} from '../kimi.hook-config-injector.js';
+import { getKimiConfigPath } from '../kimi.paths.js';
+
+describe('KimiHookConfigInjector', () => {
+  let originalHome: string | undefined;
+  let tempDir: string;
+  let injector: KimiHookConfigInjector;
+
+  beforeEach(() => {
+    originalHome = process.env.KIMI_CODE_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), 'kimi-hook-injector-'));
+    process.env.KIMI_CODE_HOME = tempDir;
+    injector = new KimiHookConfigInjector();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalHome === undefined) {
+      delete process.env.KIMI_CODE_HOME;
+    } else {
+      process.env.KIMI_CODE_HOME = originalHome;
+    }
+  });
+
+  it('creates config.toml with CodeMie hooks when none exists', async () => {
+    const configPath = getKimiConfigPath();
+
+    const result: HookInjectionResult = await injector.inject();
+
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(true);
+    expect(result.configPath).toBe(configPath);
+    expect(existsSync(configPath)).toBe(true);
+
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toContain('# CodeMie-managed hooks - do not edit manually');
+    expect(content).toContain('event = "SessionStart"');
+    expect(content).toContain('event = "SessionEnd"');
+    expect(content).toContain('event = "UserPromptSubmit"');
+    expect(content).toContain('event = "Stop"');
+    expect(content).toContain('event = "SubagentStop"');
+    expect(content).toContain('event = "PreCompact"');
+    expect(content).toContain('command = "codemie hook"');
+    expect(content).toContain('timeout = 10');
+    expect(content).toContain('timeout = 5');
+  });
+
+  it('is idempotent across multiple injections', async () => {
+    const configPath = getKimiConfigPath();
+
+    const firstResult = await injector.inject();
+    expect(firstResult.created).toBe(true);
+
+    const firstContent = readFileSync(configPath, 'utf-8');
+    const firstHookCount = (firstContent.match(/\[\[hooks\]\]/g) || []).length;
+    expect(firstHookCount).toBe(6);
+
+    const secondResult = await injector.inject();
+    expect(secondResult.success).toBe(true);
+    expect(secondResult.created).toBe(false);
+
+    const secondContent = readFileSync(configPath, 'utf-8');
+    const secondHookCount = (secondContent.match(/\[\[hooks\]\]/g) || []).length;
+    expect(secondHookCount).toBe(6);
+    expect(secondContent).toBe(firstContent);
+  });
+
+  it('backs up existing config before first modification and preserves original content', async () => {
+    const configPath = getKimiConfigPath();
+    const backupPath = `${configPath}.codemie-backup`;
+    const originalContent = '[existing]\nkey = "value"\n';
+
+    writeFileSync(configPath, originalContent, 'utf-8');
+
+    const result = await injector.inject();
+
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(false);
+    expect(existsSync(backupPath)).toBe(true);
+    expect(readFileSync(backupPath, 'utf-8')).toBe(originalContent);
+    expect(readFileSync(configPath, 'utf-8')).toContain('event = "SessionStart"');
+    expect(readFileSync(configPath, 'utf-8')).toContain('key = "value"');
+
+    await injector.restore();
+    expect(readFileSync(configPath, 'utf-8')).toBe(originalContent);
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.hook-config-injector.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.hook-config-injector.test.ts
@@ -1,12 +1,21 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   HookInjectionResult,
   KimiHookConfigInjector,
+  MANAGED_MARKER,
 } from '../kimi.hook-config-injector.js';
 import { getKimiConfigPath } from '../kimi.paths.js';
+import { ConfigurationError } from '../../../../utils/errors.js';
 
 describe('KimiHookConfigInjector', () => {
   let originalHome: string | undefined;
@@ -21,6 +30,7 @@ describe('KimiHookConfigInjector', () => {
   });
 
   afterEach(() => {
+    chmodSync(tempDir, 0o755);
     rmSync(tempDir, { recursive: true, force: true });
     if (originalHome === undefined) {
       delete process.env.KIMI_CODE_HOME;
@@ -40,7 +50,7 @@ describe('KimiHookConfigInjector', () => {
     expect(existsSync(configPath)).toBe(true);
 
     const content = readFileSync(configPath, 'utf-8');
-    expect(content).toContain('# CodeMie-managed hooks - do not edit manually');
+    expect(content).toContain(MANAGED_MARKER);
     expect(content).toContain('event = "SessionStart"');
     expect(content).toContain('event = "SessionEnd"');
     expect(content).toContain('event = "UserPromptSubmit"');
@@ -88,7 +98,90 @@ describe('KimiHookConfigInjector', () => {
     expect(readFileSync(configPath, 'utf-8')).toContain('event = "SessionStart"');
     expect(readFileSync(configPath, 'utf-8')).toContain('key = "value"');
 
-    await injector.restore();
+    const restoreResult = await injector.restore();
+    expect(restoreResult.success).toBe(true);
+    expect(restoreResult.created).toBe(false);
     expect(readFileSync(configPath, 'utf-8')).toBe(originalContent);
+  });
+
+  it('does not overwrite an existing backup on subsequent injections', async () => {
+    const configPath = getKimiConfigPath();
+    const backupPath = `${configPath}.codemie-backup`;
+    const originalContent = '[existing]\nkey = "value"\n';
+
+    writeFileSync(configPath, originalContent, 'utf-8');
+    const firstResult = await injector.inject();
+    expect(firstResult.success).toBe(true);
+    expect(firstResult.created).toBe(false);
+    expect(readFileSync(backupPath, 'utf-8')).toBe(originalContent);
+
+    // Simulate a later manual edit and re-inject; the original backup must stay intact.
+    writeFileSync(configPath, '[existing]\nkey = "updated"\n', 'utf-8');
+    const secondResult = await injector.inject();
+    expect(secondResult.success).toBe(true);
+    expect(secondResult.created).toBe(false);
+
+    expect(readFileSync(backupPath, 'utf-8')).toBe(originalContent);
+  });
+
+  it('returns failure when @iarna/toml cannot be loaded', async () => {
+    vi.spyOn(
+      injector as unknown as { loadTomlModule: () => Promise<typeof import('@iarna/toml')> },
+      'loadTomlModule'
+    ).mockRejectedValue(new ConfigurationError('Module not found'));
+
+    const result = await injector.inject();
+
+    expect(result.success).toBe(false);
+    expect(result.created).toBe(false);
+    expect(result.error).toContain('Module not found');
+  });
+
+  it('returns failure when existing config contains invalid TOML', async () => {
+    const configPath = getKimiConfigPath();
+    writeFileSync(configPath, 'this is not valid toml [[[', 'utf-8');
+
+    const result = await injector.inject();
+
+    expect(result.success).toBe(false);
+    expect(result.created).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns failure when config cannot be written', async () => {
+    chmodSync(tempDir, 0o555);
+
+    const result = await injector.inject();
+
+    expect(result.success).toBe(false);
+    expect(result.created).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns success from restore when no backup exists', async () => {
+    const result = await injector.restore();
+
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(false);
+    expect(result.configPath).toBe(getKimiConfigPath());
+  });
+
+  it('returns failure from restore when backup cannot be copied', async () => {
+    const configPath = getKimiConfigPath();
+    const backupPath = `${configPath}.codemie-backup`;
+    writeFileSync(configPath, '[existing]\nkey = "value"\n', 'utf-8');
+    const injectResult = await injector.inject();
+    expect(injectResult.success).toBe(true);
+
+    chmodSync(backupPath, 0o000);
+    try {
+      const result = await injector.restore();
+
+      expect(result.success).toBe(false);
+      expect(result.created).toBe(false);
+      expect(result.error).toBeTruthy();
+    } finally {
+      chmodSync(backupPath, 0o644);
+    }
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.hook-transformer.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.hook-transformer.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { KimiHookTransformer } from '../kimi.hook-transformer.js';
+import { getKimiMainWirePath } from '../kimi.paths.js';
+
+describe('KimiHookTransformer', () => {
+  const transformer = new KimiHookTransformer();
+
+  it('transforms SessionStart payload with source', () => {
+    const payload = {
+      hook_event_name: 'SessionStart',
+      session_id: 'session-123',
+      cwd: '/Users/alice/projects/my-app',
+      source: 'startup',
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(transformer.agentName).toBe('kimi');
+    expect(event.hook_event_name).toBe('SessionStart');
+    expect(event.session_id).toBe('session-123');
+    expect(event.cwd).toBe('/Users/alice/projects/my-app');
+    expect(event.transcript_path).toBe(getKimiMainWirePath('/Users/alice/projects/my-app', 'session-123'));
+    expect(event.transcript_path).toMatch(/agents\/main\/wire\.jsonl$/);
+    expect(event.permission_mode).toBe('default');
+    expect(event.source).toBe('startup');
+  });
+
+  it('transforms Stop payload and computes transcript path ending in agents/main/wire.jsonl', () => {
+    const payload = {
+      hook_event_name: 'Stop',
+      session_id: 'session-stop-456',
+      cwd: '/Users/bob/workspace',
+      stop_hook_active: true,
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(event.hook_event_name).toBe('Stop');
+    expect(event.session_id).toBe('session-stop-456');
+    expect(event.cwd).toBe('/Users/bob/workspace');
+    expect(event.transcript_path).toMatch(/agents\/main\/wire\.jsonl$/);
+    expect(event.stop_hook_active).toBe(true);
+    expect(event.permission_mode).toBe('default');
+  });
+
+  it('transforms SessionEnd payload with reason', () => {
+    const payload = {
+      hook_event_name: 'SessionEnd',
+      session_id: 'session-end-789',
+      cwd: '/Users/carol/project',
+      reason: 'logout',
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(event.hook_event_name).toBe('SessionEnd');
+    expect(event.session_id).toBe('session-end-789');
+    expect(event.reason).toBe('logout');
+    expect(event.transcript_path).toBe(getKimiMainWirePath('/Users/carol/project', 'session-end-789'));
+    expect(event.permission_mode).toBe('default');
+  });
+
+  it('transforms UserPromptSubmit payload without unsupported prompt field', () => {
+    const payload = {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: 'session-prompt-000',
+      cwd: '/Users/dave/project',
+      prompt: [
+        { type: 'text', text: 'hello world' },
+      ],
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(event.hook_event_name).toBe('UserPromptSubmit');
+    expect(event.session_id).toBe('session-prompt-000');
+    expect(event.cwd).toBe('/Users/dave/project');
+    expect(event.transcript_path).toBe(getKimiMainWirePath('/Users/dave/project', 'session-prompt-000'));
+    expect('prompt' in event).toBe(false);
+    expect(event.permission_mode).toBe('default');
+  });
+
+  it('preserves unknown hook_event_name values', () => {
+    const payload = {
+      hook_event_name: 'CustomKimiEvent',
+      session_id: 'session-custom',
+      cwd: '/Users/eve/project',
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(event.hook_event_name).toBe('CustomKimiEvent');
+    expect(event.session_id).toBe('session-custom');
+    expect(event.transcript_path).toBe(getKimiMainWirePath('/Users/eve/project', 'session-custom'));
+    expect(event.permission_mode).toBe('default');
+  });
+
+  it('falls back to process.cwd() when cwd is missing', () => {
+    const payload = {
+      hook_event_name: 'SessionStart',
+      session_id: 'session-no-cwd',
+      source: 'resume',
+    };
+
+    const event = transformer.transform(payload);
+
+    expect(event.cwd).toBe(process.cwd());
+    expect(event.session_id).toBe('session-no-cwd');
+    expect(event.hook_event_name).toBe('SessionStart');
+    expect(event.source).toBe('resume');
+    expect(event.transcript_path).toBe(getKimiMainWirePath(process.cwd(), 'session-no-cwd'));
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.metrics-processor.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.metrics-processor.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi } from 'vitest';
+import { KimiMetricsProcessor } from '../session/processors/kimi.metrics-processor.js';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function createProcessor(): KimiMetricsProcessor {
+  return new KimiMetricsProcessor();
+}
+
+function createBaseSession(messages: unknown[] = []): {
+  sessionId: string;
+  agentName: string;
+  metadata: Record<string, unknown>;
+  messages: unknown[];
+} {
+  return {
+    sessionId: 'test-session',
+    agentName: 'Kimi Code',
+    metadata: {},
+    messages,
+  };
+}
+
+const baseContext = {
+  apiBaseUrl: '',
+  cookies: '',
+  clientType: 'test',
+  version: '0.0.0',
+  dryRun: true,
+};
+
+describe('KimiMetricsProcessor', () => {
+  it('shouldProcess returns true only for Kimi Code sessions', () => {
+    const processor = createProcessor();
+
+    expect(processor.shouldProcess(createBaseSession())).toBe(true);
+    expect(processor.shouldProcess({ ...createBaseSession(), agentName: 'Claude Code' })).toBe(false);
+    expect(processor.shouldProcess({ ...createBaseSession(), agentName: 'kimi' })).toBe(false);
+  });
+
+  it('counts tool calls from context.append_loop_event tool.call entries', async () => {
+    const processor = createProcessor();
+    const session = createBaseSession([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', toolCallId: 'read_1', name: 'Read' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', toolCallId: 'write_1', name: 'Write' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', toolCallId: 'read_2', name: 'Read' },
+      },
+    ]);
+
+    const result = await processor.process(session, baseContext);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.recordsProcessed).toBe(3);
+    expect(session.metrics?.tools).toEqual({ Read: 2, Write: 1 });
+  });
+
+  it('tracks tool success and failure from tool.result entries', async () => {
+    const processor = createProcessor();
+    const session = createBaseSession([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', toolCallId: 'read_1', name: 'Read' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          toolCallId: 'read_1',
+          result: { output: 'ok', isError: false },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', toolCallId: 'write_1', name: 'Write' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          toolCallId: 'write_1',
+          result: { output: 'failed', isError: true },
+        },
+      },
+    ]);
+
+    await processor.process(session, baseContext);
+
+    expect(session.metrics?.toolStatus).toEqual({
+      Read: { success: 1, failure: 0 },
+      Write: { success: 0, failure: 1 },
+    });
+  });
+
+  it('matches tool results to tool calls via parentUuid fallback', async () => {
+    const processor = createProcessor();
+    const session = createBaseSession([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'tool.call', uuid: 'call-1', toolCallId: 'tool_1', name: 'Read' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          parentUuid: 'call-1',
+          result: { output: 'ok', isError: false },
+        },
+      },
+    ]);
+
+    await processor.process(session, baseContext);
+
+    expect(session.metrics?.toolStatus?.Read?.success).toBe(1);
+    expect(session.metrics?.toolStatus?.Read?.failure).toBe(0);
+  });
+
+  it('captures file operations from display.kind file_io entries', async () => {
+    const processor = createProcessor();
+    const session = createBaseSession([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'display.render', uuid: 'display-1' },
+        display: { kind: 'file_io', operation: 'read', path: '/Users/alice/project/src/index.ts' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'display.render', uuid: 'display-2' },
+        display: { kind: 'file_io', operation: 'write', path: '/Users/alice/project/src/index.ts' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'display.render', uuid: 'display-3' },
+        display: { kind: 'file_io', operation: 'edit', path: '/Users/alice/project/src/other.ts' },
+      },
+    ]);
+
+    await processor.process(session, baseContext);
+
+    expect(session.metrics?.fileOperations).toEqual([
+      { type: 'read', path: '/Users/alice/project/src/index.ts' },
+      { type: 'write', path: '/Users/alice/project/src/index.ts' },
+      { type: 'edit', path: '/Users/alice/project/src/other.ts' },
+    ]);
+  });
+
+  it('ignores unsupported display operations', async () => {
+    const processor = createProcessor();
+    const session = createBaseSession([
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'display.render', uuid: 'display-1' },
+        display: { kind: 'file_io', operation: 'delete', path: '/tmp/file.ts' },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'display.render', uuid: 'display-2' },
+        display: { kind: 'brief', text: 'noop' },
+      },
+    ]);
+
+    await processor.process(session, baseContext);
+
+    expect(session.metrics?.fileOperations).toEqual([]);
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.paths.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.paths.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import {
   encodeKimiWorkDirKey,
@@ -12,45 +12,53 @@ import {
 } from '../kimi.paths.js';
 
 describe('kimi paths', () => {
-  it('returns default home from env', () => {
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.KIMI_CODE_HOME;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.KIMI_CODE_HOME;
+    } else {
+      process.env.KIMI_CODE_HOME = originalHome;
+    }
+  });
+
+  it('returns default home when KIMI_CODE_HOME is not set', () => {
+    delete process.env.KIMI_CODE_HOME;
+
     const home = getKimiCodeHome();
 
     expect(home).toMatch(/.kimi-code$/);
   });
 
   it('respects KIMI_CODE_HOME', () => {
-    const originalHome = process.env.KIMI_CODE_HOME;
     process.env.KIMI_CODE_HOME = '/custom/kimi/home';
 
-    try {
-      expect(getKimiCodeHome()).toBe('/custom/kimi/home');
-      expect(getKimiConfigPath()).toBe('/custom/kimi/home/config.toml');
-      expect(getKimiSessionsDir()).toBe('/custom/kimi/home/sessions');
-      expect(getKimiUserSkillsDir()).toBe('/custom/kimi/home/skills');
-    } finally {
-      if (originalHome === undefined) {
-        delete process.env.KIMI_CODE_HOME;
-      } else {
-        process.env.KIMI_CODE_HOME = originalHome;
-      }
-    }
+    expect(getKimiCodeHome()).toBe('/custom/kimi/home');
+    expect(getKimiConfigPath()).toBe('/custom/kimi/home/config.toml');
+    expect(getKimiSessionsDir()).toBe('/custom/kimi/home/sessions');
+    expect(getKimiUserSkillsDir()).toBe('/custom/kimi/home/skills');
   });
 
   it('computes session directory from cwd and session id', () => {
     const cwd = '/Users/alice/projects/my-app';
     const sessionId = 'session-123';
+    const workDirKey = encodeKimiWorkDirKey(cwd);
     const sessionDir = getKimiSessionDir(cwd, sessionId);
 
-    expect(sessionDir).toContain(sessionId);
-    expect(sessionDir).toContain(encodeKimiWorkDirKey(cwd));
+    expect(sessionDir).toBe(path.join(getKimiSessionsDir(), workDirKey, sessionId));
   });
 
   it('returns main wire path', () => {
     const cwd = '/Users/alice/projects/my-app';
     const sessionId = 'session-123';
+    const sessionDir = getKimiSessionDir(cwd, sessionId);
     const wirePath = getKimiMainWirePath(cwd, sessionId);
 
-    expect(wirePath).toMatch(/agents[/\\]main[/\\]wire\.jsonl$/);
+    expect(wirePath).toBe(path.join(sessionDir, 'agents', 'main', 'wire.jsonl'));
   });
 
   it('encodes work dir key like Kimi CLI', () => {
@@ -66,5 +74,71 @@ describe('kimi paths', () => {
       .slice(0, 12);
 
     expect(key.endsWith(`_${expectedHash}`)).toBe(true);
+  });
+
+  describe('encodeKimiWorkDirKey edge cases', () => {
+    it('handles root-like paths', () => {
+      const key = encodeKimiWorkDirKey('/');
+
+      expect(key).toMatch(/^wd_workspace_[0-9a-f]{12}$/);
+    });
+
+    it('handles cwd ending in .', () => {
+      const key = encodeKimiWorkDirKey('/path/to/.');
+      const resolved = path.resolve('/path/to/.');
+
+      expect(key).toBe(`wd_to_${createHash('sha256').update(resolved).digest('hex').slice(0, 12)}`);
+    });
+
+    it('handles cwd ending in ..', () => {
+      const key = encodeKimiWorkDirKey('/path/to/..');
+      const resolved = path.resolve('/path/to/..');
+
+      expect(key).toBe(`wd_path_${createHash('sha256').update(resolved).digest('hex').slice(0, 12)}`);
+    });
+
+    it('replaces cwd with only special characters to workspace', () => {
+      const key = encodeKimiWorkDirKey('/path/!@#$%');
+      const resolved = path.resolve('/path/!@#$%');
+
+      expect(key).toMatch(/^wd_workspace_[0-9a-f]{12}$/);
+      expect(key).toBe(`wd_workspace_${createHash('sha256').update(resolved).digest('hex').slice(0, 12)}`);
+    });
+
+    it('truncates very long directory names to 40 characters', () => {
+      const longName = 'a'.repeat(100);
+      const cwd = `/path/${longName}`;
+      const resolved = path.resolve(cwd);
+      const key = encodeKimiWorkDirKey(cwd);
+      const expectedSlug = 'a'.repeat(40);
+      const expectedHash = createHash('sha256').update(resolved).digest('hex').slice(0, 12);
+
+      expect(key).toBe(`wd_${expectedSlug}_${expectedHash}`);
+    });
+
+    it('sanitizes non-ascii and whitespace characters', () => {
+      const cwd = '/path/My Project 日本語';
+      const resolved = path.resolve(cwd);
+      const key = encodeKimiWorkDirKey(cwd);
+      const expectedHash = createHash('sha256').update(resolved).digest('hex').slice(0, 12);
+
+      expect(key).toBe(`wd_my-project_${expectedHash}`);
+    });
+
+    it('produces deterministic hash for the same resolved path', () => {
+      const cwd = '/Users/alice/projects/my-app';
+
+      const first = encodeKimiWorkDirKey(cwd);
+      const second = encodeKimiWorkDirKey(cwd);
+
+      expect(first).toBe(second);
+    });
+
+    it('produces different hashes for different paths with the same basename', () => {
+      const keyA = encodeKimiWorkDirKey('/Users/alice/my-app');
+      const keyB = encodeKimiWorkDirKey('/Users/bob/my-app');
+
+      expect(keyA).not.toBe(keyB);
+    });
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.paths.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.paths.test.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import {
+  encodeKimiWorkDirKey,
+  getKimiCodeHome,
+  getKimiConfigPath,
+  getKimiMainWirePath,
+  getKimiSessionDir,
+  getKimiSessionsDir,
+  getKimiUserSkillsDir,
+} from '../kimi.paths.js';
+
+describe('kimi paths', () => {
+  it('returns default home from env', () => {
+    const home = getKimiCodeHome();
+
+    expect(home).toMatch(/.kimi-code$/);
+  });
+
+  it('respects KIMI_CODE_HOME', () => {
+    const originalHome = process.env.KIMI_CODE_HOME;
+    process.env.KIMI_CODE_HOME = '/custom/kimi/home';
+
+    try {
+      expect(getKimiCodeHome()).toBe('/custom/kimi/home');
+      expect(getKimiConfigPath()).toBe('/custom/kimi/home/config.toml');
+      expect(getKimiSessionsDir()).toBe('/custom/kimi/home/sessions');
+      expect(getKimiUserSkillsDir()).toBe('/custom/kimi/home/skills');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.KIMI_CODE_HOME;
+      } else {
+        process.env.KIMI_CODE_HOME = originalHome;
+      }
+    }
+  });
+
+  it('computes session directory from cwd and session id', () => {
+    const cwd = '/Users/alice/projects/my-app';
+    const sessionId = 'session-123';
+    const sessionDir = getKimiSessionDir(cwd, sessionId);
+
+    expect(sessionDir).toContain(sessionId);
+    expect(sessionDir).toContain(encodeKimiWorkDirKey(cwd));
+  });
+
+  it('returns main wire path', () => {
+    const cwd = '/Users/alice/projects/my-app';
+    const sessionId = 'session-123';
+    const wirePath = getKimiMainWirePath(cwd, sessionId);
+
+    expect(wirePath).toMatch(/agents[/\\]main[/\\]wire\.jsonl$/);
+  });
+
+  it('encodes work dir key like Kimi CLI', () => {
+    const cwd = '/Users/alice/projects/My Project-1';
+    const resolvedCwd = path.resolve(cwd);
+    const key = encodeKimiWorkDirKey(cwd);
+
+    expect(key).toMatch(/^wd_[a-z0-9._-]+_[0-9a-f]{12}$/);
+
+    const expectedHash = createHash('sha256')
+      .update(resolvedCwd)
+      .digest('hex')
+      .slice(0, 12);
+
+    expect(key.endsWith(`_${expectedHash}`)).toBe(true);
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { KimiPlugin, KimiPluginMetadata } from '../kimi.plugin.js';
+import { KimiAcpPlugin, KimiAcpPluginMetadata } from '../kimi-acp.plugin.js';
+import { KimiSessionAdapter } from '../kimi.session.js';
+import { KimiExtensionInstaller } from '../kimi.extension-installer.js';
+import { KimiHookTransformer } from '../kimi.hook-transformer.js';
+
+describe('KimiPlugin', () => {
+  it('metadata has expected values', () => {
+    expect(KimiPluginMetadata.name).toBe('kimi');
+    expect(KimiPluginMetadata.cliCommand).toBe('kimi');
+    expect(KimiPluginMetadata.supportedProviders).toContain('moonshot-subscription');
+    expect(KimiPluginMetadata.hookConfig?.eventNameMapping).toBeDefined();
+  });
+
+  it('returns session adapter, hook transformer, and extension installer', () => {
+    const plugin = new KimiPlugin();
+
+    expect(plugin.getSessionAdapter()).toBeInstanceOf(KimiSessionAdapter);
+    expect(plugin.getHookTransformer()).toBeInstanceOf(KimiHookTransformer);
+    expect(plugin.getExtensionInstaller()).toBeInstanceOf(KimiExtensionInstaller);
+  });
+});
+
+describe('KimiAcpPlugin', () => {
+  it('metadata name is kimi-acp and lifecycle enriches args', () => {
+    expect(KimiAcpPluginMetadata.name).toBe('kimi-acp');
+    expect(KimiAcpPluginMetadata.lifecycle?.enrichArgs?.(['--task', 'x'], {} as never)).toEqual([
+      'acp',
+      '--task',
+      'x',
+    ]);
+  });
+
+  it('plugin uses acp metadata', () => {
+    const plugin = new KimiAcpPlugin();
+
+    expect(plugin.name).toBe('kimi-acp');
+  });
+});

--- a/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { KimiPlugin, KimiPluginMetadata } from '../kimi.plugin.js';
 import { KimiAcpPlugin, KimiAcpPluginMetadata } from '../kimi-acp.plugin.js';
 import { KimiSessionAdapter } from '../kimi.session.js';
@@ -95,6 +95,12 @@ describe('KimiPlugin', () => {
 
         const { installNativeAgent } = await import('../../../../utils/native-installer.js');
         expect(installNativeAgent).toHaveBeenCalledTimes(1);
+        expect(installNativeAgent).toHaveBeenCalledWith(
+          'kimi',
+          KimiPluginMetadata.installerUrls,
+          undefined,
+          expect.any(Object),
+        );
       } finally {
         Object.defineProperty(process, 'version', {
           value: originalVersion,
@@ -107,6 +113,30 @@ describe('KimiPlugin', () => {
       const plugin = new KimiPlugin();
 
       await expect(plugin.installVersion('latest')).resolves.toBeUndefined();
+
+      const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+      expect(installNativeAgent).toHaveBeenCalledTimes(1);
+      expect(installNativeAgent).toHaveBeenCalledWith(
+        'kimi',
+        KimiPluginMetadata.installerUrls,
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('passes explicit semantic version through to native installer', async () => {
+      const plugin = new KimiPlugin();
+
+      await expect(plugin.installVersion('1.2.3')).resolves.toBeUndefined();
+
+      const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+      expect(installNativeAgent).toHaveBeenCalledTimes(1);
+      expect(installNativeAgent).toHaveBeenCalledWith(
+        'kimi',
+        KimiPluginMetadata.installerUrls,
+        '1.2.3',
+        expect.any(Object),
+      );
     });
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
@@ -81,6 +81,30 @@ describe('KimiPlugin', () => {
       }
     });
 
+    it('throws when installing supported version on Node.js < 22.19.0', async () => {
+      const originalVersion = process.version;
+      Object.defineProperty(process, 'version', {
+        value: 'v22.18.0',
+        configurable: true,
+      });
+
+      try {
+        const plugin = new KimiPlugin();
+
+        const promise = plugin.installVersion('supported');
+        await expect(promise).rejects.toThrow(AgentInstallationError);
+        await expect(promise).rejects.toThrow('Node.js >= 22.19.0');
+
+        const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+        expect(installNativeAgent).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, 'version', {
+          value: originalVersion,
+          configurable: true,
+        });
+      }
+    });
+
     it('does not throw when installing npm version on Node.js >= 22.19.0', async () => {
       const originalVersion = process.version;
       Object.defineProperty(process, 'version', {
@@ -124,6 +148,32 @@ describe('KimiPlugin', () => {
       );
     });
 
+    it('installs stable version natively', async () => {
+      const plugin = new KimiPlugin();
+
+      await expect(plugin.installVersion('stable')).resolves.toBeUndefined();
+
+      const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+      expect(installNativeAgent).toHaveBeenCalledTimes(1);
+      expect(installNativeAgent).toHaveBeenCalledWith(
+        'kimi',
+        KimiPluginMetadata.installerUrls,
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('throws for invalid version', async () => {
+      const plugin = new KimiPlugin();
+
+      const promise = plugin.installVersion('not-a-version');
+      await expect(promise).rejects.toThrow(AgentInstallationError);
+      await expect(promise).rejects.toThrow("Invalid version format: 'not-a-version'");
+
+      const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+      expect(installNativeAgent).not.toHaveBeenCalled();
+    });
+
     it('passes explicit semantic version through to native installer', async () => {
       const plugin = new KimiPlugin();
 
@@ -142,6 +192,13 @@ describe('KimiPlugin', () => {
 });
 
 describe('KimiAcpPlugin', () => {
+  it('metadata uses ACP-specific SSO client type', () => {
+    expect(KimiAcpPluginMetadata.ssoConfig).toEqual({
+      enabled: true,
+      clientType: 'codemie-kimi-acp',
+    });
+  });
+
   it('metadata name is kimi-acp and lifecycle enriches args', () => {
     expect(KimiAcpPluginMetadata.name).toBe('kimi-acp');
     expect(KimiAcpPluginMetadata.lifecycle?.enrichArgs?.(['--task', 'x'], {} as never)).toEqual([

--- a/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
@@ -49,6 +49,12 @@ describe('KimiPlugin', () => {
 
       const { installNativeAgent } = await import('../../../../utils/native-installer.js');
       expect(installNativeAgent).toHaveBeenCalledTimes(1);
+      expect(installNativeAgent).toHaveBeenCalledWith(
+        'kimi',
+        KimiPluginMetadata.installerUrls,
+        '1.0.0',
+        expect.any(Object),
+      );
     });
 
     it('throws when installing npm version on Node.js < 22.19.0', async () => {
@@ -61,13 +67,34 @@ describe('KimiPlugin', () => {
       try {
         const plugin = new KimiPlugin();
 
-        await expect(plugin.installVersion('npm')).rejects.toThrow(AgentInstallationError);
-        await expect(plugin.installVersion('npm')).rejects.toThrow(
-          'Node.js >= 22.19.0',
-        );
+        const promise = plugin.installVersion('npm');
+        await expect(promise).rejects.toThrow(AgentInstallationError);
+        await expect(promise).rejects.toThrow('Node.js >= 22.19.0');
 
         const { installNativeAgent } = await import('../../../../utils/native-installer.js');
         expect(installNativeAgent).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, 'version', {
+          value: originalVersion,
+          configurable: true,
+        });
+      }
+    });
+
+    it('does not throw when installing npm version on Node.js >= 22.19.0', async () => {
+      const originalVersion = process.version;
+      Object.defineProperty(process, 'version', {
+        value: 'v22.19.0',
+        configurable: true,
+      });
+
+      try {
+        const plugin = new KimiPlugin();
+
+        await expect(plugin.installVersion('npm')).resolves.toBeUndefined();
+
+        const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+        expect(installNativeAgent).toHaveBeenCalledTimes(1);
       } finally {
         Object.defineProperty(process, 'version', {
           value: originalVersion,

--- a/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.plugin.test.ts
@@ -1,16 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { KimiPlugin, KimiPluginMetadata } from '../kimi.plugin.js';
 import { KimiAcpPlugin, KimiAcpPluginMetadata } from '../kimi-acp.plugin.js';
 import { KimiSessionAdapter } from '../kimi.session.js';
 import { KimiExtensionInstaller } from '../kimi.extension-installer.js';
 import { KimiHookTransformer } from '../kimi.hook-transformer.js';
+import { AgentInstallationError } from '../../../../utils/errors.js';
+
+vi.mock('../../../../utils/native-installer.js', () => ({
+  installNativeAgent: vi.fn().mockResolvedValue({
+    success: true,
+    installedVersion: '1.0.0',
+    output: '',
+  }),
+}));
 
 describe('KimiPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('metadata has expected values', () => {
     expect(KimiPluginMetadata.name).toBe('kimi');
     expect(KimiPluginMetadata.cliCommand).toBe('kimi');
     expect(KimiPluginMetadata.supportedProviders).toContain('moonshot-subscription');
     expect(KimiPluginMetadata.hookConfig?.eventNameMapping).toBeDefined();
+  });
+
+  it('maps --model flag to --model', () => {
+    expect(KimiPluginMetadata.flagMappings['--model']).toEqual({
+      type: 'flag',
+      target: '--model',
+    });
   });
 
   it('returns session adapter, hook transformer, and extension installer', () => {
@@ -19,6 +39,48 @@ describe('KimiPlugin', () => {
     expect(plugin.getSessionAdapter()).toBeInstanceOf(KimiSessionAdapter);
     expect(plugin.getHookTransformer()).toBeInstanceOf(KimiHookTransformer);
     expect(plugin.getExtensionInstaller()).toBeInstanceOf(KimiExtensionInstaller);
+  });
+
+  describe('installVersion', () => {
+    it('installs supported version natively', async () => {
+      const plugin = new KimiPlugin();
+
+      await expect(plugin.installVersion('supported')).resolves.toBeUndefined();
+
+      const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+      expect(installNativeAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when installing npm version on Node.js < 22.19.0', async () => {
+      const originalVersion = process.version;
+      Object.defineProperty(process, 'version', {
+        value: 'v22.18.0',
+        configurable: true,
+      });
+
+      try {
+        const plugin = new KimiPlugin();
+
+        await expect(plugin.installVersion('npm')).rejects.toThrow(AgentInstallationError);
+        await expect(plugin.installVersion('npm')).rejects.toThrow(
+          'Node.js >= 22.19.0',
+        );
+
+        const { installNativeAgent } = await import('../../../../utils/native-installer.js');
+        expect(installNativeAgent).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, 'version', {
+          value: originalVersion,
+          configurable: true,
+        });
+      }
+    });
+
+    it('installs latest version natively', async () => {
+      const plugin = new KimiPlugin();
+
+      await expect(plugin.installVersion('latest')).resolves.toBeUndefined();
+    });
   });
 });
 

--- a/src/agents/plugins/kimi/__tests__/kimi.session.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.session.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { KimiSessionAdapter } from '../kimi.session.js';
+import { KimiMetricsProcessor } from '../session/processors/kimi.metrics-processor.js';
 
 vi.mock('../../../utils/logger.js', () => ({
   logger: {
@@ -15,6 +16,14 @@ vi.mock('../../../utils/logger.js', () => ({
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const baseContext = {
+  apiBaseUrl: '',
+  cookies: '',
+  clientType: 'test',
+  version: '0.0.0',
+  dryRun: true,
+};
 
 function createAdapter(): KimiSessionAdapter {
   return new KimiSessionAdapter({
@@ -39,6 +48,7 @@ describe('KimiSessionAdapter.parseSessionFile', () => {
     expect(session.sessionId).toBe('test-session-001');
     expect(session.agentName).toBe('Kimi Code');
     expect(session.messages.length).toBeGreaterThan(0);
+    expect(session.metrics).toBeUndefined();
   });
 
   it('extracts the model from config.update.modelAlias', async () => {
@@ -50,31 +60,48 @@ describe('KimiSessionAdapter.parseSessionFile', () => {
     expect(session.metadata.model).toBe('kimi-code/kimi-for-coding');
   });
 
-  it('counts Read and Write tool calls', async () => {
+  it('falls back to usage.record.model when config.update.modelAlias is absent', async () => {
     const adapter = createAdapter();
+
+    const session = await adapter.parseSessionFile(
+      join(__dirname, 'fixtures', 'usage-only-model.jsonl'),
+      'usage-model-session'
+    );
+
+    expect(session.metadata.model).toBe('kimi-code/fallback-model');
+  });
+
+  it('counts Read and Write tool calls after metrics processing', async () => {
+    const adapter = createAdapter();
+    const processor = new KimiMetricsProcessor();
     const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
 
     const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+    await processor.process(session, baseContext);
 
     expect(session.metrics?.tools?.Read).toBe(1);
     expect(session.metrics?.tools?.Write).toBe(1);
   });
 
-  it('tracks successful Read tool results', async () => {
+  it('tracks successful Read tool results after metrics processing', async () => {
     const adapter = createAdapter();
+    const processor = new KimiMetricsProcessor();
     const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
 
     const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+    await processor.process(session, baseContext);
 
     expect(session.metrics?.toolStatus?.Read?.success).toBeGreaterThanOrEqual(1);
     expect(session.metrics?.toolStatus?.Read?.failure).toBe(0);
   });
 
-  it('captures file operations from display metadata', async () => {
+  it('captures file operations from display metadata after metrics processing', async () => {
     const adapter = createAdapter();
+    const processor = new KimiMetricsProcessor();
     const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
 
     const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+    await processor.process(session, baseContext);
 
     const fileOps = session.metrics?.fileOperations ?? [];
     const readOps = fileOps.filter((op) => op.type === 'read');
@@ -96,8 +123,6 @@ describe('KimiSessionAdapter.parseSessionFile', () => {
     expect(session.sessionId).toBe('missing-session');
     expect(session.agentName).toBe('Kimi Code');
     expect(session.messages).toEqual([]);
-    expect(session.metrics?.tools).toEqual({});
-    expect(session.metrics?.toolStatus).toEqual({});
-    expect(session.metrics?.fileOperations).toEqual([]);
+    expect(session.metrics).toBeUndefined();
   });
 });

--- a/src/agents/plugins/kimi/__tests__/kimi.session.test.ts
+++ b/src/agents/plugins/kimi/__tests__/kimi.session.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { KimiSessionAdapter } from '../kimi.session.js';
+
+vi.mock('../../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function createAdapter(): KimiSessionAdapter {
+  return new KimiSessionAdapter({
+    name: 'kimi',
+    displayName: 'Kimi Code',
+    description: 'Kimi Code agent',
+    npmPackage: null,
+    cliCommand: 'kimi',
+    envMapping: {},
+    supportedProviders: [],
+    dataPaths: { home: '.kimi-code' },
+  });
+}
+
+describe('KimiSessionAdapter.parseSessionFile', () => {
+  it('parses the sample wire.jsonl fixture', async () => {
+    const adapter = createAdapter();
+    const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
+
+    const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+
+    expect(session.sessionId).toBe('test-session-001');
+    expect(session.agentName).toBe('Kimi Code');
+    expect(session.messages.length).toBeGreaterThan(0);
+  });
+
+  it('extracts the model from config.update.modelAlias', async () => {
+    const adapter = createAdapter();
+    const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
+
+    const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+
+    expect(session.metadata.model).toBe('kimi-code/kimi-for-coding');
+  });
+
+  it('counts Read and Write tool calls', async () => {
+    const adapter = createAdapter();
+    const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
+
+    const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+
+    expect(session.metrics?.tools?.Read).toBe(1);
+    expect(session.metrics?.tools?.Write).toBe(1);
+  });
+
+  it('tracks successful Read tool results', async () => {
+    const adapter = createAdapter();
+    const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
+
+    const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+
+    expect(session.metrics?.toolStatus?.Read?.success).toBeGreaterThanOrEqual(1);
+    expect(session.metrics?.toolStatus?.Read?.failure).toBe(0);
+  });
+
+  it('captures file operations from display metadata', async () => {
+    const adapter = createAdapter();
+    const fixturePath = join(__dirname, 'fixtures', 'sample-wire.jsonl');
+
+    const session = await adapter.parseSessionFile(fixturePath, 'test-session-001');
+
+    const fileOps = session.metrics?.fileOperations ?? [];
+    const readOps = fileOps.filter((op) => op.type === 'read');
+    const writeOps = fileOps.filter((op) => op.type === 'write');
+
+    expect(readOps.length).toBeGreaterThanOrEqual(1);
+    expect(writeOps.length).toBeGreaterThanOrEqual(1);
+    expect(readOps[0]?.path).toBe('/Users/alice/project/src/index.ts');
+  });
+
+  it('returns a minimal session for a missing file', async () => {
+    const adapter = createAdapter();
+
+    const session = await adapter.parseSessionFile(
+      join(__dirname, 'fixtures', 'does-not-exist.jsonl'),
+      'missing-session'
+    );
+
+    expect(session.sessionId).toBe('missing-session');
+    expect(session.agentName).toBe('Kimi Code');
+    expect(session.messages).toEqual([]);
+    expect(session.metrics?.tools).toEqual({});
+    expect(session.metrics?.toolStatus).toEqual({});
+    expect(session.metrics?.fileOperations).toEqual([]);
+  });
+});

--- a/src/agents/plugins/kimi/extension/SKILL.md
+++ b/src/agents/plugins/kimi/extension/SKILL.md
@@ -1,0 +1,3 @@
+# CodeMie Kimi Skill
+
+Default CodeMie skill for Kimi Code CLI.

--- a/src/agents/plugins/kimi/extension/SKILL.md
+++ b/src/agents/plugins/kimi/extension/SKILL.md
@@ -1,3 +1,6 @@
 # CodeMie Kimi Skill
 
 Default CodeMie skill for Kimi Code CLI.
+
+Provides CodeMie platform integration for Kimi Code CLI, enabling session telemetry,
+metrics capture, and conversation synchronization with the CodeMie platform.

--- a/src/agents/plugins/kimi/extension/manifest.json
+++ b/src/agents/plugins/kimi/extension/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "codemie-kimi",
+  "version": "0.1.0",
+  "description": "CodeMie integration for Kimi Code CLI"
+}

--- a/src/agents/plugins/kimi/extension/manifest.json
+++ b/src/agents/plugins/kimi/extension/manifest.json
@@ -1,5 +1,11 @@
 {
   "name": "codemie-kimi",
+  "displayName": "CodeMie",
+  "description": "Event-driven observability for Kimi CLI. Captures session events and syncs metrics/conversations to CodeMie platform.",
   "version": "0.1.0",
-  "description": "CodeMie integration for Kimi Code CLI"
+  "author": {
+    "name": "AI/Run CodeMie",
+    "email": "support@codemieai.com"
+  },
+  "homepage": "https://codemie.lab.epam.com"
 }

--- a/src/agents/plugins/kimi/extension/manifest.json
+++ b/src/agents/plugins/kimi/extension/manifest.json
@@ -3,9 +3,6 @@
   "displayName": "CodeMie",
   "description": "Event-driven observability for Kimi CLI. Captures session events and syncs metrics/conversations to CodeMie platform.",
   "version": "0.1.0",
-  "author": {
-    "name": "AI/Run CodeMie",
-    "email": "support@codemieai.com"
-  },
-  "homepage": "https://codemie.lab.epam.com"
+  "author": "AI/Run Team",
+  "homepage": "https://github.com/codemie-ai/codemie-code#readme"
 }

--- a/src/agents/plugins/kimi/kimi-acp.plugin.ts
+++ b/src/agents/plugins/kimi/kimi-acp.plugin.ts
@@ -11,6 +11,15 @@ export const KimiAcpPluginMetadata: AgentMetadata = {
   lifecycle: {
     enrichArgs: (args) => ['acp', ...args],
   },
+  postInstallHints: [
+    'Configure in your IDE:',
+    '',
+    'Zed (~/.config/zed/settings.json):',
+    '  "agent_servers": { "kimi": { "command": "codemie run kimi-acp" } }',
+    '',
+    'JetBrains (~/.jetbrains/acp.json):',
+    '  "agent_servers": { "Kimi Code via CodeMie": { "command": "codemie run kimi-acp" } }',
+  ],
 };
 
 export class KimiAcpPlugin extends KimiPlugin {

--- a/src/agents/plugins/kimi/kimi-acp.plugin.ts
+++ b/src/agents/plugins/kimi/kimi-acp.plugin.ts
@@ -1,0 +1,19 @@
+import type { AgentMetadata } from '../../core/types.js';
+import { KimiPlugin, KimiPluginMetadata } from './kimi.plugin.js';
+
+export const KimiAcpPluginMetadata: AgentMetadata = {
+  ...KimiPluginMetadata,
+  name: 'kimi-acp',
+  displayName: 'Kimi Code ACP',
+  description: 'Kimi Code CLI ACP mode for IDE integration',
+  silentMode: true,
+  lifecycle: {
+    enrichArgs: (args) => ['acp', ...args],
+  },
+};
+
+export class KimiAcpPlugin extends KimiPlugin {
+  constructor() {
+    super(KimiAcpPluginMetadata);
+  }
+}

--- a/src/agents/plugins/kimi/kimi-acp.plugin.ts
+++ b/src/agents/plugins/kimi/kimi-acp.plugin.ts
@@ -7,6 +7,7 @@ export const KimiAcpPluginMetadata: AgentMetadata = {
   displayName: 'Kimi Code ACP',
   description: 'Kimi Code CLI ACP mode for IDE integration',
   silentMode: true,
+  flagMappings: {},
   lifecycle: {
     enrichArgs: (args) => ['acp', ...args],
   },

--- a/src/agents/plugins/kimi/kimi-acp.plugin.ts
+++ b/src/agents/plugins/kimi/kimi-acp.plugin.ts
@@ -8,6 +8,7 @@ export const KimiAcpPluginMetadata: AgentMetadata = {
   description: 'Kimi Code CLI ACP mode for IDE integration',
   silentMode: true,
   flagMappings: {},
+  ssoConfig: { enabled: true, clientType: 'codemie-kimi-acp' },
   lifecycle: {
     enrichArgs: (args) => ['acp', ...args],
   },

--- a/src/agents/plugins/kimi/kimi.extension-installer.ts
+++ b/src/agents/plugins/kimi/kimi.extension-installer.ts
@@ -1,0 +1,64 @@
+/**
+ * Kimi Extension Installer
+ *
+ * Handles installation of the bundled CodeMie skill into Kimi's user skills
+ * directory at ~/.kimi-code/skills/codemie-kimi.
+ *
+ * Extends BaseExtensionInstaller to provide Kimi-specific paths.
+ * All installation logic is inherited from the base class.
+ *
+ * @module agents/plugins/kimi/extension-installer
+ */
+
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+import { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
+import type { AgentMetadata } from '../../core/types.js';
+
+/**
+ * Kimi Extension Installer
+ *
+ * Installs the bundled CodeMie skill for Kimi Code CLI.
+ */
+export class KimiExtensionInstaller extends BaseExtensionInstaller {
+  /**
+   * Constructor
+   * @param metadata - Agent metadata containing name, displayName, etc.
+   */
+  constructor(metadata: AgentMetadata) {
+    super(metadata.name); // Pass agent name to parent
+  }
+
+  /**
+   * Get the source extension directory path
+   * Works in both development and npm package contexts
+   */
+  protected getSourcePath(): string {
+    return join(dirname(fileURLToPath(import.meta.url)), 'extension');
+  }
+
+  /**
+   * Get the target installation directory
+   * @returns ~/.kimi-code/skills/codemie-kimi
+   */
+  getTargetPath(): string {
+    return join(homedir(), '.kimi-code', 'skills', 'codemie-kimi');
+  }
+
+  /**
+   * Get the manifest file path (relative to base directory)
+   * @returns manifest.json
+   */
+  protected getManifestPath(): string {
+    return 'manifest.json';
+  }
+
+  /**
+   * Get list of critical files that must exist after installation
+   * @returns Array of relative file paths
+   */
+  protected getCriticalFiles(): string[] {
+    return ['manifest.json', 'SKILL.md'];
+  }
+}

--- a/src/agents/plugins/kimi/kimi.extension-installer.ts
+++ b/src/agents/plugins/kimi/kimi.extension-installer.ts
@@ -13,6 +13,8 @@
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
+import { access } from 'fs/promises';
+import { constants } from 'fs';
 import { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
 import type { AgentMetadata } from '../../core/types.js';
 
@@ -60,5 +62,24 @@ export class KimiExtensionInstaller extends BaseExtensionInstaller {
    */
   protected getCriticalFiles(): string[] {
     return ['manifest.json', 'SKILL.md'];
+  }
+
+  /**
+   * Check if the Kimi extension is already installed and read its version.
+   *
+   * Verifies that the target directory, manifest, and SKILL.md all exist and
+   * are readable. Returns null if any of these checks fail.
+   */
+  protected async getInstalledInfo(): Promise<{ installed: boolean; version: string | null } | null> {
+    try {
+      const targetPath = this.getTargetPath();
+      await access(targetPath, constants.F_OK);
+      await access(join(targetPath, this.getManifestPath()), constants.R_OK);
+      await access(join(targetPath, 'SKILL.md'), constants.R_OK);
+      const version = await this.getVersion(targetPath);
+      return { installed: true, version };
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/agents/plugins/kimi/kimi.extension-installer.ts
+++ b/src/agents/plugins/kimi/kimi.extension-installer.ts
@@ -12,11 +12,11 @@
 
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { homedir } from 'os';
 import { access } from 'fs/promises';
 import { constants } from 'fs';
 import { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
 import type { AgentMetadata } from '../../core/types.js';
+import { getKimiUserSkillsDir } from './kimi.paths.js';
 
 /**
  * Kimi Extension Installer
@@ -42,10 +42,10 @@ export class KimiExtensionInstaller extends BaseExtensionInstaller {
 
   /**
    * Get the target installation directory
-   * @returns ~/.kimi-code/skills/codemie-kimi
+   * @returns ${KIMI_CODE_HOME:-~/.kimi-code}/skills/codemie-kimi
    */
   getTargetPath(): string {
-    return join(homedir(), '.kimi-code', 'skills', 'codemie-kimi');
+    return join(getKimiUserSkillsDir(), 'codemie-kimi');
   }
 
   /**

--- a/src/agents/plugins/kimi/kimi.hook-config-injector.ts
+++ b/src/agents/plugins/kimi/kimi.hook-config-injector.ts
@@ -1,0 +1,142 @@
+// src/agents/plugins/kimi/kimi.hook-config-injector.ts
+/**
+ * Idempotent injector for CodeMie lifecycle hooks into Kimi's global config.
+ *
+ * Kimi Code supports lifecycle hooks in `~/.kimi-code/config.toml` under
+ * `[[hooks]]` entries. This component registers the hooks CodeMie needs to
+ * observe and react to Kimi sessions while leaving user-managed configuration
+ * intact.
+ */
+
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { logger } from '../../../utils/logger.js';
+import { ConfigurationError, getErrorMessage } from '../../../utils/errors.js';
+import { getKimiConfigPath } from './kimi.paths.js';
+
+/**
+ * Result shape for hook injection.
+ */
+export interface HookInjectionResult {
+  success: boolean;
+  created: boolean;
+  configPath: string;
+  error?: string;
+}
+
+/**
+ * Events CodeMie subscribes to in Kimi Code, mapped to their hook timeouts.
+ */
+const MANAGED_EVENTS: Array<{ event: string; timeout: number }> = [
+  { event: 'SessionStart', timeout: 5 },
+  { event: 'SessionEnd', timeout: 10 },
+  { event: 'UserPromptSubmit', timeout: 5 },
+  { event: 'Stop', timeout: 5 },
+  { event: 'SubagentStop', timeout: 5 },
+  { event: 'PreCompact', timeout: 5 },
+];
+
+const MANAGED_MARKER = '# CodeMie-managed hooks - do not edit manually';
+const COMMAND = 'codemie hook';
+
+interface KimiHooksConfig {
+  hooks?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+/**
+ * Injects and restores CodeMie lifecycle hooks in Kimi's config.toml.
+ */
+export class KimiHookConfigInjector {
+  /**
+   * Idempotently inject CodeMie hooks into `~/.kimi-code/config.toml`.
+   */
+  async inject(): Promise<HookInjectionResult> {
+    const configPath = getKimiConfigPath();
+
+    try {
+      const toml = await this.loadTomlModule();
+      const configExists = existsSync(configPath);
+      let created = false;
+
+      if (!configExists) {
+        created = true;
+      } else {
+        const existingContent = readFileSync(configPath, 'utf-8');
+        if (existingContent.includes(MANAGED_MARKER)) {
+          logger.info('Kimi config already contains CodeMie-managed hooks; skipping injection.', {
+            configPath,
+          });
+          return { success: true, created: false, configPath };
+        }
+
+        this.backupConfig(configPath);
+      }
+
+      const parsedConfig: KimiHooksConfig = configExists
+        ? (toml.parse(readFileSync(configPath, 'utf-8')) as KimiHooksConfig)
+        : {};
+
+      if (!Array.isArray(parsedConfig.hooks)) {
+        parsedConfig.hooks = [];
+      }
+
+      for (const { event, timeout } of MANAGED_EVENTS) {
+        parsedConfig.hooks!.push({
+          event,
+          command: COMMAND,
+          timeout,
+        });
+      }
+
+      // @iarna/toml does not export its internal JsonMap type, so we assert the
+      // parsed object which is known to contain only TOML-compatible values.
+      const serialized = toml.stringify(parsedConfig as unknown as Record<string, never>);
+      const contentWithMarker = `${MANAGED_MARKER}\n${serialized}`;
+
+      writeFileSync(configPath, contentWithMarker, 'utf-8');
+
+      if (created) {
+        logger.info('Created Kimi config with CodeMie-managed hooks.', { configPath });
+      } else {
+        logger.info('Injected CodeMie-managed hooks into existing Kimi config.', { configPath });
+      }
+
+      return { success: true, created, configPath };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.error('Failed to inject CodeMie hooks into Kimi config.', error);
+      return { success: false, created: false, configPath, error: message };
+    }
+  }
+
+  /**
+   * Restore the original config from its CodeMie backup, if one exists.
+   */
+  async restore(): Promise<void> {
+    const configPath = getKimiConfigPath();
+    const backupPath = `${configPath}.codemie-backup`;
+
+    if (!existsSync(backupPath)) {
+      logger.info('No Kimi config backup found; nothing to restore.', { configPath });
+      return;
+    }
+
+    copyFileSync(backupPath, configPath);
+    logger.info('Restored Kimi config from CodeMie backup.', { configPath, backupPath });
+  }
+
+  private async loadTomlModule(): Promise<typeof import('@iarna/toml')> {
+    try {
+      return await import('@iarna/toml');
+    } catch (error) {
+      throw new ConfigurationError(
+        `Unable to load @iarna/toml. Run "npm install @iarna/toml" to enable Kimi hook injection. ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  private backupConfig(configPath: string): void {
+    const backupPath = `${configPath}.codemie-backup`;
+    copyFileSync(configPath, backupPath);
+  }
+}

--- a/src/agents/plugins/kimi/kimi.hook-config-injector.ts
+++ b/src/agents/plugins/kimi/kimi.hook-config-injector.ts
@@ -35,8 +35,12 @@ const MANAGED_EVENTS: Array<{ event: string; timeout: number }> = [
   { event: 'PreCompact', timeout: 5 },
 ];
 
-const MANAGED_MARKER = '# CodeMie-managed hooks - do not edit manually';
+export const MANAGED_MARKER = '# CodeMie-managed hooks - do not edit manually';
 const COMMAND = 'codemie hook';
+
+type TomlMap = { [key: string]: TomlValue };
+type TomlArray = string[] | number[] | boolean[] | Date[] | TomlMap[];
+type TomlValue = string | number | boolean | Date | TomlArray | TomlArray[] | TomlMap;
 
 interface KimiHooksConfig {
   hooks?: Array<Record<string, unknown>>;
@@ -57,11 +61,12 @@ export class KimiHookConfigInjector {
       const toml = await this.loadTomlModule();
       const configExists = existsSync(configPath);
       let created = false;
+      let existingContent: string | undefined;
 
       if (!configExists) {
         created = true;
       } else {
-        const existingContent = readFileSync(configPath, 'utf-8');
+        existingContent = readFileSync(configPath, 'utf-8');
         if (existingContent.includes(MANAGED_MARKER)) {
           logger.info('Kimi config already contains CodeMie-managed hooks; skipping injection.', {
             configPath,
@@ -72,9 +77,10 @@ export class KimiHookConfigInjector {
         this.backupConfig(configPath);
       }
 
-      const parsedConfig: KimiHooksConfig = configExists
-        ? (toml.parse(readFileSync(configPath, 'utf-8')) as KimiHooksConfig)
-        : {};
+      const parsedConfig: KimiHooksConfig =
+        existingContent !== undefined
+          ? (toml.parse(existingContent) as KimiHooksConfig)
+          : {};
 
       if (!Array.isArray(parsedConfig.hooks)) {
         parsedConfig.hooks = [];
@@ -88,9 +94,7 @@ export class KimiHookConfigInjector {
         });
       }
 
-      // @iarna/toml does not export its internal JsonMap type, so we assert the
-      // parsed object which is known to contain only TOML-compatible values.
-      const serialized = toml.stringify(parsedConfig as unknown as Record<string, never>);
+      const serialized = toml.stringify(parsedConfig as unknown as TomlMap);
       const contentWithMarker = `${MANAGED_MARKER}\n${serialized}`;
 
       writeFileSync(configPath, contentWithMarker, 'utf-8');
@@ -112,17 +116,24 @@ export class KimiHookConfigInjector {
   /**
    * Restore the original config from its CodeMie backup, if one exists.
    */
-  async restore(): Promise<void> {
+  async restore(): Promise<HookInjectionResult> {
     const configPath = getKimiConfigPath();
     const backupPath = `${configPath}.codemie-backup`;
 
     if (!existsSync(backupPath)) {
       logger.info('No Kimi config backup found; nothing to restore.', { configPath });
-      return;
+      return { success: true, created: false, configPath };
     }
 
-    copyFileSync(backupPath, configPath);
-    logger.info('Restored Kimi config from CodeMie backup.', { configPath, backupPath });
+    try {
+      copyFileSync(backupPath, configPath);
+      logger.info('Restored Kimi config from CodeMie backup.', { configPath, backupPath });
+      return { success: true, created: false, configPath };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.error('Failed to restore Kimi config from CodeMie backup.', error);
+      return { success: false, created: false, configPath, error: message };
+    }
   }
 
   private async loadTomlModule(): Promise<typeof import('@iarna/toml')> {
@@ -137,6 +148,13 @@ export class KimiHookConfigInjector {
 
   private backupConfig(configPath: string): void {
     const backupPath = `${configPath}.codemie-backup`;
+    if (existsSync(backupPath)) {
+      logger.debug('Kimi config backup already exists; skipping backup creation.', {
+        configPath,
+        backupPath,
+      });
+      return;
+    }
     copyFileSync(configPath, backupPath);
   }
 }

--- a/src/agents/plugins/kimi/kimi.hook-transformer.ts
+++ b/src/agents/plugins/kimi/kimi.hook-transformer.ts
@@ -1,0 +1,55 @@
+// src/agents/plugins/kimi/kimi.hook-transformer.ts
+/**
+ * Kimi hook payload transformer.
+ *
+ * Kimi emits lifecycle hooks as JSON on stdin with Kimi-specific field names.
+ * Unlike Claude and Gemini, Kimi payloads do not include a transcript path;
+ * the transformer computes it from the working directory and session id using
+ * the same deterministic layout Kimi uses for its session storage.
+ */
+
+import type { BaseHookEvent, HookTransformer } from '../../core/types.js';
+import { getKimiMainWirePath } from './kimi.paths.js';
+
+/**
+ * Transforms Kimi hook payloads to CodeMie's internal BaseHookEvent format.
+ */
+export class KimiHookTransformer implements HookTransformer {
+  readonly agentName = 'kimi';
+
+  /**
+   * Transform a Kimi hook event into the internal BaseHookEvent shape.
+   *
+   * @param event - Raw JSON payload received from Kimi on stdin
+   * @returns Transformed event compatible with CodeMie hook handlers
+   */
+  transform(event: unknown): BaseHookEvent {
+    const payload = event as Record<string, unknown>;
+
+    const sessionId = typeof payload.session_id === 'string' ? payload.session_id : '';
+    const cwd = typeof payload.cwd === 'string' ? payload.cwd : process.cwd();
+    const hookEventName = typeof payload.hook_event_name === 'string' ? payload.hook_event_name : '';
+
+    const transformed: BaseHookEvent = {
+      hook_event_name: hookEventName,
+      session_id: sessionId,
+      transcript_path: sessionId ? getKimiMainWirePath(cwd, sessionId) : '',
+      permission_mode: 'default',
+      cwd,
+    };
+
+    if (typeof payload.source === 'string') {
+      transformed.source = payload.source;
+    }
+
+    if (typeof payload.reason === 'string') {
+      transformed.reason = payload.reason;
+    }
+
+    if (typeof payload.stop_hook_active === 'boolean') {
+      transformed.stop_hook_active = payload.stop_hook_active;
+    }
+
+    return transformed;
+  }
+}

--- a/src/agents/plugins/kimi/kimi.paths.ts
+++ b/src/agents/plugins/kimi/kimi.paths.ts
@@ -1,19 +1,63 @@
+// src/agents/plugins/kimi/kimi.paths.ts
+/**
+ * Kimi path utilities.
+ *
+ * Kimi stores session data and user state at:
+ *   ${KIMI_CODE_HOME:-~/.kimi-code}/sessions/{workDirKey}/{sessionId}/agents/main/wire.jsonl
+ *
+ * Kimi does not use XDG conventions by default, but it supports KIMI_CODE_HOME
+ * for isolating local state.
+ *
+ * Work directory keys are deterministic: the slug is derived from the resolved
+ * directory basename (truncated and sanitized), and the suffix is the first 12
+ * characters of a SHA-256 hash of the resolved path. This keeps directory names
+ * readable while avoiding collisions between different paths that share the same
+ * basename.
+ */
+
 import { createHash } from 'crypto';
 import { homedir } from 'os';
 import { basename, join, resolve } from 'path';
 
+/**
+ * Returns the Kimi home directory.
+ *
+ * Defaults to ${userHome}/.kimi-code unless KIMI_CODE_HOME is set.
+ */
 export function getKimiCodeHome(): string {
   return process.env.KIMI_CODE_HOME || join(homedir(), '.kimi-code');
 }
 
+/**
+ * Returns the path to Kimi's global config file.
+ *
+ *   ${KIMI_CODE_HOME}/config.toml
+ */
 export function getKimiConfigPath(): string {
   return join(getKimiCodeHome(), 'config.toml');
 }
 
+/**
+ * Returns the base directory for all Kimi sessions.
+ *
+ *   ${KIMI_CODE_HOME}/sessions
+ */
 export function getKimiSessionsDir(): string {
   return join(getKimiCodeHome(), 'sessions');
 }
 
+/**
+ * Encodes a working directory path into a deterministic, filesystem-safe key.
+ *
+ * The key has the shape:
+ *   wd_{slug}_{hash}
+ *
+ * - `slug` is the lowercase basename of the resolved cwd, with non-alphanumeric
+ *   characters replaced by `-`, leading/trailing dashes stripped, and truncated
+ *   to 40 characters. If the result is empty, `.`, or `..`, it is replaced with
+ *   `workspace`.
+ * - `hash` is the first 12 characters of the SHA-256 digest of the resolved cwd.
+ */
 export function encodeKimiWorkDirKey(cwd: string): string {
   const resolvedCwd = resolve(cwd);
   let slug = basename(resolvedCwd).toLowerCase();
@@ -34,14 +78,29 @@ export function encodeKimiWorkDirKey(cwd: string): string {
   return `wd_${slug}_${hash}`;
 }
 
+/**
+ * Returns the session directory for a given cwd and session id.
+ *
+ *   ${KIMI_CODE_HOME}/sessions/{workDirKey}/{sessionId}
+ */
 export function getKimiSessionDir(cwd: string, sessionId: string): string {
   return join(getKimiSessionsDir(), encodeKimiWorkDirKey(cwd), sessionId);
 }
 
+/**
+ * Returns the main agent wire file path for a given cwd and session id.
+ *
+ *   ${KIMI_CODE_HOME}/sessions/{workDirKey}/{sessionId}/agents/main/wire.jsonl
+ */
 export function getKimiMainWirePath(cwd: string, sessionId: string): string {
   return join(getKimiSessionDir(cwd, sessionId), 'agents', 'main', 'wire.jsonl');
 }
 
+/**
+ * Returns the directory for user-defined Kimi skills.
+ *
+ *   ${KIMI_CODE_HOME}/skills
+ */
 export function getKimiUserSkillsDir(): string {
   return join(getKimiCodeHome(), 'skills');
 }

--- a/src/agents/plugins/kimi/kimi.paths.ts
+++ b/src/agents/plugins/kimi/kimi.paths.ts
@@ -1,0 +1,47 @@
+import { createHash } from 'crypto';
+import { homedir } from 'os';
+import { basename, join, resolve } from 'path';
+
+export function getKimiCodeHome(): string {
+  return process.env.KIMI_CODE_HOME || join(homedir(), '.kimi-code');
+}
+
+export function getKimiConfigPath(): string {
+  return join(getKimiCodeHome(), 'config.toml');
+}
+
+export function getKimiSessionsDir(): string {
+  return join(getKimiCodeHome(), 'sessions');
+}
+
+export function encodeKimiWorkDirKey(cwd: string): string {
+  const resolvedCwd = resolve(cwd);
+  let slug = basename(resolvedCwd).toLowerCase();
+
+  slug = slug.replace(/[^a-z0-9._-]/g, '-');
+  slug = slug.replace(/^-+|-+$/g, '');
+  slug = slug.slice(0, 40);
+
+  if (slug === '' || slug === '.' || slug === '..') {
+    slug = 'workspace';
+  }
+
+  const hash = createHash('sha256')
+    .update(resolvedCwd)
+    .digest('hex')
+    .slice(0, 12);
+
+  return `wd_${slug}_${hash}`;
+}
+
+export function getKimiSessionDir(cwd: string, sessionId: string): string {
+  return join(getKimiSessionsDir(), encodeKimiWorkDirKey(cwd), sessionId);
+}
+
+export function getKimiMainWirePath(cwd: string, sessionId: string): string {
+  return join(getKimiSessionDir(cwd, sessionId), 'agents', 'main', 'wire.jsonl');
+}
+
+export function getKimiUserSkillsDir(): string {
+  return join(getKimiCodeHome(), 'skills');
+}

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -1,0 +1,197 @@
+import type { AgentMetadata, HookTransformer } from '../../core/types.js';
+import { BaseAgentAdapter } from '../../core/BaseAgentAdapter.js';
+import type { SessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+import type { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
+import { KimiSessionAdapter } from './kimi.session.js';
+import { KimiExtensionInstaller } from './kimi.extension-installer.js';
+import { KimiHookTransformer } from './kimi.hook-transformer.js';
+import { installNativeAgent } from '../../../utils/native-installer.js';
+import {
+  AgentInstallationError,
+  createErrorContext,
+  getErrorMessage,
+} from '../../../utils/errors.js';
+import { logger } from '../../../utils/logger.js';
+import { sanitizeLogArgs } from '../../../utils/security.js';
+import chalk from 'chalk';
+import { commandExists, exec } from '../../../utils/processes.js';
+import { resolveHomeDir } from '../../../utils/paths.js';
+
+const KIMI_SUPPORTED_VERSION = '1.0.0';
+const KIMI_MINIMUM_SUPPORTED_VERSION = '0.9.0';
+
+const KIMI_INSTALLER_URLS = {
+  macOS: 'https://code.kimi.com/kimi-code/install.sh',
+  windows: 'https://code.kimi.com/kimi-code/install.ps1',
+  linux: 'https://code.kimi.com/kimi-code/install.sh',
+};
+
+export const KimiPluginMetadata: AgentMetadata = {
+  name: 'kimi',
+  displayName: 'Kimi Code',
+  description: 'Kimi Code CLI - Moonshot AI coding agent',
+  npmPackage: '@moonshot-ai/kimi-code',
+  cliCommand: 'kimi',
+  supportedVersion: KIMI_SUPPORTED_VERSION,
+  minimumSupportedVersion: KIMI_MINIMUM_SUPPORTED_VERSION,
+  installerUrls: KIMI_INSTALLER_URLS,
+  dataPaths: { home: '.kimi-code' },
+  envMapping: {},
+  supportedProviders: ['moonshot-subscription'],
+  blockedModelPatterns: [],
+  recommendedModels: ['kimi-for-coding', 'kimi-k2'],
+  ssoConfig: { enabled: true, clientType: 'codemie-kimi' },
+  flagMappings: {
+    '--task': { type: 'flag', target: '-p' },
+  },
+  metricsConfig: {
+    excludeErrorsFromTools: ['Bash'],
+  },
+  extensionsConfig: {
+    project: '.kimi-code',
+    global: '~/.kimi-code',
+    skillsEntryFile: 'SKILL.md',
+  },
+  hookConfig: {
+    eventNameMapping: {
+      'SessionStart': 'SessionStart',
+      'SessionEnd': 'SessionEnd',
+      'UserPromptSubmit': 'UserPromptSubmit',
+      'Stop': 'Stop',
+      'SubagentStop': 'SubagentStop',
+      'PreCompact': 'PreCompact',
+      'PermissionRequest': 'PermissionRequest',
+      'PermissionResult': 'PermissionRequest',
+    },
+  },
+};
+
+export class KimiPlugin extends BaseAgentAdapter {
+  private sessionAdapter?: SessionAdapter;
+  private extensionInstaller?: BaseExtensionInstaller;
+  private hookTransformer?: HookTransformer;
+
+  constructor(metadata: AgentMetadata = KimiPluginMetadata) {
+    super(metadata);
+  }
+
+  getSessionAdapter(): SessionAdapter {
+    if (!this.sessionAdapter) {
+      this.sessionAdapter = new KimiSessionAdapter(this.metadata);
+    }
+    return this.sessionAdapter;
+  }
+
+  getExtensionInstaller(): BaseExtensionInstaller {
+    if (!this.extensionInstaller) {
+      this.extensionInstaller = new KimiExtensionInstaller(this.metadata);
+    }
+    return this.extensionInstaller;
+  }
+
+  getHookTransformer(): HookTransformer {
+    if (!this.hookTransformer) {
+      this.hookTransformer = new KimiHookTransformer();
+    }
+    return this.hookTransformer;
+  }
+
+  override async isInstalled(): Promise<boolean> {
+    if (!this.metadata.cliCommand) {
+      return true;
+    }
+
+    if (await commandExists(this.metadata.cliCommand)) {
+      return true;
+    }
+
+    if (process.platform !== 'win32') {
+      const fullPath = resolveHomeDir('.local/bin/kimi');
+      try {
+        const result = await exec(fullPath, ['--version']);
+        return result.code === 0;
+      } catch {
+        // Full path check failed, fall through to PATH check already performed
+      }
+    }
+
+    logger.debug('[kimi-plugin] Kimi not installed. Install with:');
+    logger.debug('[kimi-plugin]   codemie install kimi');
+
+    return false;
+  }
+
+  override async install(): Promise<void> {
+    if (!this.metadata.installerUrls) {
+      throw new AgentInstallationError(
+        this.metadata.name,
+        'No installer URLs configured for native installation',
+      );
+    }
+
+    try {
+      const result = await installNativeAgent(
+        this.metadata.name,
+        this.metadata.installerUrls,
+        undefined,
+        {
+          timeout: 300000,
+          verifyCommand: this.metadata.cliCommand || undefined,
+          verifyPath:
+            process.platform === 'win32' ? undefined : resolveHomeDir('.local/bin/kimi'),
+          installFlags: ['--force'],
+        },
+      );
+
+      if (!result.success) {
+        throw new AgentInstallationError(
+          this.metadata.name,
+          `Installation failed. Output: ${result.output}`,
+        );
+      }
+
+      logger.success(`${this.metadata.displayName} installed successfully`);
+    } catch (error) {
+      if (error instanceof AgentInstallationError) {
+        throw error;
+      }
+
+      const errorContext = createErrorContext(error, {
+        agent: this.metadata.name,
+      });
+      logger.error('Kimi installation failed', ...sanitizeLogArgs(errorContext));
+
+      throw new AgentInstallationError(
+        this.metadata.name,
+        `Failed to install ${this.metadata.displayName}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  override async installVersion(version?: string): Promise<void> {
+    let resolvedVersion: string | undefined = version;
+
+    if (version === 'supported') {
+      if (!this.metadata.supportedVersion) {
+        throw new AgentInstallationError(
+          this.metadata.name,
+          'No supported version defined in metadata',
+        );
+      }
+      resolvedVersion = this.metadata.supportedVersion;
+      logger.debug('Resolved version', {
+        from: 'supported',
+        to: resolvedVersion,
+      });
+    } else if (resolvedVersion && resolvedVersion !== 'latest' && resolvedVersion !== 'stable') {
+      logger.warn(
+        chalk.yellow(
+          `${this.metadata.displayName} does not support installing version ${resolvedVersion}. ` +
+            'Installing the latest version instead.',
+        ),
+      );
+    }
+
+    await this.install();
+  }
+}

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -190,33 +190,36 @@ export class KimiPlugin extends BaseAgentAdapter {
         from: 'supported',
         to: resolvedVersion,
       });
-    } else if (version === 'npm') {
+    } else if (version === 'npm' || version === 'latest') {
+      // The 'npm' and 'latest' channels request the latest build. Kimi uses the
+      // native installer, so passing undefined installs the latest version.
       resolvedVersion = undefined;
     }
 
-    const isNpmVersion =
+    // Only known channels and valid semantic versions are accepted. Everything
+    // else falls back to the latest native build with a warning.
+    const isKnownChannel = ['latest', 'stable', 'supported', 'npm'].includes(version ?? '');
+    if (version && !isKnownChannel && !isValidSemanticVersion(version)) {
+      logger.warn(
+        chalk.yellow(
+          `${this.metadata.displayName} does not support installing version ${version}. ` +
+            'Installing the latest version instead.',
+        ),
+      );
+      resolvedVersion = undefined;
+    }
+
+    // npm-channel and explicit semantic-version installs require a recent Node
+    // runtime because the installer internally resolves package metadata.
+    const isNpmBasedChannel =
       version === 'npm' || (version !== undefined && isValidSemanticVersion(version));
     if (
-      isNpmVersion &&
+      isNpmBasedChannel &&
       compareVersions(process.version, KIMI_MINIMUM_NODE_VERSION_FOR_NPM) < 0
     ) {
       throw new AgentInstallationError(
         this.metadata.name,
-        `Kimi npm installs require Node.js >= ${KIMI_MINIMUM_NODE_VERSION_FOR_NPM} (current: ${process.version})`,
-      );
-    }
-
-    if (
-      resolvedVersion &&
-      resolvedVersion !== 'latest' &&
-      resolvedVersion !== 'stable' &&
-      version !== 'supported'
-    ) {
-      logger.warn(
-        chalk.yellow(
-          `${this.metadata.displayName} does not support installing version ${resolvedVersion}. ` +
-            'Installing the latest version instead.',
-        ),
+        `Kimi installs from the npm channel or explicit versions require Node.js >= ${KIMI_MINIMUM_NODE_VERSION_FOR_NPM} (current: ${process.version})`,
       );
     }
 

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -124,7 +124,7 @@ export class KimiPlugin extends BaseAgentAdapter {
     return false;
   }
 
-  override async install(): Promise<void> {
+  private async installNative(version?: string): Promise<void> {
     if (!this.metadata.installerUrls) {
       throw new AgentInstallationError(
         this.metadata.name,
@@ -136,7 +136,7 @@ export class KimiPlugin extends BaseAgentAdapter {
       const result = await installNativeAgent(
         this.metadata.name,
         this.metadata.installerUrls,
-        undefined,
+        version,
         {
           timeout: 300000,
           verifyCommand: this.metadata.cliCommand || undefined,
@@ -171,6 +171,10 @@ export class KimiPlugin extends BaseAgentAdapter {
     }
   }
 
+  override async install(): Promise<void> {
+    return this.installVersion(undefined);
+  }
+
   override async installVersion(version?: string): Promise<void> {
     let resolvedVersion: string | undefined = version;
 
@@ -186,6 +190,8 @@ export class KimiPlugin extends BaseAgentAdapter {
         from: 'supported',
         to: resolvedVersion,
       });
+    } else if (version === 'npm') {
+      resolvedVersion = undefined;
     }
 
     const isNpmVersion =
@@ -200,7 +206,12 @@ export class KimiPlugin extends BaseAgentAdapter {
       );
     }
 
-    if (resolvedVersion && resolvedVersion !== 'latest' && resolvedVersion !== 'stable') {
+    if (
+      resolvedVersion &&
+      resolvedVersion !== 'latest' &&
+      resolvedVersion !== 'stable' &&
+      version !== 'supported'
+    ) {
       logger.warn(
         chalk.yellow(
           `${this.metadata.displayName} does not support installing version ${resolvedVersion}. ` +
@@ -209,6 +220,6 @@ export class KimiPlugin extends BaseAgentAdapter {
       );
     }
 
-    await this.install();
+    await this.installNative(resolvedVersion);
   }
 }

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -14,7 +14,6 @@ import {
 import { compareVersions, isValidSemanticVersion } from '../../../utils/version-utils.js';
 import { logger } from '../../../utils/logger.js';
 import { sanitizeLogArgs } from '../../../utils/security.js';
-import chalk from 'chalk';
 import { commandExists, exec } from '../../../utils/processes.js';
 import { resolveHomeDir } from '../../../utils/paths.js';
 
@@ -175,9 +174,46 @@ export class KimiPlugin extends BaseAgentAdapter {
     return this.installVersion(undefined);
   }
 
-  override async installVersion(version?: string): Promise<void> {
-    let resolvedVersion: string | undefined = version;
+  /**
+   * Get Kimi version by parsing 'kimi --version' output.
+   * Extracts the first semantic version found in the output.
+   *
+   * Checks the native installer full path first on Unix systems, then falls
+   * back to the command in PATH for other installation methods.
+   */
+  override async getVersion(): Promise<string | null> {
+    if (!this.metadata.cliCommand) {
+      return null;
+    }
 
+    const parseVersion = (output: string): string | null => {
+      const match = output.match(/(\d+\.\d+\.\d+)/);
+      return match ? match[1] : output.trim() || null;
+    };
+
+    // Try full path first on Unix systems (native installer places binary at ~/.local/bin/kimi)
+    if (process.platform !== 'win32') {
+      const fullPath = resolveHomeDir('.local/bin/kimi');
+      try {
+        const result = await exec(fullPath, ['--version']);
+        return parseVersion(result.stdout);
+      } catch {
+        // Full path check failed, fall through to PATH check
+      }
+    }
+
+    // Fall back to command in PATH
+    try {
+      const result = await exec(this.metadata.cliCommand, ['--version']);
+      return parseVersion(result.stdout);
+    } catch {
+      return null;
+    }
+  }
+
+  override async installVersion(version?: string): Promise<void> {
+    // Resolve 'supported' to the version from metadata
+    let resolvedVersion: string | undefined = version;
     if (version === 'supported') {
       if (!this.metadata.supportedVersion) {
         throw new AgentInstallationError(
@@ -190,36 +226,39 @@ export class KimiPlugin extends BaseAgentAdapter {
         from: 'supported',
         to: resolvedVersion,
       });
-    } else if (version === 'npm' || version === 'latest') {
-      // The 'npm' and 'latest' channels request the latest build. Kimi uses the
-      // native installer, so passing undefined installs the latest version.
+    } else if (version === 'npm' || version === 'latest' || version === 'stable') {
+      // The 'npm', 'latest', and 'stable' channels request the latest build.
+      // Kimi uses the native installer, so passing undefined installs the
+      // latest version.
       resolvedVersion = undefined;
     }
 
-    // Only known channels and valid semantic versions are accepted. Everything
-    // else falls back to the latest native build with a warning.
-    const isKnownChannel = ['latest', 'stable', 'supported', 'npm'].includes(version ?? '');
-    if (version && !isKnownChannel && !isValidSemanticVersion(version)) {
-      logger.warn(
-        chalk.yellow(
-          `${this.metadata.displayName} does not support installing version ${version}. ` +
-            'Installing the latest version instead.',
-        ),
-      );
-      resolvedVersion = undefined;
+    // Reject unknown channels and invalid semantic versions.
+    if (version) {
+      const allowedChannels = ['latest', 'stable', 'supported', 'npm'];
+      const isAllowedChannel = allowedChannels.includes(version);
+      const isValidVersion = isValidSemanticVersion(version);
+
+      if (!isAllowedChannel && !isValidVersion) {
+        throw new AgentInstallationError(
+          this.metadata.name,
+          `Invalid version format: '${version}'. Expected semantic version (e.g., '1.0.0'), 'latest', 'stable', 'supported', or 'npm'.`,
+        );
+      }
     }
 
-    // npm-channel and explicit semantic-version installs require a recent Node
-    // runtime because the installer internally resolves package metadata.
-    const isNpmBasedChannel =
-      version === 'npm' || (version !== undefined && isValidSemanticVersion(version));
+    // npm-channel, supported-channel, and explicit semantic-version installs
+    // require a recent Node runtime because the installer internally resolves
+    // package metadata.
+    const isSemverInstall = resolvedVersion !== undefined && isValidSemanticVersion(resolvedVersion);
+    const isNpmChannel = version === 'npm';
     if (
-      isNpmBasedChannel &&
+      (isNpmChannel || isSemverInstall) &&
       compareVersions(process.version, KIMI_MINIMUM_NODE_VERSION_FOR_NPM) < 0
     ) {
       throw new AgentInstallationError(
         this.metadata.name,
-        `Kimi installs from the npm channel or explicit versions require Node.js >= ${KIMI_MINIMUM_NODE_VERSION_FOR_NPM} (current: ${process.version})`,
+        `Kimi installs from the npm channel, the supported version, or explicit versions require Node.js >= ${KIMI_MINIMUM_NODE_VERSION_FOR_NPM} (current: ${process.version})`,
       );
     }
 

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -11,6 +11,7 @@ import {
   createErrorContext,
   getErrorMessage,
 } from '../../../utils/errors.js';
+import { compareVersions, isValidSemanticVersion } from '../../../utils/version-utils.js';
 import { logger } from '../../../utils/logger.js';
 import { sanitizeLogArgs } from '../../../utils/security.js';
 import chalk from 'chalk';
@@ -19,6 +20,7 @@ import { resolveHomeDir } from '../../../utils/paths.js';
 
 const KIMI_SUPPORTED_VERSION = '1.0.0';
 const KIMI_MINIMUM_SUPPORTED_VERSION = '0.9.0';
+const KIMI_MINIMUM_NODE_VERSION_FOR_NPM = '22.19.0';
 
 const KIMI_INSTALLER_URLS = {
   macOS: 'https://code.kimi.com/kimi-code/install.sh',
@@ -43,6 +45,7 @@ export const KimiPluginMetadata: AgentMetadata = {
   ssoConfig: { enabled: true, clientType: 'codemie-kimi' },
   flagMappings: {
     '--task': { type: 'flag', target: '-p' },
+    '--model': { type: 'flag', target: '--model' },
   },
   metricsConfig: {
     excludeErrorsFromTools: ['Bash'],
@@ -183,7 +186,21 @@ export class KimiPlugin extends BaseAgentAdapter {
         from: 'supported',
         to: resolvedVersion,
       });
-    } else if (resolvedVersion && resolvedVersion !== 'latest' && resolvedVersion !== 'stable') {
+    }
+
+    const isNpmVersion =
+      version === 'npm' || (version !== undefined && isValidSemanticVersion(version));
+    if (
+      isNpmVersion &&
+      compareVersions(process.version, KIMI_MINIMUM_NODE_VERSION_FOR_NPM) < 0
+    ) {
+      throw new AgentInstallationError(
+        this.metadata.name,
+        `Kimi npm installs require Node.js >= ${KIMI_MINIMUM_NODE_VERSION_FOR_NPM} (current: ${process.version})`,
+      );
+    }
+
+    if (resolvedVersion && resolvedVersion !== 'latest' && resolvedVersion !== 'stable') {
       logger.warn(
         chalk.yellow(
           `${this.metadata.displayName} does not support installing version ${resolvedVersion}. ` +

--- a/src/agents/plugins/kimi/kimi.session.ts
+++ b/src/agents/plugins/kimi/kimi.session.ts
@@ -19,7 +19,6 @@ import type { SessionProcessor, ProcessingContext } from '../../core/session/Bas
 import type { AgentMetadata } from '../../core/types.js';
 import { readJSONLTolerant } from '../../core/session/utils/jsonl-reader.js';
 import { logger } from '../../../utils/logger.js';
-import { ToolExecutionError } from '../../../utils/errors.js';
 import { KimiMetricsProcessor } from './session/processors/kimi.metrics-processor.js';
 import type { KimiWireEvent } from './session/types.js';
 
@@ -94,15 +93,87 @@ export class KimiSessionAdapter implements SessionAdapter {
   /**
    * Process a Kimi session file with all registered processors.
    *
-   * Not yet implemented — processors are currently run externally by callers
-   * after `parseSessionFile`. The adapter only registers processors here.
+   * Parses the wire.jsonl file once, runs each registered processor in priority
+   * order, and returns an aggregated result. This is the entry point used by
+   * `codemie hook` during incremental sync.
    */
   async processSession(
-    _filePath: string,
-    _sessionId: string,
-    _context: ProcessingContext
+    filePath: string,
+    sessionId: string,
+    context: ProcessingContext
   ): Promise<AggregatedResult> {
-    throw new ToolExecutionError('processSession', 'Kimi session processing is not implemented yet');
+    try {
+      logger.debug(
+        `[kimi-adapter] Processing session ${sessionId} with ${this.processors.length} processor${this.processors.length !== 1 ? 's' : ''}`
+      );
+
+      const parsedSession = await this.parseSessionFile(filePath, sessionId);
+
+      const processorResults: Record<string, {
+        success: boolean;
+        message?: string;
+        recordsProcessed?: number;
+      }> = {};
+      const failedProcessors: string[] = [];
+      let totalRecords = 0;
+
+      for (const processor of this.processors) {
+        try {
+          if (!processor.shouldProcess(parsedSession)) {
+            logger.debug(`[kimi-adapter] Processor ${processor.name} skipped (shouldProcess returned false)`);
+            continue;
+          }
+
+          logger.debug(`[kimi-adapter] Running processor: ${processor.name}`);
+
+          const result = await processor.process(parsedSession, context);
+
+          processorResults[processor.name] = {
+            success: result.success,
+            message: result.message,
+            recordsProcessed: result.metadata?.recordsProcessed as number | undefined,
+          };
+
+          if (!result.success) {
+            failedProcessors.push(processor.name);
+            logger.warn(`[kimi-adapter] Processor ${processor.name} failed: ${result.message}`);
+          } else {
+            logger.debug(`[kimi-adapter] Processor ${processor.name} succeeded: ${result.message}`);
+          }
+
+          const recordsProcessed = result.metadata?.recordsProcessed as number | undefined;
+          if (typeof recordsProcessed === 'number') {
+            totalRecords += recordsProcessed;
+          }
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          logger.error(`[kimi-adapter] Processor ${processor.name} threw error:`, error);
+
+          processorResults[processor.name] = {
+            success: false,
+            message: errorMessage,
+          };
+          failedProcessors.push(processor.name);
+        }
+      }
+
+      const result: AggregatedResult = {
+        success: failedProcessors.length === 0,
+        processors: processorResults,
+        totalRecords,
+        failedProcessors,
+      };
+
+      logger.debug(
+        `[kimi-adapter] Processing complete: ${result.success ? 'SUCCESS' : 'FAILED'} ` +
+        `(${totalRecords} records, ${failedProcessors.length} failed processors)`
+      );
+
+      return result;
+    } catch (error) {
+      logger.error(`[kimi-adapter] Session processing failed:`, error);
+      throw error;
+    }
   }
 
   private createMinimalSession(sessionId: string): ParsedSession {

--- a/src/agents/plugins/kimi/kimi.session.ts
+++ b/src/agents/plugins/kimi/kimi.session.ts
@@ -117,11 +117,10 @@ export class KimiSessionAdapter implements SessionAdapter {
 
       const model = this.extractModel(events);
       const { createdAt, updatedAt } = this.extractTimestamps(events);
-      const metrics = this.extractMetrics(events);
 
       logger.debug(
         `[kimi-adapter] Parsed session ${sessionId}: ${events.length} events, ` +
-        `model=${model ?? 'unknown'}, tools=${Object.keys(metrics.tools ?? {}).length}`
+        `model=${model ?? 'unknown'}`
       );
 
       const metadata = {
@@ -136,7 +135,6 @@ export class KimiSessionAdapter implements SessionAdapter {
         agentName: this.metadata.displayName || 'Kimi Code',
         metadata,
         messages: events,
-        metrics,
       };
     } catch (error) {
       logger.warn(`[kimi-adapter] Failed to parse session file ${filePath}:`, error);
@@ -170,11 +168,6 @@ export class KimiSessionAdapter implements SessionAdapter {
       agentName: this.metadata.displayName || 'Kimi Code',
       metadata,
       messages: [],
-      metrics: {
-        tools: {},
-        toolStatus: {},
-        fileOperations: [],
-      },
     };
   }
 
@@ -223,82 +216,4 @@ export class KimiSessionAdapter implements SessionAdapter {
     return { createdAt, updatedAt };
   }
 
-  private extractMetrics(events: KimiWireEvent[]): NonNullable<ParsedSession['metrics']> {
-    const tools: Record<string, number> = {};
-    const toolStatus: Record<string, { success: number; failure: number }> = {};
-    const fileOperations: Array<{ type: string; path?: string }> = [];
-
-    // First pass: index tool calls by toolCallId so tool results can be matched.
-    const toolCallById = new Map<string, KimiWireEvent & { event: { name: string } }>();
-
-    for (const event of events) {
-      if (
-        event.type === 'context.append_loop_event' &&
-        event.event?.type === 'tool.call' &&
-        typeof event.event.toolCallId === 'string' &&
-        typeof event.event.name === 'string'
-      ) {
-        const toolName = event.event.name;
-        tools[toolName] = (tools[toolName] || 0) + 1;
-
-        if (!toolStatus[toolName]) {
-          toolStatus[toolName] = { success: 0, failure: 0 };
-        }
-
-        toolCallById.set(event.event.toolCallId, event as KimiWireEvent & { event: { name: string } });
-      }
-    }
-
-    // Second pass: match tool results to tool calls and update status.
-    for (const event of events) {
-      if (
-        event.type !== 'context.append_loop_event' ||
-        event.event?.type !== 'tool.result' ||
-        !event.event.result
-      ) {
-        continue;
-      }
-
-      const matchedToolCall =
-        (typeof event.event.toolCallId === 'string' && toolCallById.get(event.event.toolCallId)) ||
-        (typeof event.event.parentUuid === 'string' && toolCallById.get(event.event.parentUuid));
-
-      if (!matchedToolCall) {
-        continue;
-      }
-
-      const toolName = matchedToolCall.event.name;
-      const isError = event.event.result.isError === true;
-
-      if (isError) {
-        toolStatus[toolName].failure++;
-      } else {
-        toolStatus[toolName].success++;
-      }
-    }
-
-    // Third pass: collect file operations from display metadata.
-    for (const event of events) {
-      if (event.type !== 'context.append_loop_event') {
-        continue;
-      }
-
-      const display = event.display;
-      if (!display || display.kind !== 'file_io') {
-        continue;
-      }
-
-      const operation = display.operation;
-      if (operation !== 'read' && operation !== 'write' && operation !== 'edit') {
-        continue;
-      }
-
-      fileOperations.push({
-        type: operation,
-        path: typeof display.path === 'string' ? display.path : undefined,
-      });
-    }
-
-    return { tools, toolStatus, fileOperations };
-  }
 }

--- a/src/agents/plugins/kimi/kimi.session.ts
+++ b/src/agents/plugins/kimi/kimi.session.ts
@@ -21,66 +21,15 @@ import { readJSONLTolerant } from '../../core/session/utils/jsonl-reader.js';
 import { logger } from '../../../utils/logger.js';
 import { ToolExecutionError } from '../../../utils/errors.js';
 import { KimiMetricsProcessor } from './session/processors/kimi.metrics-processor.js';
-
-interface KimiWireEvent {
-  type: string;
-  time?: number;
-  // metadata
-  protocol_version?: string;
-  created_at?: number;
-  app_version?: string;
-  // config.update
-  profileName?: string;
-  systemPrompt?: string;
-  modelAlias?: string;
-  thinkingLevel?: string;
-  // usage.record
-  model?: string;
-  usage?: {
-    inputOther?: number;
-    output?: number;
-    inputCacheRead?: number;
-    inputCacheCreation?: number;
-  };
-  usageScope?: string;
-  // context.append_loop_event
-  event?: {
-    type?: string;
-    uuid?: string;
-    turnId?: string;
-    step?: number;
-    toolCallId?: string;
-    parentUuid?: string;
-    name?: string;
-    args?: Record<string, unknown>;
-    description?: string;
-    result?: {
-      output?: string;
-      isError?: boolean;
-    };
-    usage?: {
-      inputOther?: number;
-      output?: number;
-      inputCacheRead?: number;
-      inputCacheCreation?: number;
-    };
-    finishReason?: string;
-  };
-  display?: {
-    kind?: string;
-    operation?: string;
-    path?: string;
-    content?: string;
-    before?: string;
-    after?: string;
-  };
-}
+import type { KimiWireEvent } from './session/types.js';
 
 export class KimiSessionAdapter implements SessionAdapter {
   readonly agentName = 'kimi';
   private processors: SessionProcessor[] = [];
 
   constructor(private readonly metadata: AgentMetadata) {
+    // Register processors now, but execution is currently orchestrated externally
+    // until processSession is implemented.
     this.initializeProcessors();
   }
 
@@ -145,8 +94,8 @@ export class KimiSessionAdapter implements SessionAdapter {
   /**
    * Process a Kimi session file with all registered processors.
    *
-   * Not yet implemented — Kimi metrics are currently extracted directly
-   * by parseSessionFile for analytics consumption.
+   * Not yet implemented — processors are currently run externally by callers
+   * after `parseSessionFile`. The adapter only registers processors here.
    */
   async processSession(
     _filePath: string,

--- a/src/agents/plugins/kimi/kimi.session.ts
+++ b/src/agents/plugins/kimi/kimi.session.ts
@@ -1,0 +1,304 @@
+/**
+ * Kimi Session Adapter
+ *
+ * Parses Kimi Code `wire.jsonl` session transcripts into the unified
+ * ParsedSession format used by CodeMie processors.
+ *
+ * Wire file path:
+ *   ${KIMI_CODE_HOME}/sessions/{workDirKey}/{sessionId}/agents/main/wire.jsonl
+ */
+
+import type {
+  SessionAdapter,
+  ParsedSession,
+  AggregatedResult,
+  SessionDiscoveryOptions,
+  SessionDescriptor,
+} from '../../core/session/BaseSessionAdapter.js';
+import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
+import type { AgentMetadata } from '../../core/types.js';
+import { readJSONLTolerant } from '../../core/session/utils/jsonl-reader.js';
+import { logger } from '../../../utils/logger.js';
+import { ToolExecutionError } from '../../../utils/errors.js';
+import { KimiMetricsProcessor } from './session/processors/kimi.metrics-processor.js';
+
+interface KimiWireEvent {
+  type: string;
+  time?: number;
+  // metadata
+  protocol_version?: string;
+  created_at?: number;
+  app_version?: string;
+  // config.update
+  profileName?: string;
+  systemPrompt?: string;
+  modelAlias?: string;
+  thinkingLevel?: string;
+  // usage.record
+  model?: string;
+  usage?: {
+    inputOther?: number;
+    output?: number;
+    inputCacheRead?: number;
+    inputCacheCreation?: number;
+  };
+  usageScope?: string;
+  // context.append_loop_event
+  event?: {
+    type?: string;
+    uuid?: string;
+    turnId?: string;
+    step?: number;
+    toolCallId?: string;
+    parentUuid?: string;
+    name?: string;
+    args?: Record<string, unknown>;
+    description?: string;
+    result?: {
+      output?: string;
+      isError?: boolean;
+    };
+    usage?: {
+      inputOther?: number;
+      output?: number;
+      inputCacheRead?: number;
+      inputCacheCreation?: number;
+    };
+    finishReason?: string;
+  };
+  display?: {
+    kind?: string;
+    operation?: string;
+    path?: string;
+    content?: string;
+    before?: string;
+    after?: string;
+  };
+}
+
+export class KimiSessionAdapter implements SessionAdapter {
+  readonly agentName = 'kimi';
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new KimiMetricsProcessor());
+    logger.debug(`[kimi-adapter] Initialized ${this.processors.length} processors`);
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+    logger.debug(`[kimi-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
+  }
+
+  /**
+   * Discover native Kimi sessions (placeholder).
+   */
+  async discoverSessions(_options?: SessionDiscoveryOptions): Promise<SessionDescriptor[]> {
+    logger.debug('[kimi-adapter] discoverSessions is not implemented yet');
+    return [];
+  }
+
+  /**
+   * Parse a Kimi `wire.jsonl` file into the unified ParsedSession format.
+   */
+  async parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession> {
+    try {
+      const events = await readJSONLTolerant<KimiWireEvent>(filePath, '[kimi-adapter]');
+
+      if (events.length === 0) {
+        logger.debug(`[kimi-adapter] Session file is empty or unreadable: ${filePath}`);
+        return this.createMinimalSession(sessionId);
+      }
+
+      const model = this.extractModel(events);
+      const { createdAt, updatedAt } = this.extractTimestamps(events);
+      const metrics = this.extractMetrics(events);
+
+      logger.debug(
+        `[kimi-adapter] Parsed session ${sessionId}: ${events.length} events, ` +
+        `model=${model ?? 'unknown'}, tools=${Object.keys(metrics.tools ?? {}).length}`
+      );
+
+      const metadata = {
+        projectPath: filePath,
+        createdAt,
+        updatedAt,
+        model,
+      };
+
+      return {
+        sessionId,
+        agentName: this.metadata.displayName || 'Kimi Code',
+        metadata,
+        messages: events,
+        metrics,
+      };
+    } catch (error) {
+      logger.warn(`[kimi-adapter] Failed to parse session file ${filePath}:`, error);
+      return this.createMinimalSession(sessionId);
+    }
+  }
+
+  /**
+   * Process a Kimi session file with all registered processors.
+   *
+   * Not yet implemented — Kimi metrics are currently extracted directly
+   * by parseSessionFile for analytics consumption.
+   */
+  async processSession(
+    _filePath: string,
+    _sessionId: string,
+    _context: ProcessingContext
+  ): Promise<AggregatedResult> {
+    throw new ToolExecutionError('processSession', 'Kimi session processing is not implemented yet');
+  }
+
+  private createMinimalSession(sessionId: string): ParsedSession {
+    const metadata = {
+      createdAt: undefined,
+      updatedAt: undefined,
+      model: undefined,
+    };
+
+    return {
+      sessionId,
+      agentName: this.metadata.displayName || 'Kimi Code',
+      metadata,
+      messages: [],
+      metrics: {
+        tools: {},
+        toolStatus: {},
+        fileOperations: [],
+      },
+    };
+  }
+
+  private extractModel(events: KimiWireEvent[]): string | undefined {
+    for (const event of events) {
+      if (event.type === 'config.update' && event.modelAlias) {
+        return event.modelAlias;
+      }
+    }
+
+    for (const event of events) {
+      if (event.type === 'usage.record' && event.model) {
+        return event.model;
+      }
+    }
+
+    return undefined;
+  }
+
+  private extractTimestamps(events: KimiWireEvent[]): {
+    createdAt: string | undefined;
+    updatedAt: string | undefined;
+  } {
+    let createdAt: string | undefined;
+    let updatedAt: string | undefined;
+
+    for (const event of events) {
+      if (typeof event.time === 'number') {
+        createdAt = new Date(event.time).toISOString();
+        break;
+      }
+      if (typeof event.created_at === 'number') {
+        createdAt = new Date(event.created_at).toISOString();
+        break;
+      }
+    }
+
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (typeof event.time === 'number') {
+        updatedAt = new Date(event.time).toISOString();
+        break;
+      }
+    }
+
+    return { createdAt, updatedAt };
+  }
+
+  private extractMetrics(events: KimiWireEvent[]): NonNullable<ParsedSession['metrics']> {
+    const tools: Record<string, number> = {};
+    const toolStatus: Record<string, { success: number; failure: number }> = {};
+    const fileOperations: Array<{ type: string; path?: string }> = [];
+
+    // First pass: index tool calls by toolCallId so tool results can be matched.
+    const toolCallById = new Map<string, KimiWireEvent & { event: { name: string } }>();
+
+    for (const event of events) {
+      if (
+        event.type === 'context.append_loop_event' &&
+        event.event?.type === 'tool.call' &&
+        typeof event.event.toolCallId === 'string' &&
+        typeof event.event.name === 'string'
+      ) {
+        const toolName = event.event.name;
+        tools[toolName] = (tools[toolName] || 0) + 1;
+
+        if (!toolStatus[toolName]) {
+          toolStatus[toolName] = { success: 0, failure: 0 };
+        }
+
+        toolCallById.set(event.event.toolCallId, event as KimiWireEvent & { event: { name: string } });
+      }
+    }
+
+    // Second pass: match tool results to tool calls and update status.
+    for (const event of events) {
+      if (
+        event.type !== 'context.append_loop_event' ||
+        event.event?.type !== 'tool.result' ||
+        !event.event.result
+      ) {
+        continue;
+      }
+
+      const matchedToolCall =
+        (typeof event.event.toolCallId === 'string' && toolCallById.get(event.event.toolCallId)) ||
+        (typeof event.event.parentUuid === 'string' && toolCallById.get(event.event.parentUuid));
+
+      if (!matchedToolCall) {
+        continue;
+      }
+
+      const toolName = matchedToolCall.event.name;
+      const isError = event.event.result.isError === true;
+
+      if (isError) {
+        toolStatus[toolName].failure++;
+      } else {
+        toolStatus[toolName].success++;
+      }
+    }
+
+    // Third pass: collect file operations from display metadata.
+    for (const event of events) {
+      if (event.type !== 'context.append_loop_event') {
+        continue;
+      }
+
+      const display = event.display;
+      if (!display || display.kind !== 'file_io') {
+        continue;
+      }
+
+      const operation = display.operation;
+      if (operation !== 'read' && operation !== 'write' && operation !== 'edit') {
+        continue;
+      }
+
+      fileOperations.push({
+        type: operation,
+        path: typeof display.path === 'string' ? display.path : undefined,
+      });
+    }
+
+    return { tools, toolStatus, fileOperations };
+  }
+}

--- a/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
+++ b/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
@@ -13,40 +13,7 @@
 import type { SessionProcessor, ProcessingContext, ProcessingResult } from '../../../../core/session/BaseProcessor.js';
 import type { ParsedSession } from '../../../../core/session/BaseSessionAdapter.js';
 import { logger } from '../../../../../utils/logger.js';
-
-interface KimiWireEvent {
-  type: string;
-  event?: {
-    type?: string;
-    uuid?: string;
-    turnId?: string;
-    step?: number;
-    toolCallId?: string;
-    parentUuid?: string;
-    name?: string;
-    args?: Record<string, unknown>;
-    description?: string;
-    result?: {
-      output?: string;
-      isError?: boolean;
-    };
-    usage?: {
-      inputOther?: number;
-      output?: number;
-      inputCacheRead?: number;
-      inputCacheCreation?: number;
-    };
-    finishReason?: string;
-  };
-  display?: {
-    kind?: string;
-    operation?: string;
-    path?: string;
-    content?: string;
-    before?: string;
-    after?: string;
-  };
-}
+import type { KimiWireEvent } from '../types.js';
 
 export class KimiMetricsProcessor implements SessionProcessor {
   readonly name = 'kimi-metrics';
@@ -58,6 +25,8 @@ export class KimiMetricsProcessor implements SessionProcessor {
 
   async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
     try {
+      // Safe cast: shouldProcess has already verified this is a Kimi Code session,
+      // whose messages are parsed from Kimi wire.jsonl events.
       const messages = session.messages as KimiWireEvent[];
       const metrics = this.extractMetrics(messages);
 

--- a/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
+++ b/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
@@ -1,18 +1,52 @@
 /**
  * Kimi Metrics Processor
  *
- * Placeholder processor for Kimi Code session metrics.
+ * Extracts metrics from Kimi Code session wire events.
  *
  * Responsibilities:
  * - Detect Kimi Code sessions
- * - Report how many records were seen for metrics aggregation
- *
- * Full delta generation and JSONL writing will be implemented in a follow-up task.
+ * - Count tool calls and results from `context.append_loop_event` events
+ * - Track file operations from display metadata
+ * - Store aggregated metrics on the parsed session
  */
 
 import type { SessionProcessor, ProcessingContext, ProcessingResult } from '../../../../core/session/BaseProcessor.js';
 import type { ParsedSession } from '../../../../core/session/BaseSessionAdapter.js';
 import { logger } from '../../../../../utils/logger.js';
+
+interface KimiWireEvent {
+  type: string;
+  event?: {
+    type?: string;
+    uuid?: string;
+    turnId?: string;
+    step?: number;
+    toolCallId?: string;
+    parentUuid?: string;
+    name?: string;
+    args?: Record<string, unknown>;
+    description?: string;
+    result?: {
+      output?: string;
+      isError?: boolean;
+    };
+    usage?: {
+      inputOther?: number;
+      output?: number;
+      inputCacheRead?: number;
+      inputCacheCreation?: number;
+    };
+    finishReason?: string;
+  };
+  display?: {
+    kind?: string;
+    operation?: string;
+    path?: string;
+    content?: string;
+    before?: string;
+    after?: string;
+  };
+}
 
 export class KimiMetricsProcessor implements SessionProcessor {
   readonly name = 'kimi-metrics';
@@ -24,14 +58,16 @@ export class KimiMetricsProcessor implements SessionProcessor {
 
   async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
     try {
-      const recordsProcessed = session.messages.length;
+      const messages = session.messages as KimiWireEvent[];
+      const metrics = this.extractMetrics(messages);
 
-      logger.debug(`[${this.name}] Metrics aggregation placeholder for session ${session.sessionId}: ${recordsProcessed} records`);
+      session.metrics = metrics;
+
+      logger.debug(`[${this.name}] Extracted metrics for session ${session.sessionId}: ${messages.length} records`);
 
       return {
         success: true,
-        message: 'Metrics processing placeholder completed',
-        metadata: { recordsProcessed }
+        metadata: { recordsProcessed: messages.length }
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -42,5 +78,89 @@ export class KimiMetricsProcessor implements SessionProcessor {
         message: `Metrics processing failed: ${errorMessage}`
       };
     }
+  }
+
+  private extractMetrics(events: KimiWireEvent[]): NonNullable<ParsedSession['metrics']> {
+    const tools: Record<string, number> = {};
+    const toolStatus: Record<string, { success: number; failure: number }> = {};
+    const fileOperations: Array<{ type: string; path?: string }> = [];
+
+    // First pass: index tool calls by toolCallId so tool results can be matched.
+    const toolCallById = new Map<string, KimiWireEvent & { event: { name: string } }>();
+
+    for (const event of events) {
+      if (
+        event.type === 'context.append_loop_event' &&
+        event.event?.type === 'tool.call' &&
+        typeof event.event.toolCallId === 'string' &&
+        typeof event.event.name === 'string'
+      ) {
+        const toolName = event.event.name;
+        tools[toolName] = (tools[toolName] || 0) + 1;
+
+        if (!toolStatus[toolName]) {
+          toolStatus[toolName] = { success: 0, failure: 0 };
+        }
+
+        const typedEvent = event as KimiWireEvent & { event: { name: string } };
+        toolCallById.set(event.event.toolCallId, typedEvent);
+
+        if (typeof event.event.uuid === 'string') {
+          toolCallById.set(event.event.uuid, typedEvent);
+        }
+      }
+    }
+
+    // Second pass: match tool results to tool calls and update status.
+    for (const event of events) {
+      if (
+        event.type !== 'context.append_loop_event' ||
+        event.event?.type !== 'tool.result' ||
+        !event.event.result
+      ) {
+        continue;
+      }
+
+      const matchedToolCall =
+        (typeof event.event.toolCallId === 'string' && toolCallById.get(event.event.toolCallId)) ||
+        (typeof event.event.parentUuid === 'string' && toolCallById.get(event.event.parentUuid));
+
+      if (!matchedToolCall) {
+        continue;
+      }
+
+      const toolName = matchedToolCall.event.name;
+      const isError = event.event.result.isError === true;
+
+      if (isError) {
+        toolStatus[toolName].failure++;
+      } else {
+        toolStatus[toolName].success++;
+      }
+    }
+
+    // Third pass: collect file operations from display metadata.
+    for (const event of events) {
+      if (event.type !== 'context.append_loop_event') {
+        continue;
+      }
+
+      const display = event.display;
+      if (!display || display.kind !== 'file_io') {
+        continue;
+      }
+
+      const operation = display.operation;
+      if (operation !== 'read' && operation !== 'write' && operation !== 'edit') {
+        continue;
+      }
+
+      fileOperations.push({
+        type: operation,
+        path: typeof display.path === 'string' ? display.path : undefined,
+      });
+    }
+
+    return { tools, toolStatus, fileOperations };
   }
 }

--- a/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
+++ b/src/agents/plugins/kimi/session/processors/kimi.metrics-processor.ts
@@ -1,0 +1,46 @@
+/**
+ * Kimi Metrics Processor
+ *
+ * Placeholder processor for Kimi Code session metrics.
+ *
+ * Responsibilities:
+ * - Detect Kimi Code sessions
+ * - Report how many records were seen for metrics aggregation
+ *
+ * Full delta generation and JSONL writing will be implemented in a follow-up task.
+ */
+
+import type { SessionProcessor, ProcessingContext, ProcessingResult } from '../../../../core/session/BaseProcessor.js';
+import type { ParsedSession } from '../../../../core/session/BaseSessionAdapter.js';
+import { logger } from '../../../../../utils/logger.js';
+
+export class KimiMetricsProcessor implements SessionProcessor {
+  readonly name = 'kimi-metrics';
+  readonly priority = 1;
+
+  shouldProcess(session: ParsedSession): boolean {
+    return session.agentName === 'Kimi Code';
+  }
+
+  async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
+    try {
+      const recordsProcessed = session.messages.length;
+
+      logger.debug(`[${this.name}] Metrics aggregation placeholder for session ${session.sessionId}: ${recordsProcessed} records`);
+
+      return {
+        success: true,
+        message: 'Metrics processing placeholder completed',
+        metadata: { recordsProcessed }
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`[${this.name}] Processing failed:`, error);
+
+      return {
+        success: false,
+        message: `Metrics processing failed: ${errorMessage}`
+      };
+    }
+  }
+}

--- a/src/agents/plugins/kimi/session/types.ts
+++ b/src/agents/plugins/kimi/session/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared types for Kimi Code `wire.jsonl` session events.
+ */
+
+export interface KimiUsage {
+  inputOther?: number;
+  output?: number;
+  inputCacheRead?: number;
+  inputCacheCreation?: number;
+}
+
+export type KimiDisplayOperation = 'read' | 'write' | 'edit';
+
+export interface KimiWireEventDisplay {
+  kind?: string;
+  operation?: KimiDisplayOperation;
+  path?: string;
+  content?: string;
+  before?: string;
+  after?: string;
+}
+
+export interface KimiLoopEvent {
+  type?: string;
+  uuid?: string;
+  turnId?: string;
+  step?: number;
+  toolCallId?: string;
+  parentUuid?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+  description?: string;
+  result?: {
+    output?: string;
+    isError?: boolean;
+  };
+  usage?: KimiUsage;
+  finishReason?: string;
+}
+
+export interface KimiWireEvent {
+  type: string;
+  time?: number;
+  // metadata
+  protocol_version?: string;
+  created_at?: number;
+  app_version?: string;
+  // config.update
+  profileName?: string;
+  systemPrompt?: string;
+  modelAlias?: string;
+  thinkingLevel?: string;
+  // usage.record
+  model?: string;
+  usage?: KimiUsage;
+  usageScope?: string;
+  // context.append_loop_event
+  event?: KimiLoopEvent;
+  display?: KimiWireEventDisplay;
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -4,6 +4,8 @@ import { CodeMieCodePlugin } from './plugins/codemie-code.plugin.js';
 import { GeminiPlugin } from './plugins/gemini/gemini.plugin.js';
 import { OpenCodePlugin } from './plugins/opencode/index.js';
 import { CodexPlugin } from './plugins/codex/index.js';
+import { KimiPlugin } from './plugins/kimi/kimi.plugin.js';
+import { KimiAcpPlugin } from './plugins/kimi/kimi-acp.plugin.js';
 import { AgentAdapter, AgentAnalyticsAdapter } from './core/types.js';
 
 // Re-export for backwards compatibility
@@ -33,6 +35,8 @@ export class AgentRegistry {
     AgentRegistry.registerPlugin(new GeminiPlugin());
     AgentRegistry.registerPlugin(new OpenCodePlugin());
     AgentRegistry.registerPlugin(new CodexPlugin());
+    AgentRegistry.registerPlugin(new KimiPlugin());
+    AgentRegistry.registerPlugin(new KimiAcpPlugin());
 
     AgentRegistry.initialized = true;
   }

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -1273,18 +1273,22 @@ export function createHookCommand(): Command {
           process.exit(2); // Blocking error
         }
 
-        if (!event.transcript_path) {
-          logger.error('[hook] Missing required field: transcript_path');
-          logger.debug(`[hook] Received event: ${JSON.stringify(event)}`);
-          process.exit(2); // Blocking error
-        }
-
         // Initialize logger context using CODEMIE_SESSION_ID from environment
         // This ensures consistent session ID across all hooks
         const { sessionId, agentName } = initializeHookContext();
 
-        // Apply hook transformation if agent provides a transformer
+        // Apply hook transformation if agent provides a transformer.
+        // Some agents (e.g. Kimi) do not emit a transcript_path in their raw
+        // hook payload; the transformer computes it from agent-specific session
+        // layout before we validate the internal event shape.
         const transformedEvent = applyHookTransformation(event, agentName);
+
+        // Validate required fields after transformation so agent-specific
+        // transformers can populate fields such as transcript_path.
+        validateHookEvent(transformedEvent);
+        if (process.exitCode === 2) {
+          return; // Validation failed
+        }
 
         // Normalize event name and log processing info
         normalizeAndLogEvent(transformedEvent, sessionId, agentName);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -37,6 +37,7 @@ import './plugins/jwt/index.js';
 import './plugins/litellm/index.js';
 import './plugins/bedrock/index.js';
 import './plugins/anthropic-subscription/index.js';
+import './plugins/moonshot-subscription/index.js';
 
 // Re-export plugin modules for direct access if needed
 export * as Ollama from './plugins/ollama/index.js';
@@ -45,3 +46,4 @@ export * as JWT from './plugins/jwt/index.js';
 export * as LiteLLM from './plugins/litellm/index.js';
 export * as Bedrock from './plugins/bedrock/index.js';
 export * as AnthropicSubscription from './plugins/anthropic-subscription/index.js';
+export * as MoonshotSubscription from './plugins/moonshot-subscription/index.js';

--- a/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.setup-steps.test.ts
+++ b/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.setup-steps.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MoonshotSubscriptionSetupSteps } from '../moonshot-subscription.setup-steps.js';
+import { MoonshotSubscriptionTemplate } from '../moonshot-subscription.template.js';
+import { ConfigurationError } from '../../../../utils/errors.js';
+
+const { mockCommandExists, mockPrompt, mockAuthenticateWithCodeMie, mockSelectCodeMieProject, mockPromptForCodeMieUrl } = vi.hoisted(() => ({
+  mockCommandExists: vi.fn(),
+  mockPrompt: vi.fn(),
+  mockAuthenticateWithCodeMie: vi.fn(),
+  mockSelectCodeMieProject: vi.fn(),
+  mockPromptForCodeMieUrl: vi.fn(),
+}));
+
+vi.mock('inquirer', () => ({
+  default: { prompt: mockPrompt },
+}));
+
+vi.mock('../../../../utils/processes.js', () => ({
+  commandExists: mockCommandExists,
+}));
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../core/registry.js', () => ({
+  ProviderRegistry: { registerSetupSteps: vi.fn() },
+}));
+
+vi.mock('@/providers/core/codemie-auth-helpers.js', () => ({
+  DEFAULT_CODEMIE_BASE_URL: 'https://codemie.example.com',
+  authenticateWithCodeMie: mockAuthenticateWithCodeMie,
+  promptForCodeMieUrl: mockPromptForCodeMieUrl,
+  selectCodeMieProject: mockSelectCodeMieProject,
+}));
+
+describe('MoonshotSubscriptionSetupSteps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCommandExists.mockResolvedValue(true);
+  });
+
+  describe('getCredentials', () => {
+    it('throws ConfigurationError when kimi is not on PATH', async () => {
+      mockCommandExists.mockResolvedValue(false);
+
+      await expect(MoonshotSubscriptionSetupSteps.getCredentials(false)).rejects.toThrow(ConfigurationError);
+      await expect(MoonshotSubscriptionSetupSteps.getCredentials(false)).rejects.toThrow(
+        'Kimi Code CLI (kimi) was not found on PATH'
+      );
+    });
+
+    it('returns credentials with empty apiKey and manual authMethod when analytics is disabled', async () => {
+      mockPrompt.mockResolvedValue({ enableCodeMieAnalytics: false });
+
+      const credentials = await MoonshotSubscriptionSetupSteps.getCredentials(false);
+
+      expect(credentials.baseUrl).toBe(MoonshotSubscriptionTemplate.defaultBaseUrl);
+      expect(credentials.apiKey).toBe('');
+      expect(credentials.additionalConfig).toEqual({
+        authMethod: 'manual',
+        codeMieUrl: undefined,
+        codeMieProject: undefined,
+        userEmail: undefined,
+      });
+    });
+
+    it('authenticates and selects project when analytics is enabled', async () => {
+      mockPrompt.mockResolvedValue({ enableCodeMieAnalytics: true });
+      mockPromptForCodeMieUrl.mockResolvedValue('https://codemie.lab.epam.com');
+      mockAuthenticateWithCodeMie.mockResolvedValue({
+        success: true,
+        apiUrl: 'https://codemie.lab.epam.com/code-assistant-api',
+        cookies: { session: 'abc' },
+      });
+      mockSelectCodeMieProject.mockResolvedValue({ project: 'my-project', userEmail: 'user@example.com' });
+
+      const credentials = await MoonshotSubscriptionSetupSteps.getCredentials(false);
+
+      expect(mockPromptForCodeMieUrl).toHaveBeenCalledWith(
+        'https://codemie.example.com',
+        'CodeMie platform URL for analytics sync:'
+      );
+      expect(mockAuthenticateWithCodeMie).toHaveBeenCalledWith('https://codemie.lab.epam.com', 120000);
+      expect(mockSelectCodeMieProject).toHaveBeenCalled();
+      expect(credentials.additionalConfig).toEqual({
+        authMethod: 'manual',
+        codeMieUrl: 'https://codemie.lab.epam.com',
+        codeMieProject: 'my-project',
+        userEmail: 'user@example.com',
+      });
+    });
+  });
+
+  describe('fetchModels', () => {
+    it('returns the template recommended models list', async () => {
+      const models = await MoonshotSubscriptionSetupSteps.fetchModels({});
+
+      expect(models).toEqual(MoonshotSubscriptionTemplate.recommendedModels);
+    });
+  });
+
+  describe('selectModel', () => {
+    it('returns the first model when codeMieUrl is present', async () => {
+      const selectedModel = await MoonshotSubscriptionSetupSteps.selectModel?.(
+        { additionalConfig: { codeMieUrl: 'https://codemie.lab.epam.com' } },
+        ['kimi-for-coding', 'kimi-k2']
+      );
+
+      expect(selectedModel).toBe('kimi-for-coding');
+    });
+
+    it('returns null when codeMieUrl is not present', async () => {
+      const selectedModel = await MoonshotSubscriptionSetupSteps.selectModel?.(
+        { additionalConfig: {} },
+        ['kimi-for-coding', 'kimi-k2']
+      );
+
+      expect(selectedModel).toBeNull();
+    });
+
+    it('falls back to template recommended model when models list is empty and codeMieUrl is set', async () => {
+      const selectedModel = await MoonshotSubscriptionSetupSteps.selectModel?.(
+        { additionalConfig: { codeMieUrl: 'https://codemie.lab.epam.com' } },
+        []
+      );
+
+      expect(selectedModel).toBe(MoonshotSubscriptionTemplate.recommendedModels[0]);
+    });
+  });
+
+  describe('buildConfig', () => {
+    it('returns expected CodeMieConfigOptions shape', () => {
+      const config = MoonshotSubscriptionSetupSteps.buildConfig(
+        {
+          baseUrl: MoonshotSubscriptionTemplate.defaultBaseUrl,
+          apiKey: '',
+          additionalConfig: {
+            authMethod: 'manual',
+            codeMieUrl: 'https://codemie.lab.epam.com',
+            codeMieProject: 'my-project',
+          },
+        },
+        'kimi-for-coding'
+      );
+
+      expect(config.provider).toBe('moonshot-subscription');
+      expect(config.baseUrl).toBe(MoonshotSubscriptionTemplate.defaultBaseUrl);
+      expect(config.apiKey).toBe('');
+      expect(config.model).toBe('kimi-for-coding');
+      expect(config.authMethod).toBe('manual');
+      expect(config.codeMieUrl).toBe('https://codemie.lab.epam.com');
+      expect(config.codeMieProject).toBe('my-project');
+    });
+
+    it('falls back to template defaultBaseUrl when credentials have no baseUrl', () => {
+      const config = MoonshotSubscriptionSetupSteps.buildConfig(
+        { additionalConfig: { authMethod: 'manual' } },
+        'kimi-k2'
+      );
+
+      expect(config.baseUrl).toBe(MoonshotSubscriptionTemplate.defaultBaseUrl);
+    });
+
+    it('omits codeMieUrl and codeMieProject when analytics is not enabled', () => {
+      const config = MoonshotSubscriptionSetupSteps.buildConfig(
+        {
+          baseUrl: MoonshotSubscriptionTemplate.defaultBaseUrl,
+          apiKey: '',
+          additionalConfig: { authMethod: 'manual' },
+        },
+        'kimi-for-coding'
+      );
+
+      expect(config.codeMieUrl).toBeUndefined();
+      expect(config.codeMieProject).toBeUndefined();
+    });
+  });
+});

--- a/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.setup-steps.test.ts
+++ b/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.setup-steps.test.ts
@@ -23,11 +23,14 @@ vi.mock('../../../../utils/logger.js', () => ({
   logger: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('../../core/registry.js', () => ({
-  ProviderRegistry: { registerSetupSteps: vi.fn() },
+vi.mock('../../../core/registry.js', () => ({
+  ProviderRegistry: {
+    registerProvider: vi.fn((template) => template),
+    registerSetupSteps: vi.fn(),
+  },
 }));
 
-vi.mock('@/providers/core/codemie-auth-helpers.js', () => ({
+vi.mock('../../../core/codemie-auth-helpers.js', () => ({
   DEFAULT_CODEMIE_BASE_URL: 'https://codemie.example.com',
   authenticateWithCodeMie: mockAuthenticateWithCodeMie,
   promptForCodeMieUrl: mockPromptForCodeMieUrl,

--- a/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.template.test.ts
+++ b/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.template.test.ts
@@ -1,7 +1,33 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MoonshotSubscriptionTemplate } from '../moonshot-subscription.template.js';
+import { KimiHookConfigInjector } from '../../../../agents/plugins/kimi/kimi.hook-config-injector.js';
+
+const mockKimiHookConfigInjector = vi.mocked(KimiHookConfigInjector);
+
+const { mockGetAgent, mockInject } = vi.hoisted(() => ({
+  mockGetAgent: vi.fn(),
+  mockInject: vi.fn(),
+}));
+
+vi.mock('../../../../agents/registry.js', () => ({
+  AgentRegistry: { getAgent: mockGetAgent },
+}));
+
+vi.mock('../../../../agents/plugins/kimi/kimi.hook-config-injector.js', () => ({
+  KimiHookConfigInjector: vi.fn(function () {
+    return { inject: mockInject };
+  }),
+}));
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
 
 describe('MoonshotSubscriptionTemplate', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should require no authentication', () => {
     expect(MoonshotSubscriptionTemplate.requiresAuth).toBe(false);
     expect(MoonshotSubscriptionTemplate.authType).toBe('none');
@@ -25,5 +51,90 @@ describe('MoonshotSubscriptionTemplate', () => {
 
   it('should recommend at least one model', () => {
     expect(MoonshotSubscriptionTemplate.recommendedModels.length).toBeGreaterThan(0);
+  });
+
+  describe('agentHooks - beforeRun (*)', () => {
+    beforeEach(() => {
+      mockInject.mockResolvedValue({ success: true, created: true, configPath: '/mock/.kimi-code/config.toml' });
+      mockKimiHookConfigInjector.mockImplementation(function () {
+        return { inject: mockInject };
+      });
+      mockGetAgent.mockReturnValue({ name: 'kimi' });
+    });
+
+    it('strips Kimi model env vars and does not mutate the original env when agent is kimi', async () => {
+      const env: Record<string, string> = {
+        KIMI_MODEL_API_KEY: 'some-key',
+        KIMI_MODEL_BASE_URL: 'http://localhost:1234',
+        KIMI_MODEL_NAME: 'kimi-for-coding',
+        OTHER_VAR: 'keep-me',
+      };
+
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      const result = await hook!.beforeRun!(env, { agent: 'kimi' });
+
+      expect(result.KIMI_MODEL_API_KEY).toBeUndefined();
+      expect(result.KIMI_MODEL_BASE_URL).toBeUndefined();
+      expect(result.KIMI_MODEL_NAME).toBeUndefined();
+      expect(result.OTHER_VAR).toBe('keep-me');
+
+      // Must not mutate the caller's object
+      expect(env.KIMI_MODEL_API_KEY).toBe('some-key');
+      expect(env.KIMI_MODEL_BASE_URL).toBe('http://localhost:1234');
+      expect(env.KIMI_MODEL_NAME).toBe('kimi-for-coding');
+    });
+
+    it('returns env unchanged for non-kimi agents', async () => {
+      const env: Record<string, string> = {
+        KIMI_MODEL_API_KEY: 'some-key',
+        OTHER_VAR: 'keep-me',
+      };
+
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      const result = await hook!.beforeRun!(env, { agent: 'claude' });
+
+      expect(result).toBe(env); // exact same reference — no copy created
+      expect(result.KIMI_MODEL_API_KEY).toBe('some-key');
+    });
+
+    it('injects Kimi hooks when agent is kimi', async () => {
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      await hook!.beforeRun!({}, { agent: 'kimi' });
+
+      expect(mockKimiHookConfigInjector).toHaveBeenCalledTimes(1);
+      expect(mockInject).toHaveBeenCalledTimes(1);
+    });
+
+    it('strips vars and continues when agent is not in the registry', async () => {
+      mockGetAgent.mockReturnValue(undefined);
+
+      const env: Record<string, string> = { KIMI_MODEL_API_KEY: 'key' };
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      const result = await hook!.beforeRun!(env, { agent: 'kimi' });
+
+      expect(result.KIMI_MODEL_API_KEY).toBeUndefined();
+      expect(mockKimiHookConfigInjector).not.toHaveBeenCalled();
+    });
+
+    it('strips vars and continues when hook injection reports failure', async () => {
+      mockInject.mockResolvedValue({ success: false, created: false, configPath: '/mock/.kimi-code/config.toml', error: 'disk full' });
+
+      const env: Record<string, string> = { KIMI_MODEL_API_KEY: 'key' };
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      const result = await hook!.beforeRun!(env, { agent: 'kimi' });
+
+      expect(result.KIMI_MODEL_API_KEY).toBeUndefined();
+      expect(mockInject).toHaveBeenCalledTimes(1);
+    });
+
+    it('strips vars and does not throw when injector throws', async () => {
+      mockInject.mockRejectedValue(new Error('ENOENT'));
+
+      const env: Record<string, string> = { KIMI_MODEL_API_KEY: 'key' };
+      const hook = MoonshotSubscriptionTemplate.agentHooks?.['*'];
+      const result = await hook!.beforeRun!(env, { agent: 'kimi' });
+
+      expect(result.KIMI_MODEL_API_KEY).toBeUndefined();
+    });
   });
 });

--- a/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.template.test.ts
+++ b/src/providers/plugins/moonshot-subscription/__tests__/moonshot-subscription.template.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { MoonshotSubscriptionTemplate } from '../moonshot-subscription.template.js';
+
+describe('MoonshotSubscriptionTemplate', () => {
+  it('should require no authentication', () => {
+    expect(MoonshotSubscriptionTemplate.requiresAuth).toBe(false);
+    expect(MoonshotSubscriptionTemplate.authType).toBe('none');
+  });
+
+  it('should export CodeMie env vars with empty API key and optional analytics values', () => {
+    const codeMieUrl = 'https://codemie.example.com';
+    const codeMieProject = 'my-project';
+
+    const env = MoonshotSubscriptionTemplate.exportEnvVars!({
+      provider: 'moonshot-subscription',
+      codeMieUrl,
+      codeMieProject
+    });
+
+    expect(env.CODEMIE_API_KEY).toBe('');
+    expect(env.CODEMIE_URL).toBe(codeMieUrl);
+    expect(env.CODEMIE_SYNC_API_URL).toBe(`${codeMieUrl}/code-assistant-api`);
+    expect(env.CODEMIE_PROJECT).toBe(codeMieProject);
+  });
+
+  it('should recommend at least one model', () => {
+    expect(MoonshotSubscriptionTemplate.recommendedModels.length).toBeGreaterThan(0);
+  });
+});

--- a/src/providers/plugins/moonshot-subscription/index.ts
+++ b/src/providers/plugins/moonshot-subscription/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Moonshot Subscription Provider - Complete Provider Implementation
+ *
+ * Native Kimi Code authentication via an existing Moonshot subscription.
+ * Auto-registers with ProviderRegistry on import.
+ */
+
+export { MoonshotSubscriptionTemplate } from './moonshot-subscription.template.js';
+export { MoonshotSubscriptionSetupSteps } from './moonshot-subscription.setup-steps.js';

--- a/src/providers/plugins/moonshot-subscription/moonshot-subscription.setup-steps.ts
+++ b/src/providers/plugins/moonshot-subscription/moonshot-subscription.setup-steps.ts
@@ -1,0 +1,114 @@
+/**
+ * Moonshot Subscription Setup Steps
+ *
+ * Interactive setup flow for native Kimi Code authentication.
+ */
+
+import inquirer from 'inquirer';
+import type { ProviderCredentials, ProviderSetupSteps } from '../../core/types.js';
+import { ProviderRegistry } from '../../core/registry.js';
+import type { CodeMieConfigOptions } from '../../../env/types.js';
+import { logger } from '../../../utils/logger.js';
+import { ConfigurationError } from '../../../utils/errors.js';
+import { MoonshotSubscriptionTemplate } from './moonshot-subscription.template.js';
+import {
+  DEFAULT_CODEMIE_BASE_URL,
+  authenticateWithCodeMie,
+  promptForCodeMieUrl,
+  selectCodeMieProject
+} from '../../core/codemie-auth-helpers.js';
+import { commandExists } from '../../../utils/processes.js';
+
+export const MoonshotSubscriptionSetupSteps: ProviderSetupSteps = {
+  name: 'moonshot-subscription',
+
+  async getCredentials(_isUpdate = false): Promise<ProviderCredentials> {
+    logger.info('Moonshot Subscription Setup');
+    logger.info('This provider uses Kimi Code native browser authentication.');
+    logger.info('CodeMie will not store a Moonshot API key for this profile.');
+
+    const kimiInstalled = await commandExists('kimi');
+    if (!kimiInstalled) {
+      throw new ConfigurationError(
+        'Kimi Code CLI (kimi) was not found on PATH. Install Kimi Code and authenticate before running this setup.'
+      );
+    }
+
+    logger.success('Kimi Code CLI detected');
+
+    const answers = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'enableCodeMieAnalytics',
+        message: 'Login to CodeMie platform to enable analytics sync?',
+        default: false
+      }
+    ]);
+
+    let codeMieUrl: string | undefined;
+    let codeMieProject: string | undefined;
+    let userEmail: string | undefined;
+
+    if (answers.enableCodeMieAnalytics) {
+      codeMieUrl = await promptForCodeMieUrl(
+        DEFAULT_CODEMIE_BASE_URL,
+        'CodeMie platform URL for analytics sync:'
+      );
+
+      logger.info('Authenticating to CodeMie platform...');
+      const authResult = await authenticateWithCodeMie(codeMieUrl, 120000);
+
+      if (!authResult.success) {
+        throw new ConfigurationError(`CodeMie authentication failed: ${authResult.error || 'Unknown error'}`);
+      }
+
+      logger.success('CodeMie authentication successful');
+      logger.info('Fetching available projects...');
+      ({ project: codeMieProject, userEmail } = await selectCodeMieProject(authResult));
+      logger.success('Analytics sync enabled for CodeMie platform');
+    }
+
+    return {
+      baseUrl: MoonshotSubscriptionTemplate.defaultBaseUrl,
+      apiKey: '',
+      additionalConfig: {
+        authMethod: 'manual',
+        codeMieUrl,
+        codeMieProject,
+        userEmail
+      }
+    };
+  },
+
+  async fetchModels(_credentials: ProviderCredentials): Promise<string[]> {
+    return [...MoonshotSubscriptionTemplate.recommendedModels];
+  },
+
+  async selectModel(
+    credentials: ProviderCredentials,
+    models: string[]
+  ): Promise<string | null> {
+    if (credentials.additionalConfig?.codeMieUrl) {
+      return models[0] || MoonshotSubscriptionTemplate.recommendedModels[0] || null;
+    }
+
+    return null;
+  },
+
+  buildConfig(
+    credentials: ProviderCredentials,
+    selectedModel: string
+  ): Partial<CodeMieConfigOptions> {
+    return {
+      provider: 'moonshot-subscription',
+      baseUrl: credentials.baseUrl || MoonshotSubscriptionTemplate.defaultBaseUrl,
+      apiKey: '',
+      model: selectedModel,
+      authMethod: 'manual',
+      codeMieUrl: credentials.additionalConfig?.codeMieUrl as string | undefined,
+      codeMieProject: credentials.additionalConfig?.codeMieProject as string | undefined,
+    };
+  }
+};
+
+ProviderRegistry.registerSetupSteps('moonshot-subscription', MoonshotSubscriptionSetupSteps);

--- a/src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts
+++ b/src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts
@@ -58,8 +58,8 @@ export const MoonshotSubscriptionTemplate = registerProvider<ProviderTemplate>({
           const agent = AgentRegistry.getAgent('kimi');
           if (!agent) {
             const { logger } = await import('../../../utils/logger.js');
-            logger.warn('[kimi] Kimi agent not found in registry; skipping hook injection');
-            logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+            logger.warn('[moonshot-subscription] Kimi agent not found in registry; skipping hook injection');
+            logger.warn('[moonshot-subscription] Continuing without hooks - metrics may not be captured');
             return updated;
           }
 
@@ -68,14 +68,14 @@ export const MoonshotSubscriptionTemplate = registerProvider<ProviderTemplate>({
 
           if (!result.success) {
             const { logger } = await import('../../../utils/logger.js');
-            logger.warn(`[kimi] Hook injection returned failure: ${result.error || 'unknown error'}`);
-            logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+            logger.warn(`[moonshot-subscription] Hook injection returned failure: ${result.error || 'unknown error'}`);
+            logger.warn('[moonshot-subscription] Continuing without hooks - metrics may not be captured');
           }
         } catch (error) {
           const { logger } = await import('../../../utils/logger.js');
           const errorMsg = error instanceof Error ? error.message : String(error);
-          logger.error(`[kimi] Hook injection threw exception: ${errorMsg}`);
-          logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+          logger.error(`[moonshot-subscription] Hook injection threw exception: ${errorMsg}`);
+          logger.warn('[moonshot-subscription] Continuing without hooks - metrics may not be captured');
         }
 
         return updated;

--- a/src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts
+++ b/src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts
@@ -1,0 +1,126 @@
+/**
+ * Moonshot Subscription Provider Template
+ *
+ * Template definition for native Kimi Code authentication using
+ * an existing Moonshot subscription login.
+ *
+ * Auto-registers on import via registerProvider().
+ */
+
+import type { ProviderTemplate } from '../../core/types.js';
+import type { AgentConfig } from '../../../agents/core/types.js';
+import { registerProvider } from '../../core/decorators.js';
+import { ensureApiBase } from '../../core/codemie-auth-helpers.js';
+
+export const MoonshotSubscriptionTemplate = registerProvider<ProviderTemplate>({
+  name: 'moonshot-subscription',
+  displayName: 'Moonshot Subscription',
+  description: 'Native Kimi Code CLI authentication using your Moonshot subscription',
+  defaultBaseUrl: 'https://api.moonshot.ai/v1',
+  requiresAuth: false,
+  authType: 'none',
+  priority: 16,
+  defaultProfileName: 'moonshot-subscription',
+  recommendedModels: ['kimi-for-coding', 'kimi-k2'],
+  capabilities: ['streaming', 'tools', 'function-calling', 'vision'],
+  supportsModelInstallation: false,
+  supportsStreaming: true,
+
+  agentHooks: {
+    '*': {
+      async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig): Promise<NodeJS.ProcessEnv> {
+        if (config.agent !== 'kimi') {
+          return env;
+        }
+
+        // Return a copy so callers that hold a reference to the original env are not affected.
+        const updated = { ...env };
+
+        // Native Kimi subscription auth relies on Kimi Code's stored login in
+        // ~/.kimi-code/config.toml. Explicit Moonshot API/proxy env vars override
+        // that flow and can cause 401s.
+        delete updated.KIMI_MODEL_API_KEY;
+        delete updated.KIMI_MODEL_BASE_URL;
+        delete updated.KIMI_MODEL_NAME;
+
+        // Inject CodeMie lifecycle hooks into Kimi config so local metrics and
+        // conversation files are produced even though model traffic is not
+        // proxied through CodeMie.
+        //
+        // Dynamic import avoids a circular dependency: AgentRegistry imports all
+        // plugins (including this provider template) as side effects, so a
+        // static top-level import here would form a cycle. The dynamic import
+        // defers resolution until runtime when the registry is fully initialised.
+        try {
+          const { AgentRegistry } = await import('../../../agents/registry.js');
+          const { KimiHookConfigInjector } = await import('../../../agents/plugins/kimi/kimi.hook-config-injector.js');
+
+          const agent = AgentRegistry.getAgent('kimi');
+          if (!agent) {
+            const { logger } = await import('../../../utils/logger.js');
+            logger.warn('[kimi] Kimi agent not found in registry; skipping hook injection');
+            logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+            return updated;
+          }
+
+          const injector = new KimiHookConfigInjector();
+          const result = await injector.inject();
+
+          if (!result.success) {
+            const { logger } = await import('../../../utils/logger.js');
+            logger.warn(`[kimi] Hook injection returned failure: ${result.error || 'unknown error'}`);
+            logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+          }
+        } catch (error) {
+          const { logger } = await import('../../../utils/logger.js');
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          logger.error(`[kimi] Hook injection threw exception: ${errorMsg}`);
+          logger.warn('[kimi] Continuing without hooks - metrics may not be captured');
+        }
+
+        return updated;
+      }
+    }
+  },
+
+  // Kimi Code should use its own stored login/session instead of a placeholder token.
+  exportEnvVars: (config) => {
+    const env: Record<string, string> = {
+      CODEMIE_API_KEY: ''
+    };
+
+    if (config.codeMieUrl) {
+      env.CODEMIE_URL = config.codeMieUrl;
+      env.CODEMIE_SYNC_API_URL = ensureApiBase(config.codeMieUrl);
+    }
+
+    if (config.codeMieProject) {
+      env.CODEMIE_PROJECT = config.codeMieProject;
+    }
+
+    return env;
+  },
+
+  setupInstructions: `
+# Moonshot Subscription Setup Instructions
+
+Use this option when Kimi Code is already authenticated with your Moonshot account
+and you want CodeMie to use that native login flow directly.
+
+## Prerequisites
+
+1. Install Kimi Code
+2. Authenticate Kimi Code with your Moonshot subscription
+
+\`\`\`bash
+kimi auth login
+\`\`\`
+
+## Notes
+
+- No API key is stored in CodeMie for this provider
+- Kimi Code uses its existing local authentication/session from \`~/.kimi-code/config.toml\`
+- CodeMie injects lifecycle hooks into Kimi config to capture metrics locally
+- This provider is intended for native \`kimi\` usage
+`
+});


### PR DESCRIPTION
## Summary

Introduces full Kimi agent integration into the CodeMie platform: a plugin-based agent (`KimiPlugin`) and an ACP-SSO variant (`KimiAcpPlugin`), along with the supporting infrastructure — path helpers, hook config injector, hook payload transformer, session adapter, metrics processor, and extension installer. Adds a `moonshot-subscription` provider and wires everything into the CLI registry.

## Changes

- **KimiPlugin / KimiAcpPlugin** — core agent plugins supporting model flag mapping, Node version guard, and ACP SSO distinction; wired into `AgentCLI` and `package.json`
- **Path helpers** — `getKimiDataDir()` and related utilities for resolving Kimi data directories
- **Hook config injector** — idempotent writer for `~/.kimi-code/config.toml` hook entries
- **Hook payload transformer** — translates CodeMie hook events into Kimi-compatible payloads
- **Session adapter & metrics processor** — adapts Kimi sessions and extracts metrics from `wire.jsonl`; shared `KimiWireEvent` type
- **Extension installer** — idempotent installer for Kimi skills with full test coverage
- **`processSession` and `validate` hooks** — implemented post-transformation with automated verification script
- **`moonshot-subscription` provider** — setup steps, template, and tests for the Moonshot subscription flow
- **`hookConfig` in `AgentMetadata`** — extended agent metadata type to carry hook configuration

## Impact

Kimi becomes a first-class agent in the registry alongside Claude and other providers. `codemie use kimi` and `codemie use kimi-acp` are now fully operational. No breaking changes to existing agents.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)