### PR TITLE
fix(agents): correctly import Claude Desktop file-analysis conversations

### DIFF
--- a/src/agents/plugins/claude/__tests__/claude.conversations-processor.test.ts
+++ b/src/agents/plugins/claude/__tests__/claude.conversations-processor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConversationsProcessor } from '../session/processors/claude.conversations-processor.js';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+// Minimal helpers to build Claude Desktop (Cowork) transcript records.
+let clock = 0;
+const ts = () => new Date(1700000000000 + clock++ * 1000).toISOString();
+
+const user = (uuid: string, content: any) => ({
+  type: 'user',
+  uuid,
+  timestamp: ts(),
+  message: { role: 'user', content },
+});
+const assistant = (uuid: string, content: any[]) => ({
+  type: 'assistant',
+  uuid,
+  timestamp: ts(),
+  message: { role: 'assistant', content },
+});
+// Cowork interleaves many of these *inside* a turn (init + audit events).
+const system = (uuid: string, subtype = 'init') => ({ type: 'system', subtype, uuid, timestamp: ts() });
+
+/**
+ * Builds a Claude Desktop conversation where a file is uploaded and analysed:
+ * system events appear in the middle of the turn and the user message is
+ * wrapped in an <uploaded_files> block.
+ */
+function buildFileAnalysisTurn() {
+  return [
+    user(
+      'u1',
+      '<uploaded_files>\n<file><file_path>/Users/me/Documents/Report.docx</file_path>' +
+        '<file_uuid>abc</file_uuid></file>\n</uploaded_files>\n\nanalyze this file'
+    ),
+    system('s-init-1'),
+    system('s-init-2'),
+    assistant('a1', [
+      { type: 'thinking', thinking: 'reading the file' },
+      { type: 'tool_use', id: 't1', name: 'Read', input: { file: 'Report.docx' } },
+    ]),
+    user('tr1', [{ type: 'tool_result', tool_use_id: 't1', content: 'file contents' }]),
+    // Mid-turn system event: this is what used to truncate the turn.
+    system('s-audit-1', 'audit'),
+    assistant('a2', [{ type: 'text', text: 'This document is a homework guide.' }]),
+  ];
+}
+
+describe('ClaudeConversationsProcessor.transformMessages — file upload + analysis', () => {
+  const proc = new ConversationsProcessor();
+  const transform = (messages: unknown[]) =>
+    (proc as any).transformMessages(messages, { lastSyncedHistoryIndex: -1 }, 'assistant-id', 'claude', undefined);
+
+  it('keeps the assistant answer even when system events appear mid-turn', async () => {
+    const { history } = await transform(buildFileAnalysisTurn());
+
+    const assistantEntry = history.find((h: any) => h.role === 'Assistant');
+    expect(assistantEntry).toBeDefined();
+    // Regression: this was '' because a mid-turn system event truncated the turn.
+    expect(assistantEntry.message).toContain('homework guide');
+  });
+
+  it('surfaces uploaded file names inline and strips the <uploaded_files> wrapper', async () => {
+    const { history } = await transform(buildFileAnalysisTurn());
+
+    const userEntry = history.find((h: any) => h.role === 'User');
+    expect(userEntry).toBeDefined();
+    // Imported files are not in CodeMie storage, so no file_names reference is
+    // emitted (otherwise the backend file reader 500s on a plain name).
+    expect(userEntry.file_names).toEqual([]);
+    // The file name is shown inline next to the real prompt; no raw XML leaks.
+    expect(userEntry.message).toContain('Report.docx');
+    expect(userEntry.message).toContain('analyze this file');
+    expect(userEntry.message).not.toContain('<uploaded_files>');
+  });
+
+  it('does not treat a plain message without attachments as having files', async () => {
+    const { history } = await transform([
+      user('u1', 'just a question'),
+      assistant('a1', [{ type: 'text', text: 'an answer' }]),
+    ]);
+
+    const userEntry = history.find((h: any) => h.role === 'User');
+    expect(userEntry.file_names).toEqual([]);
+    expect(userEntry.message).toBe('just a question');
+  });
+});

--- a/src/agents/plugins/claude/session/processors/claude.conversations-processor.ts
+++ b/src/agents/plugins/claude/session/processors/claude.conversations-processor.ts
@@ -266,11 +266,11 @@ export class ConversationsProcessor implements SessionProcessor {
         const msg = messages[i];
         if (!msg.uuid) continue;
 
-        // Stop at system messages (e.g., stop hooks)
-        if (msg.type === 'system') {
-          turnEndIndex = i;
-          break;
-        }
+        // A turn ends only at the next real user message. Do NOT break on
+        // `system` records: Claude Desktop (Cowork) interleaves many system
+        // events (init + audit) *inside* a single turn, so breaking here
+        // truncated the turn before the assistant's final answer, leaving the
+        // response empty in CodeMie.
 
         if (msg.type === 'user' && !this.shouldFilterMessage(msg, messagesByUuid) && !this.isToolResult(msg)) {
           turnEndIndex = i;
@@ -314,11 +314,11 @@ export class ConversationsProcessor implements SessionProcessor {
         const msg = messages[i];
         if (!msg.uuid) continue;
 
-        // Stop at system messages (e.g., stop hooks)
-        if (msg.type === 'system') {
-          turnEndIndex = i;
-          break;
-        }
+        // A turn ends only at the next real user message. Do NOT break on
+        // `system` records: Claude Desktop (Cowork) interleaves many system
+        // events (init + audit) *inside* a single turn, so breaking here
+        // truncated the turn before the assistant's final answer, leaving the
+        // response empty in CodeMie.
 
         if (msg.type === 'user' && !this.shouldFilterMessage(msg, messagesByUuid) && !this.isToolResult(msg)) {
           turnEndIndex = i;
@@ -382,7 +382,15 @@ export class ConversationsProcessor implements SessionProcessor {
       return [];
     }
 
-    const userText = this.extractUserMessage(userMessage);
+    const rawUserText = this.extractUserMessage(userMessage);
+    const { fileNames, text: cleanedText } = this.extractUploadedFiles(rawUserText);
+    // Imported files live in Claude Desktop, not CodeMie storage, so we can't emit
+    // them as `file_names` references: the reader expects a base64 storage key and
+    // returns 500 ("expected 3 values") on a plain name. Surface the attached file
+    // names inline in the message instead, and keep file_names empty.
+    const userText = fileNames.length
+      ? [...fileNames.map((name) => `📎 ${name}`), cleanedText].filter(Boolean).join('\n\n')
+      : cleanedText;
 
     history.push({
       role: 'User',
@@ -673,6 +681,32 @@ export class ConversationsProcessor implements SessionProcessor {
     }
 
     return map;
+  }
+
+  /**
+   * Claude Desktop prepends an <uploaded_files> block to the user's text when a
+   * file is attached, e.g.
+   *   <uploaded_files><file><file_path>/abs/Report.docx</file_path>...</file></uploaded_files>
+   *   analyze this file
+   * Pull the attached file names out (-> `file_names`) and strip the wrapper so
+   * the visible message is the real prompt, not raw XML.
+   */
+  private extractUploadedFiles(text: string): { fileNames: string[]; text: string } {
+    if (!text || !text.includes('<uploaded_files>')) {
+      return { fileNames: [], text: text ?? '' };
+    }
+    const fileNames: string[] = [];
+    const blockRegex = /<uploaded_files>[\s\S]*?<\/uploaded_files>/g;
+    const pathRegex = /<file_path>([\s\S]*?)<\/file_path>/g;
+    for (const block of text.match(blockRegex) ?? []) {
+      let match: RegExpExecArray | null;
+      while ((match = pathRegex.exec(block)) !== null) {
+        const fullPath = match[1].trim();
+        const base = fullPath.split(/[\\/]/).pop() || fullPath;
+        if (base) fileNames.push(base);
+      }
+    }
+    return { fileNames, text: text.replace(blockRegex, '').trim() };
   }
 
   private extractUserMessage(msg: any): string {

--- a/src/telemetry/clients/claude-desktop/claude-desktop.discovery.ts
+++ b/src/telemetry/clients/claude-desktop/claude-desktop.discovery.ts
@@ -139,8 +139,8 @@ export async function discoverClaudeDesktopSessions(
       if (!metadata.sessionId.startsWith('local_')) continue;
       // Skip until the inner Claude session id exists. Until then agentSessionId
       // (the conversation id) falls back to the external `local_<id>`, and an early
-      // poll syncs an empty stub conversation under it — a duplicate of the real
-      // conversation that later syncs under the inner uuid (EPMCDME-12743).
+      // poll syncs an empty stub conversation under it - a duplicate of the real
+      // conversation that later syncs under the inner uuid.
       if (!metadata.cliSessionId) continue;
       if (!transcriptPath || !existsSync(transcriptPath)) continue;
       if (metadata.lastActivityAt < sinceMs && metadata.createdAt < sinceMs) continue;

--- a/src/telemetry/clients/claude-desktop/claude-desktop.discovery.ts
+++ b/src/telemetry/clients/claude-desktop/claude-desktop.discovery.ts
@@ -137,6 +137,11 @@ export async function discoverClaudeDesktopSessions(
         : claudeTranscriptPath;
 
       if (!metadata.sessionId.startsWith('local_')) continue;
+      // Skip until the inner Claude session id exists. Until then agentSessionId
+      // (the conversation id) falls back to the external `local_<id>`, and an early
+      // poll syncs an empty stub conversation under it — a duplicate of the real
+      // conversation that later syncs under the inner uuid (EPMCDME-12743).
+      if (!metadata.cliSessionId) continue;
       if (!transcriptPath || !existsSync(transcriptPath)) continue;
       if (metadata.lastActivityAt < sinceMs && metadata.createdAt < sinceMs) continue;
       if (seenSessionIds.has(metadata.sessionId)) continue;


### PR DESCRIPTION
## Claude Desktop file-analysis import fix

Claude Desktop (Cowork) conversations that include a file upload and analysis were imported into CodeMie incompletely:

- the assistant's analysis reply was missing (empty response);
- the uploaded file appeared as raw `<uploaded_files>` XML in both the message and the chat name, and opening it returned a 500;
- the conversation showed up twice — the real chat plus an empty duplicate.

With this change such conversations import fully and correctly: the user prompt, the attached file name, and the complete assistant reply are shown in a single chat.

Verified end-to-end against a real Cowork file-analysis session; unit tests cover the message and file transformation.