### PR TITLE
fix(cli): handle Windows paths with special characters in usernames

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -664,7 +664,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       const { getCommandPath } = await import('../../utils/processes.js');
       const resolvedPath = await getCommandPath(this.metadata.cliCommand);
       if (resolvedPath) {
-        commandPath = isWindows && resolvedPath.includes(' ') ? `"${resolvedPath}"` : resolvedPath;
+        commandPath = isWindows && /[ ()&|<>^%[\]{}]/.test(resolvedPath) ? `"${resolvedPath}"` : resolvedPath;
         logger.debug(`Resolved command path: ${resolvedPath}`);
       } else if (!isWindows) {
         // On Unix, check common installation paths if command not found in PATH
@@ -689,7 +689,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       if (isWindows && transformedArgs.length > 0) {
         // Quote arguments containing spaces or special characters
         const quotedArgs = transformedArgs.map(arg =>
-          arg.includes(' ') || arg.includes('"') ? `"${arg.replace(/"/g, '\\"')}"` : arg
+          /[ "()&|<>^%[\]{}]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg
         );
         finalCommand = `${commandPath} ${quotedArgs.join(' ')}`;
         finalArgs = [];

--- a/src/utils/__tests__/windows-path.test.ts
+++ b/src/utils/__tests__/windows-path.test.ts
@@ -293,7 +293,6 @@ describe('windows-path', () => {
 				'C:\\test > output.txt',
 				'C:\\test < input.txt',
 				'C:\\test ^ test2',
-				'C:\\test (malicious)'
 			];
 
 			for (const path of maliciousPaths) {
@@ -305,6 +304,26 @@ describe('windows-path', () => {
 			}
 
 			expect(execSpy).not.toHaveBeenCalled();
+		});
+
+		it('should accept paths with parentheses in directory names', async () => {
+			execSpy.mockResolvedValueOnce({
+				code: 0,
+				stdout: 'PATH    REG_EXPAND_SZ    C:\\Windows\n',
+				stderr: '',
+			});
+			execSpy.mockResolvedValueOnce({
+				code: 0,
+				stdout: 'SUCCESS: Specified value was saved.\n',
+				stderr: '',
+			});
+
+			const { addToUserPath } = await import('../windows-path.js');
+			const result = await addToUserPath('C:\\Users\\Test(User)\\.local\\bin');
+
+			expect(result.success).toBe(true);
+			expect(result.pathAdded).toBe('C:\\Users\\Test(User)\\.local\\bin');
+			expect(result.alreadyInPath).toBe(false);
 		});
 
 		it('should accept paths with dots and underscores (safe characters)', async () => {

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -62,7 +62,7 @@ export async function exec(
       // On Windows CMD, & | < > ^ % are metacharacters and must be quoted.
       const needsQuoting = (arg: string) =>
         arg.includes(' ') || arg.includes('"') ||
-        (isWindows && /[&|<>^%]/.test(arg));
+        (isWindows && /[&|<>^%()[\]{}]/.test(arg));
       const quotedArgs = args.map(arg =>
         needsQuoting(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg
       );

--- a/src/utils/windows-path.ts
+++ b/src/utils/windows-path.ts
@@ -49,8 +49,12 @@ function validateDirectoryPath(directory: string): string | null {
 		}
 
 		// SECURITY: Check for shell metacharacters that could enable command injection
-		// Windows shell special chars: & | < > ^ ( ) " ; , \n \r
-		const dangerousChars = /[&|<>^();,\n\r"]/;
+		// Windows cmd.exe metacharacters: & | < > ^ "
+		// Note: ( ) are valid in Windows directory names (e.g. "Program Files (x86)") and
+		// safe here because callers use exec() with shell:false / array args.
+		// Note: ; is the Windows PATH separator — a directory name containing ; would corrupt
+		// the PATH registry value by splitting into two spurious entries.
+		const dangerousChars = /[&|<>^;,\n\r"]/;
 		if (dangerousChars.test(normalizedPath)) {
 			logger.warn('Directory path contains dangerous shell metacharacters', {
 				directory: normalizedPath


### PR DESCRIPTION
## Summary

Fixes CLI failures on Windows when the user profile directory contains special characters such as parentheses. The root cause was two separate issues: `validateDirectoryPath` treating `(` and `)` as dangerous shell metacharacters (blocking them entirely), and the Windows spawn path in `BaseAgentAdapter` not quoting paths/args that contain those characters before passing them to `cmd.exe`.

## Changes

- `src/utils/windows-path.ts` — removed `(` and `)` from `dangerousChars`; they are valid Windows directory characters and safe when using `spawn` with `shell:false` / array args. Corrected comment to clarify that `;` is kept because it is the Windows PATH separator, not a cmd.exe metacharacter.
- `src/agents/core/BaseAgentAdapter.ts` — extended both the `commandPath` and `transformedArgs` quoting regexes to include `( ) [ ] { }`, aligning them with `exec.ts` and preventing cmd.exe from misinterpreting these characters as syntax.
- `src/utils/exec.ts` — extended `needsQuoting` in shell mode to include `( ) [ ] { }`.
- `src/utils/__tests__/windows-path.test.ts` — removed `C:\test (malicious)` from the rejection list; added acceptance test for paths with parentheses in directory names.

## Impact

Before: `codemie-code` failed with `'C:\Users\Username' is not recognized as an internal or external command` for any user whose profile path contained `(` or similar characters.

After: all valid Windows directory names (including those with parentheses, brackets, and braces) are handled correctly.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed (build + unit tests pass)
- [x] No breaking changes