### PR TITLE
fix(analytics): include sub-agent transcripts in token usage extraction

### DIFF
--- a/src/cli/commands/analytics/cost/__tests__/cost-enricher.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/cost-enricher.test.ts
@@ -166,6 +166,58 @@ describe('enrichCosts', () => {
     const { index } = await enrichCosts(raw, baseDeps); // baseDeps = exactly one usage message
     expect(index.get('s1')!.costSeries).toBeUndefined();
   });
+
+  it('folds sub-agent usage into the session total; series endpoint equals it', async () => {
+    const deps: EnricherDeps = {
+      ...baseDeps,
+      parseNative: async () =>
+        ({
+          sessionId: 's1', agentName: 'claude', metadata: {},
+          messages: [
+            { timestamp: '2026-06-08T10:00:00Z', requestId: 'r1', message: { id: 'm1', model: 'claude-sonnet-4-5', usage: { input_tokens: 1_000_000, output_tokens: 0 } } },
+            { timestamp: '2026-06-08T10:06:00Z', requestId: 'r2', message: { id: 'm2', model: 'claude-sonnet-4-5', usage: { input_tokens: 500_000, output_tokens: 0 } } },
+          ],
+          subagents: [{
+            agentId: 'a1', filePath: '/fake/s1/subagents/agent-a1.jsonl',
+            messages: [
+              { timestamp: '2026-06-08T10:03:00Z', requestId: 'r3', message: { id: 'sub1', model: 'claude-sonnet-4-5', usage: { input_tokens: 2_000_000, output_tokens: 0 } } },
+            ],
+          }],
+        }) as never,
+    };
+    const { index } = await enrichCosts(raw, deps);
+    const c = index.get('s1')!;
+    expect(c.tokens.input).toBe(3_500_000); // 1.5M main + 2M sub-agent
+    expect(c.costUSD).toBeCloseTo(10.5, 6); // 3.5M input @ $3/1M sonnet-4-5
+    const series = c.costSeries!;
+    expect(series[series.length - 1].cost).toBeCloseTo(c.costUSD, 6); // endpoint invariant
+    expect(series[series.length - 1].tokens).toBe(c.tokens.total);
+    const axis = series.map((p) => p.t);
+    expect([...axis].sort((a, b) => a - b)).toEqual(axis); // sub-agent record interleaved in time order
+  });
+
+  it('sub-agent records join the cross-session dedup (replayed response counted once)', async () => {
+    const shared = { timestamp: '2026-06-08T10:00:00Z', requestId: 'req-1', message: { id: 'msg-1', model: 'claude-sonnet-4-5', usage: { input_tokens: 1_000_000, output_tokens: 0 } } };
+    const raws = [
+      { sessionId: 'A', startEvent: { agentName: 'claude', data: { startTime: 1000 } }, deltas: [] },
+      { sessionId: 'B', startEvent: { agentName: 'claude', data: { startTime: 2000 } }, deltas: [] },
+    ] as never[];
+    const deps: EnricherDeps = {
+      resolveAgentName: () => 'claude',
+      loadAgentSessionFile: async () => '/fake/log.jsonl',
+      parseNative: async (_agent, _file, sid) =>
+        sid === 'A'
+          ? ({
+              sessionId: 'A', agentName: 'claude', metadata: {}, messages: [],
+              subagents: [{ agentId: 'a1', filePath: '/fake/agent-a1.jsonl', messages: [shared] }],
+            } as never)
+          : ({ sessionId: 'B', agentName: 'claude', metadata: {}, messages: [shared] } as never),
+    };
+    const { index, summary } = await enrichCosts(raws, deps);
+    expect(index.get('A')!.costUSD).toBeCloseTo(3, 6); // earliest session owns it — via its sub-agent
+    expect(index.get('B')!.costUSD).toBe(0); // replay deduped
+    expect(summary.totalCostUSD).toBeCloseTo(3, 6);
+  });
 });
 
 describe('buildCostSeries', () => {

--- a/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
@@ -158,3 +158,64 @@ describe('gatherDedupedUsageRecords + sumUsageRecords', () => {
     expect(map.get('claude-sonnet-4-6')!.input).toBe(30);
   });
 });
+
+describe('extractClaudeUsageRecords — sub-agent transcripts', () => {
+  const msg = (id: string, model: string, input: number, ts?: string) => ({
+    ...(ts && { timestamp: ts }),
+    requestId: 'r-' + id,
+    message: { id, model, usage: { input_tokens: input, output_tokens: 0 } },
+  });
+  function parsed(
+    messages: unknown[],
+    subagents?: Array<{ agentId: string; filePath: string; messages: unknown[] }>
+  ): never {
+    return { sessionId: 's', agentName: 'claude', metadata: {}, messages, ...(subagents && { subagents }), metrics: {} } as never;
+  }
+
+  it('merges records from the main transcript and every sub-agent transcript', () => {
+    const p = parsed(
+      [msg('m1', 'claude-sonnet-4-6', 100)],
+      [
+        { agentId: 'a1', filePath: '/fake/s/subagents/agent-a1.jsonl', messages: [msg('s1', 'claude-sonnet-4-6', 200)] },
+        { agentId: 'a2', filePath: '/fake/s/subagents/agent-a2.jsonl', messages: [msg('s2', 'claude-sonnet-4-6', 300)] },
+      ]
+    );
+    const recs = extractClaudeUsageRecords(p);
+    expect(recs).toHaveLength(3);
+    expect(recs.reduce((n, r) => n + r.usage.input, 0)).toBe(600);
+  });
+
+  it('splits per-model totals when a sub-agent uses a different model', () => {
+    const p = parsed(
+      [msg('m1', 'claude-sonnet-4-6', 100)],
+      [{ agentId: 'a1', filePath: '/fake/agent-a1.jsonl', messages: [msg('s1', 'claude-haiku-4-5', 50)] }]
+    );
+    const map = readUsageByModel('claude', p);
+    expect(map.get('claude-sonnet-4-6')!.input).toBe(100);
+    expect(map.get('claude-haiku-4-5')!.input).toBe(50);
+  });
+
+  it('dedupes a response present in both main and a sub-agent file; unique sub-agent work still counts', () => {
+    const dup = msg('m1', 'claude-sonnet-4-6', 100);
+    const p = parsed(
+      [dup],
+      [{ agentId: 'a1', filePath: '/fake/agent-a1.jsonl', messages: [dup, msg('s1', 'claude-sonnet-4-6', 40)] }]
+    );
+    const recs = gatherDedupedUsageRecords('claude', p, new Set());
+    expect(recs.reduce((n, r) => n + r.usage.input, 0)).toBe(140); // not 240 (dup once), not 100 (sub-agent counted)
+  });
+
+  it('ignores a malformed sub-agent entry (non-array messages) without throwing', () => {
+    const p = parsed(
+      [msg('m1', 'claude-sonnet-4-6', 100)],
+      [{ agentId: 'bad', filePath: '/fake/agent-bad.jsonl', messages: 'corrupt' as never }]
+    );
+    expect(extractClaudeUsageRecords(p)).toHaveLength(1);
+  });
+
+  it('sessions without subagents behave exactly as before (regression guard)', () => {
+    const recs = extractClaudeUsageRecords(parsed([msg('m1', 'claude-sonnet-4-6', 100)]));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].usage.input).toBe(100);
+  });
+});

--- a/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
@@ -218,4 +218,24 @@ describe('extractClaudeUsageRecords — sub-agent transcripts', () => {
     expect(recs).toHaveLength(1);
     expect(recs[0].usage.input).toBe(100);
   });
+
+  it('sorts merged records chronologically when every record is timed', () => {
+    const p = parsed(
+      [
+        msg('m1', 'claude-sonnet-4-6', 1, '2026-06-08T10:00:00Z'),
+        msg('m2', 'claude-sonnet-4-6', 2, '2026-06-08T10:04:00Z'),
+      ],
+      [{ agentId: 'a1', filePath: '/fake/agent-a1.jsonl', messages: [msg('s1', 'claude-sonnet-4-6', 3, '2026-06-08T10:02:00Z')] }]
+    );
+    // sub-agent record (10:02) lands between the two main records
+    expect(extractClaudeUsageRecords(p).map((r) => r.usage.input)).toEqual([1, 3, 2]);
+  });
+
+  it('keeps concatenation order (main first) when any record lacks a timestamp', () => {
+    const p = parsed(
+      [msg('m1', 'claude-sonnet-4-6', 1, '2026-06-08T10:04:00Z')],
+      [{ agentId: 'a1', filePath: '/fake/agent-a1.jsonl', messages: [msg('s1', 'claude-sonnet-4-6', 2)] }] // untimed
+    );
+    expect(extractClaudeUsageRecords(p).map((r) => r.usage.input)).toEqual([1, 2]);
+  });
 });

--- a/src/cli/commands/analytics/cost/usage-readers.ts
+++ b/src/cli/commands/analytics/cost/usage-readers.ts
@@ -29,7 +29,7 @@ function messagesOf(parsed: ParsedSession): unknown[] {
 
 /**
  * The session's message arrays: main transcript first, then each sub-agent transcript
- * (Task/Agent dispatches the adapter parsed into `parsed.subagents`). Sub-agent token
+ * (transcripts of Task/Agent dispatches that the adapter parsed into `parsed.subagents`). Sub-agent token
  * usage belongs to the owning session — readers that skip these undercount sessions
  * that dispatch agents. Non-array `messages` entries are skipped with the same
  * defensive posture as {@link messagesOf}.
@@ -74,6 +74,8 @@ export interface UsageRecord {
  * across the main transcript AND every sub-agent transcript in `parsed.subagents`.
  * Claude Code replays prior turns into resumed/forked session files, so the SAME API
  * response (same message.id + requestId) appears in multiple logs — callers dedupe by `key`.
+ * Records are returned in chronological order when every record is timed; otherwise in
+ * concatenation order (main transcript first, then sub-agent files in discovery order).
  */
 export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] {
   const records: UsageRecord[] = [];
@@ -103,6 +105,14 @@ export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] 
         usage: { input, output, cacheRead, cacheCreation, total: input + output + cacheRead + cacheCreation },
       });
     }
+  }
+  // Main and sub-agent records interleave in real time. Sort chronologically when every
+  // record is timed — the same condition buildCostSeries uses for its real time axis — so
+  // the cumulative cost/token series stays monotonic in time. Single-file sessions are
+  // already in order (stable sort ⇒ no-op); any untimed record ⇒ keep concatenation order,
+  // matching the series' ordinal-axis fallback.
+  if (records.length > 1 && records.every((r) => r.ts !== null)) {
+    records.sort((a, b) => (a.ts as number) - (b.ts as number));
   }
   return records;
 }
@@ -253,7 +263,7 @@ export function gatherUsageDeduped(agentName: string, parsed: ParsedSession, see
 /**
  * Ordered, deduped per-message Claude usage records (for a per-session time-series).
  * Mirrors {@link gatherUsageDeduped}'s dedup (skips keys already in `seen`, mutates `seen`)
- * but preserves message order instead of summing. Returns [] when there is no per-message
+ * but preserves chronological record order instead of summing. Returns [] when there is no per-message
  * order to series-ize: an authoritative SDK `modelUsage` rollup, or a non-Claude agent.
  * MUST be called at most once per session against a shared `seen` set (it consumes keys).
  */

--- a/src/cli/commands/analytics/cost/usage-readers.ts
+++ b/src/cli/commands/analytics/cost/usage-readers.ts
@@ -27,6 +27,23 @@ function messagesOf(parsed: ParsedSession): unknown[] {
   return Array.isArray(parsed.messages) ? parsed.messages : [];
 }
 
+/**
+ * The session's message arrays: main transcript first, then each sub-agent transcript
+ * (Task/Agent dispatches the adapter parsed into `parsed.subagents`). Sub-agent token
+ * usage belongs to the owning session — readers that skip these undercount sessions
+ * that dispatch agents. Non-array `messages` entries are skipped with the same
+ * defensive posture as {@link messagesOf}.
+ */
+function allMessageArrays(parsed: ParsedSession): unknown[][] {
+  const arrays: unknown[][] = [messagesOf(parsed)];
+  for (const sub of parsed.subagents ?? []) {
+    if (Array.isArray(sub.messages)) {
+      arrays.push(sub.messages);
+    }
+  }
+  return arrays;
+}
+
 interface ClaudeRawMessage {
   requestId?: string;
   timestamp?: string; // top-level ISO timestamp on the native JSONL line
@@ -53,36 +70,39 @@ export interface UsageRecord {
 }
 
 /**
- * Extract one {@link UsageRecord} per Claude assistant message (skipping `<synthetic>`).
+ * Extract one {@link UsageRecord} per Claude assistant message (skipping `<synthetic>`),
+ * across the main transcript AND every sub-agent transcript in `parsed.subagents`.
  * Claude Code replays prior turns into resumed/forked session files, so the SAME API
  * response (same message.id + requestId) appears in multiple logs — callers dedupe by `key`.
  */
 export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] {
   const records: UsageRecord[] = [];
-  for (const raw of messagesOf(parsed) as ClaudeRawMessage[]) {
-    const usage = raw.message?.usage;
-    if (!usage) {
-      continue;
+  for (const messages of allMessageArrays(parsed)) {
+    for (const raw of messages as ClaudeRawMessage[]) {
+      const usage = raw.message?.usage;
+      if (!usage) {
+        continue;
+      }
+      const model = raw.message?.model ?? 'unknown';
+      if (model === '<synthetic>') {
+        continue; // synthetic system messages — not a billable model
+      }
+      const input = usage.input_tokens ?? 0;
+      const output = usage.output_tokens ?? 0;
+      const cacheRead = usage.cache_read_input_tokens ?? 0;
+      const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+      const id = raw.message?.id;
+      const reqId = raw.requestId;
+      const key = id || reqId ? `${id ?? ''}::${reqId ?? ''}` : null;
+      const parsedTs = raw.timestamp ? Date.parse(raw.timestamp) : NaN;
+      const ts = Number.isFinite(parsedTs) ? parsedTs : null;
+      records.push({
+        key,
+        ts,
+        model,
+        usage: { input, output, cacheRead, cacheCreation, total: input + output + cacheRead + cacheCreation },
+      });
     }
-    const model = raw.message?.model ?? 'unknown';
-    if (model === '<synthetic>') {
-      continue; // synthetic system messages — not a billable model
-    }
-    const input = usage.input_tokens ?? 0;
-    const output = usage.output_tokens ?? 0;
-    const cacheRead = usage.cache_read_input_tokens ?? 0;
-    const cacheCreation = usage.cache_creation_input_tokens ?? 0;
-    const id = raw.message?.id;
-    const reqId = raw.requestId;
-    const key = id || reqId ? `${id ?? ''}::${reqId ?? ''}` : null;
-    const parsedTs = raw.timestamp ? Date.parse(raw.timestamp) : NaN;
-    const ts = Number.isFinite(parsedTs) ? parsedTs : null;
-    records.push({
-      key,
-      ts,
-      model,
-      usage: { input, output, cacheRead, cacheCreation, total: input + output + cacheRead + cacheCreation },
-    });
   }
   return records;
 }


### PR DESCRIPTION
## Summary

Token usage extraction for Claude sessions only read the **main transcript**, so any session that dispatched Task/Agent sub-agents had the sub-agents' token usage silently dropped — undercounting both token totals and cost for those sessions. This PR folds every sub-agent transcript into the owning session's usage records and keeps the merged records in chronological order so the per-session cost/token time-series stays monotonic.

## Changes

- **Include sub-agent transcripts in usage extraction** — new `allMessageArrays()` helper in `usage-readers.ts` yields the main transcript followed by each parsed sub-agent transcript; `extractClaudeUsageRecords` now iterates all of them instead of only the main `messages` array.
- **Order merged records chronologically** — when every record is timed, records are sorted by timestamp (the same condition `buildCostSeries` uses for its real-time axis); when any record is untimed, ordering falls back to concatenation order (main transcript first, then sub-agent transcripts in discovery order).
- **Tests** — lock the sub-agent usage-folding and ordering invariants in `cost-enricher.test.ts` and `usage-readers.test.ts`.

## Impact

- Sessions that dispatch sub-agents now report **complete** token usage and cost instead of undercounting.
- The cumulative cost/token series stays monotonic in time for these merged sessions.
- Dedup behavior is unchanged — replayed messages (same `message.id` + `requestId`) are still deduped by `key` by callers.
- No API, CLI, or config changes; single-transcript sessions are unaffected (the chronological sort is a no-op when there is nothing to merge).

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
