### PR TITLE
feat(analytics): per-agent cost breakdown and clickable Gantt timeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,5 @@ docs/superpowers
 .playwright-mcp/
 codemie-analytics-*.html
 .worktrees/
-.worktrees/
+.playwright-cli/
+output/playwright

--- a/docs/ANALYTICS-REPORT.md
+++ b/docs/ANALYTICS-REPORT.md
@@ -145,7 +145,7 @@ Clicking a session anywhere in the report opens a detail overlay with:
 - **Activity** — turns, tool calls and success rate, agent/skill/command invocation counts
 - **Code changes** — files changed, lines added/removed, net
 - **Token & cost growth chart** — cumulative cost and token usage per turn (from the native log; shown when data is available)
-- **Dispatch timeline** — Gantt-style view of agent invocations within the session, positioned by start time relative to the session span
+- **Dispatch timeline** — Interactive Gantt of agent dispatches. Bars are proportionally scaled to the agent activity window; click any bar to open a detail panel on the right showing that agent's estimated cost, token breakdown (input / output / cache read / cache write), wall-clock duration, start offset from session start, and top tool call counts. Skills and slash commands are shown in the chip lists below the Gantt, not as bars.
 - **Skills / Agent subtypes / Slash commands** — chip lists of what was invoked and how many times
 
 ---

--- a/src/agents/core/session/BaseSessionAdapter.ts
+++ b/src/agents/core/session/BaseSessionAdapter.ts
@@ -39,7 +39,9 @@ export interface ParsedSession {
     agentId: string;
     slug?: string;
     filePath: string;
-    messages: unknown[]; // Pre-parsed messages from sub-agent file
+    messages: unknown[];
+    toolUseId?: string;   // from agent-<id>.meta.json — links to parent tool_use.id
+    agentType?: string;   // from agent-<id>.meta.json — the agent type string
   }>;
 
   // Parsed metrics data (optional - for metrics processor)

--- a/src/agents/plugins/claude/claude.session.ts
+++ b/src/agents/plugins/claude/claude.session.ts
@@ -8,7 +8,7 @@
 import { join, dirname, basename } from 'path';
 import { homedir } from 'os';
 import { existsSync } from 'fs';
-import { readdir, stat } from 'fs/promises';
+import { readdir, readFile, stat } from 'fs/promises';
 import type { SessionAdapter, ParsedSession, AggregatedResult } from '../../core/session/BaseSessionAdapter.js';
 import type { SessionDiscoveryOptions, SessionDescriptor } from '../../core/session/discovery-types.js';
 import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
@@ -220,6 +220,8 @@ export class ClaudeSessionAdapter implements SessionAdapter {
         slug?: string;
         filePath: string;
         messages: unknown[];
+        toolUseId?: string;
+        agentType?: string;
       }> = [];
 
       for (const subagentFile of subagentFiles) {
@@ -228,7 +230,9 @@ export class ClaudeSessionAdapter implements SessionAdapter {
           subagents.push({
             agentId: subagentFile.agentId,
             filePath: subagentFile.filePath,
-            messages: subagentMessages
+            messages: subagentMessages,
+            toolUseId: subagentFile.toolUseId,
+            agentType: subagentFile.agentType,
           });
 
           logger.debug(
@@ -348,6 +352,8 @@ export class ClaudeSessionAdapter implements SessionAdapter {
   private async findSubagentFiles(sessionFilePath: string): Promise<Array<{
     agentId: string;
     filePath: string;
+    toolUseId?: string;
+    agentType?: string;
   }>> {
     try {
       const parentDir = dirname(sessionFilePath);
@@ -364,12 +370,26 @@ export class ClaudeSessionAdapter implements SessionAdapter {
 
       // Find all agent-*.jsonl files
       const files = await readdir(subagentsDir);
-      const agentFiles = files
-        .filter(f => f.startsWith('agent-') && f.endsWith('.jsonl'))
-        .map(f => ({
-          agentId: f.replace('agent-', '').replace('.jsonl', ''),
-          filePath: join(subagentsDir, f)
-        }));
+      const agentFiles = await Promise.all(
+        files
+          .filter(f => f.startsWith('agent-') && f.endsWith('.jsonl'))
+          .map(async f => {
+            const agentId = f.replace('agent-', '').replace('.jsonl', '');
+            const filePath = join(subagentsDir, f);
+            let toolUseId: string | undefined;
+            let agentType: string | undefined;
+            try {
+              const metaRaw = JSON.parse(
+                await readFile(join(subagentsDir, f.replace('.jsonl', '.meta.json')), 'utf-8')
+              );
+              if (typeof metaRaw.toolUseId === 'string') toolUseId = metaRaw.toolUseId;
+              if (typeof metaRaw.agentType === 'string') agentType = metaRaw.agentType;
+            } catch {
+              // meta file absent or malformed — proceed without it
+            }
+            return { agentId, filePath, toolUseId, agentType };
+          })
+      );
 
       logger.debug(
         `[claude-adapter] Found ${agentFiles.length} sub-agent file${agentFiles.length !== 1 ? 's' : ''} ` +

--- a/src/cli/commands/analytics/cost/__tests__/cost-enricher.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/cost-enricher.test.ts
@@ -220,6 +220,125 @@ describe('enrichCosts', () => {
   });
 });
 
+describe('enrichCosts — dispatch cost attribution', () => {
+  it('attributes cost, tokens, and tools to a dispatch when subagent matches by toolUseId', async () => {
+    const subagentMessages = [
+      {
+        timestamp: '2026-06-08T10:02:00Z',
+        requestId: 'req-sub-1',
+        message: {
+          id: 'msg-sub-1',
+          role: 'assistant',
+          model: 'claude-sonnet-4-5',
+          usage: { input_tokens: 100_000, output_tokens: 500, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+          content: [
+            { type: 'tool_use', id: 'tool-1', name: 'Read', input: {} },
+            { type: 'tool_use', id: 'tool-2', name: 'Bash', input: {} },
+            { type: 'tool_use', id: 'tool-3', name: 'Read', input: {} },
+          ],
+        },
+      },
+    ];
+
+    const deps: EnricherDeps = {
+      resolveAgentName: () => 'claude',
+      loadAgentSessionFile: async () => '/fake/parent.jsonl',
+      parseNative: async () =>
+        ({
+          sessionId: 'parent-1',
+          agentName: 'claude',
+          metadata: {},
+          messages: [
+            {
+              timestamp: '2026-06-08T10:00:00Z',
+              message: {
+                role: 'assistant',
+                content: [{ type: 'tool_use', id: 'toolu_dispatch_1', name: 'Agent', input: { subagent_type: 'tech-analyst' } }],
+              },
+            },
+            {
+              timestamp: '2026-06-08T10:05:00Z',
+              message: {
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: 'toolu_dispatch_1', content: 'done' }],
+              },
+            },
+          ],
+          subagents: [
+            {
+              agentId: 'agent-abc',
+              filePath: '/fake/parent-1/subagents/agent-abc.jsonl',
+              messages: subagentMessages,
+              toolUseId: 'toolu_dispatch_1',
+              agentType: 'tech-analyst',
+            },
+          ],
+        }) as never,
+    };
+
+    const rawSession = [{ sessionId: 'parent-1', startEvent: { agentName: 'claude' }, deltas: [] }] as never[];
+    const { index } = await enrichCosts(rawSession, deps);
+    const cost = index.get('parent-1')!;
+
+    expect(cost.priced).toBe(true);
+    expect(cost.dispatches).toBeDefined();
+    const dispatch = cost.dispatches!.find(d => d.name === 'tech-analyst');
+    expect(dispatch).toBeDefined();
+    expect(dispatch!.costUSD).toBeGreaterThan(0);
+    expect(dispatch!.tokens?.input).toBe(100_000);
+    expect(dispatch!.tokens?.output).toBe(500);
+
+    expect(dispatch!.tools).toBeDefined();
+    const readTool = dispatch!.tools!.find(t => t.name === 'Read');
+    const bashTool = dispatch!.tools!.find(t => t.name === 'Bash');
+    expect(readTool?.calls).toBe(2);
+    expect(bashTool?.calls).toBe(1);
+
+    // _toolUseId must NOT be in the stored dispatch (stripped before storage)
+    expect((dispatch as { _toolUseId?: string })._toolUseId).toBeUndefined();
+  });
+
+  it('leaves dispatch cost undefined when no subagent matches (graceful degradation)', async () => {
+    const deps: EnricherDeps = {
+      resolveAgentName: () => 'claude',
+      loadAgentSessionFile: async () => '/fake/parent.jsonl',
+      parseNative: async () =>
+        ({
+          sessionId: 'parent-2',
+          agentName: 'claude',
+          metadata: {},
+          messages: [
+            {
+              timestamp: '2026-06-08T10:00:00Z',
+              message: {
+                role: 'assistant',
+                content: [{ type: 'tool_use', id: 'toolu_no_meta', name: 'Agent', input: { subagent_type: 'Explore' } }],
+              },
+            },
+            {
+              timestamp: '2026-06-08T10:01:00Z',
+              message: {
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: 'toolu_no_meta', content: 'done' }],
+              },
+            },
+          ],
+          subagents: undefined,
+        }) as never,
+    };
+
+    const rawSession = [{ sessionId: 'parent-2', startEvent: { agentName: 'claude' }, deltas: [] }] as never[];
+    const { index } = await enrichCosts(rawSession, deps);
+    const cost = index.get('parent-2')!;
+
+    const dispatch = cost.dispatches?.find(d => d.name === 'Explore');
+    expect(dispatch).toBeDefined();
+    expect(dispatch!.costUSD).toBeUndefined();
+    expect(dispatch!.tokens).toBeUndefined();
+    expect(dispatch!.tools).toBeUndefined();
+  });
+});
+
 describe('buildCostSeries', () => {
   const rec = (ts: number | null, model: string, input: number): UsageRecord =>
     ({ key: null, ts, model, usage: { input, output: 0, cacheRead: 0, cacheCreation: 0, total: input } });

--- a/src/cli/commands/analytics/cost/__tests__/dispatch-extractor.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/dispatch-extractor.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { extractDispatchEvents } from '../dispatch-extractor.js';
+import type { DispatchEventRaw } from '../types.js';
 import { MAX_DISPATCHES } from '../types.js';
 
 function parsed(messages: unknown[]): never {
@@ -31,7 +32,7 @@ describe('extractDispatchEvents', () => {
       agentUse('a1', 'tech-analyst', '2026-06-08T10:00:00Z'),
       result('a1', '2026-06-08T10:02:30Z'),
     ]));
-    expect(ev).toEqual([{ kind: 'agent', name: 'tech-analyst', start: Date.parse('2026-06-08T10:00:00Z'), durationMs: 150000 }]);
+    expect(ev).toEqual([{ kind: 'agent', name: 'tech-analyst', start: Date.parse('2026-06-08T10:00:00Z'), durationMs: 150000, _toolUseId: 'a1' }]);
   });
 
   it('handles Task (standard Claude Code), Skill (0s), and command point events; sorts by start', () => {
@@ -61,7 +62,7 @@ describe('extractDispatchEvents', () => {
 
   it('emits an unmatched dispatch (no tool_result) as a 0-duration marker', () => {
     const ev = extractDispatchEvents(parsed([agentUse('a1', 'orphan', '2026-06-08T10:00:00Z')]));
-    expect(ev).toEqual([{ kind: 'agent', name: 'orphan', start: Date.parse('2026-06-08T10:00:00Z'), durationMs: 0 }]);
+    expect(ev).toEqual([{ kind: 'agent', name: 'orphan', start: Date.parse('2026-06-08T10:00:00Z'), durationMs: 0, _toolUseId: 'a1' }]);
   });
 
   it('caps at MAX_DISPATCHES', () => {
@@ -75,5 +76,18 @@ describe('extractDispatchEvents', () => {
 
   it('returns [] when there are no dispatches', () => {
     expect(extractDispatchEvents(parsed([{ timestamp: '2026-06-08T10:00:00Z', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } }]))).toEqual([]);
+  });
+
+  it('includes _toolUseId for agent dispatches and omits it for skills/commands', () => {
+    const ev = extractDispatchEvents(parsed([
+      agentUse('toolu_abc123', 'tech-analyst', '2026-06-08T10:00:00Z'),
+      result('toolu_abc123', '2026-06-08T10:02:00Z'),
+      skillUse('s1', 'superpowers:brainstorming', '2026-06-08T10:02:30Z'),
+      result('s1', '2026-06-08T10:02:30Z'),
+      commandMsg('sdlc-task', '2026-06-08T10:03:00Z'),
+    ])) as DispatchEventRaw[];
+    expect(ev[0]._toolUseId).toBe('toolu_abc123');  // agent gets toolUseId
+    expect(ev[1]._toolUseId).toBeUndefined();         // skill: no toolUseId
+    expect(ev[2]._toolUseId).toBeUndefined();         // command: no toolUseId
   });
 });

--- a/src/cli/commands/analytics/cost/cost-enricher.ts
+++ b/src/cli/commands/analytics/cost/cost-enricher.ts
@@ -12,6 +12,7 @@ import { readFile } from 'node:fs/promises';
 import type { RawSessionData } from '../data-loader.js';
 import type { ParsedSession, SessionAdapter } from '../../../../agents/core/session/BaseSessionAdapter.js';
 import type { SessionCost, SessionCostIndex, CostSummary, ModelCost, TokenUsage, CostSeriesPoint } from './types.js';
+import type { DispatchEventRaw } from './types.js';
 import { MAX_SERIES_POINTS } from './types.js';
 import { emptyUsage, addUsage, costBreakdown } from './cost-calculator.js';
 import { lookupPrice } from './pricing.js';
@@ -187,6 +188,70 @@ async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T)
   return out;
 }
 
+/**
+ * Second-pass enrichment: for each agent dispatch that has a matching subagent entry
+ * (linked by toolUseId from the .meta.json), extract usage from the subagent's messages,
+ * price it, and attach costUSD + tokens + tools to the dispatch event in place.
+ *
+ * The per-dispatch cost is an ALLOCATION of already-counted session tokens (subagents are
+ * included in the session total via allMessageArrays). Do NOT add to `seen` here.
+ */
+function enrichDispatchCosts(dispatches: DispatchEventRaw[], parsed: ParsedSession): void {
+  if (!parsed.subagents?.length) return;
+
+  const byToolUseId = new Map<string, { messages: unknown[] }>();
+  for (const sub of parsed.subagents) {
+    if (sub.toolUseId && Array.isArray(sub.messages)) {
+      byToolUseId.set(sub.toolUseId, sub);
+    }
+  }
+  if (!byToolUseId.size) return;
+
+  for (const dispatch of dispatches) {
+    if (dispatch.kind !== 'agent' || !dispatch._toolUseId) continue;
+    const sub = byToolUseId.get(dispatch._toolUseId);
+    if (!sub) continue;
+
+    const subSeen = new Set<string>();
+    const records = gatherDedupedUsageRecords(
+      'claude',
+      { sessionId: '', agentName: 'claude', metadata: {}, messages: sub.messages } as unknown as ParsedSession,
+      subSeen,
+    );
+
+    if (records.length) {
+      const usageByModel = sumUsageRecords(records);
+      let totalCost = 0;
+      let totalTokens = emptyUsage();
+      let priced = false;
+      for (const [rawModel, usage] of usageByModel) {
+        const model = normalizeModelName(rawModel);
+        const price = lookupPrice(model);
+        if (price) { totalCost += costBreakdown(usage, price).total; priced = true; }
+        totalTokens = addUsage(totalTokens, usage);
+      }
+      if (priced) dispatch.costUSD = Math.round(totalCost * 1e8) / 1e8;
+      dispatch.tokens = totalTokens;
+    }
+
+    const toolCounts: Record<string, number> = {};
+    for (const raw of sub.messages as Array<{ message?: { content?: unknown } }>) {
+      const content = raw.message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const b of content as Array<{ type?: string; name?: string }>) {
+        if (b.type === 'tool_use' && b.name) {
+          toolCounts[b.name] = (toolCounts[b.name] || 0) + 1;
+        }
+      }
+    }
+    const tools = Object.entries(toolCounts)
+      .map(([name, calls]) => ({ name, calls }))
+      .sort((a, b) => b.calls - a.calls)
+      .slice(0, 8);
+    if (tools.length) dispatch.tools = tools;
+  }
+}
+
 export async function enrichCosts(
   sessions: RawSessionData[],
   deps: EnricherDeps = realDeps
@@ -236,7 +301,9 @@ export async function enrichCosts(
       try {
         const dispatches = extractDispatchEvents(entry.parsed);
         if (dispatches.length) {
-          cost.dispatches = dispatches;
+          enrichDispatchCosts(dispatches, entry.parsed);
+          // Strip internal _toolUseId before storing in the public cost index
+          cost.dispatches = dispatches.map(({ _toolUseId: _id, ...d }) => d);
         }
       } catch (e) {
         logger.debug(`[cost] dispatch extraction failed for ${entry.sessionId}:`, e);

--- a/src/cli/commands/analytics/cost/dispatch-extractor.ts
+++ b/src/cli/commands/analytics/cost/dispatch-extractor.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ParsedSession } from '../../../../agents/core/session/BaseSessionAdapter.js';
-import type { DispatchEvent } from './types.js';
+import type { DispatchEventRaw } from './types.js';
 import { MAX_DISPATCHES } from './types.js';
 
 interface RawBlock {
@@ -20,7 +20,12 @@ interface RawBlock {
   name?: string;
   id?: string;
   tool_use_id?: string;
-  input?: { skill?: unknown; subagent_type?: unknown };
+  input?: {
+    skill?: unknown;
+    subagent_type?: unknown;
+    name?: unknown;
+    description?: unknown;
+  };
   text?: unknown;
 }
 interface RawMsg {
@@ -32,10 +37,10 @@ interface RawMsg {
 const COMMAND_TAG = /<command-name>([^<]+)<\/command-name>/g;
 
 /** Extract timed top-level dispatches (agents/skills) + command point events, sorted by start. */
-export function extractDispatchEvents(parsed: ParsedSession): DispatchEvent[] {
+export function extractDispatchEvents(parsed: ParsedSession): DispatchEventRaw[] {
   const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
-  const pending = new Map<string, { kind: 'agent' | 'skill'; name: string; start: number }>();
-  const events: DispatchEvent[] = [];
+  const pending = new Map<string, { kind: 'agent' | 'skill'; name: string; start: number; toolUseId?: string }>();
+  const events: DispatchEventRaw[] = [];
 
   const scanCommands = (text: string, at: number): void => {
     if (!text.includes('<command-message>')) {
@@ -72,15 +77,17 @@ export function extractDispatchEvents(parsed: ParsedSession): DispatchEvent[] {
 
     for (const b of content as RawBlock[]) {
       if (b?.type === 'tool_use' && ts != null && b.id) {
-        if ((b.name === 'Agent' || b.name === 'Task') && typeof b.input?.subagent_type === 'string') {
-          pending.set(b.id, { kind: 'agent', name: b.input.subagent_type.trim() || 'agent', start: ts });
+        if (b.name === 'Agent' || b.name === 'Task') {
+          const agentName = [b.input?.subagent_type, b.input?.name]
+            .find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+          pending.set(b.id, { kind: 'agent', name: agentName?.trim() ?? 'agent', start: ts, toolUseId: b.id });
         } else if (b.name === 'Skill' && typeof b.input?.skill === 'string') {
           pending.set(b.id, { kind: 'skill', name: b.input.skill.trim() || 'skill', start: ts });
         }
       } else if (b?.type === 'tool_result' && b.tool_use_id && pending.has(b.tool_use_id)) {
         const p = pending.get(b.tool_use_id)!;
         pending.delete(b.tool_use_id);
-        events.push({ kind: p.kind, name: p.name, start: p.start, durationMs: ts != null ? Math.max(0, ts - p.start) : 0 });
+        events.push({ kind: p.kind, name: p.name, start: p.start, durationMs: ts != null ? Math.max(0, ts - p.start) : 0, _toolUseId: p.kind === 'agent' ? p.toolUseId : undefined });
       } else if (isUser && b?.type === 'text' && typeof b.text === 'string' && ts != null) {
         scanCommands(b.text, ts);
       }
@@ -89,7 +96,7 @@ export function extractDispatchEvents(parsed: ParsedSession): DispatchEvent[] {
 
   // Dispatches whose tool_result never appeared (truncated/streaming log) → 0-duration markers.
   for (const p of pending.values()) {
-    events.push({ kind: p.kind, name: p.name, start: p.start, durationMs: 0 });
+    events.push({ kind: p.kind, name: p.name, start: p.start, durationMs: 0, _toolUseId: p.kind === 'agent' ? p.toolUseId : undefined });
   }
 
   events.sort((a, b) => a.start - b.start);

--- a/src/cli/commands/analytics/cost/types.ts
+++ b/src/cli/commands/analytics/cost/types.ts
@@ -36,9 +36,18 @@ export const MAX_SERIES_POINTS = 40;
 export interface DispatchEvent {
   kind: 'agent' | 'skill' | 'command';
   name: string;
-  start: number; // epoch ms of the tool_use / command
-  durationMs: number; // tool_result − tool_use; 0 for skills/commands/unmatched
+  start: number;       // epoch ms of the tool_use / command
+  durationMs: number;  // tool_result − tool_use; 0 for skills/commands/unmatched
+  tokens?: TokenUsage; // from subagent transcript; absent when no meta match or unpriced model
+  costUSD?: number;    // priced from tokens; absent when unpriced or no meta match
+  tools?: Array<{ name: string; calls: number }>; // top tool call counts from subagent; max 8
 }
+
+/**
+ * Internal dispatch event used during cost enrichment — carries _toolUseId to join
+ * against parsed.subagents. Stripped before the event is stored in SessionCost.dispatches.
+ */
+export type DispatchEventRaw = DispatchEvent & { _toolUseId?: string };
 
 /** Max dispatch events kept per session — payload guard for very long runs. */
 export const MAX_DISPATCHES = 60;

--- a/src/cli/commands/analytics/report/client/app.js
+++ b/src/cli/commands/analytics/report/client/app.js
@@ -155,6 +155,93 @@
     return cv;
   }
 
+  var INVOCATION_CHARTS = [
+    { kind: 'skill', title: 'Skills invoked', color: '#7c4fff' },
+    { kind: 'agent', title: 'Agent subtypes', color: '#ff6b6b' },
+    { kind: 'command', title: 'Slash commands', color: '#4a9eff' },
+  ];
+
+  function appendToolsAndModels(host, fs, chartFn) {
+    var toolAgg = new Map();
+    fs.forEach(function (s) {
+      (s.tools || []).forEach(function (t) {
+        var cur = toolAgg.get(t.toolName) || { total: 0, success: 0, failure: 0 };
+        cur.total += t.totalCalls; cur.success += t.successCount; cur.failure += t.failureCount;
+        toolAgg.set(t.toolName, cur);
+      });
+    });
+    var tools = Array.from(toolAgg.entries()).map(function (e) { return { name: e[0], total: e[1].total, success: e[1].success, rate: e[1].total ? Math.round((e[1].success / e[1].total) * 100) : 0 }; })
+      .sort(function (a, b) { return b.total - a.total; });
+    var maxTool = tools.length ? tools[0].total : 1;
+
+    var row = el('div', 'grid-2 mb16');
+    var toolCard = card('Tool usage & success rate');
+    tools.slice(0, 12).forEach(function (t) {
+      var bar = el('div', 'bar-row');
+      var color = t.rate >= 90 ? '#259F4C' : (t.rate >= 70 ? '#F5A534' : '#F9303C');
+      bar.innerHTML = '<span class="nm">' + esc(t.name) + '</span><div class="bar-track"><div class="bar-fill" style="width:' + Math.max(3, (t.total / maxTool) * 100) + '%;background:' + color + '"></div></div><span class="vl">' + fmtNum(t.total) + ' · ' + t.rate + '%</span>';
+      toolCard._body.appendChild(bar);
+    });
+    if (!tools.length) toolCard._body.appendChild(el('div', 'empty', 'No per-tool data.'));
+    row.appendChild(toolCard);
+
+    var modelAgg = new Map();
+    fs.forEach(function (s) { (s.perModelCost || []).forEach(function (m) { modelAgg.set(m.model, (modelAgg.get(m.model) || 0) + (m.tokens ? m.tokens.total : 0)); }); });
+    var modelCard = card('Tokens by model');
+    var mEntries = Array.from(modelAgg.entries()).sort(function (a, b) { return b[1] - a[1]; }).slice(0, 8);
+    if (mEntries.length) {
+      chartFn(canvasIn(modelCard._body), {
+        type: 'bar',
+        data: { labels: mEntries.map(function (e) { return e[0]; }), datasets: [{ data: mEntries.map(function (e) { return e[1]; }), backgroundColor: mEntries.map(function (_, i) { return PALETTE[i % PALETTE.length]; }), borderRadius: 5 }] },
+        options: { indexAxis: 'y', plugins: { legend: { display: false }, tooltip: { callbacks: { label: function (c) { return fmtTokens(c.parsed.x) + ' tokens'; } } } }, scales: { x: { grid: { color: GRID }, ticks: { callback: function (v) { return fmtTokens(v); } } }, y: { grid: { display: false } } } }
+      });
+    } else {
+      modelCard._body.appendChild(el('div', 'empty', 'No token data (sessions unpriced or no native logs).'));
+    }
+    row.appendChild(modelCard);
+    host.appendChild(row);
+  }
+
+  function appendInvocationCharts(host, fs, chartFn) {
+    INVOCATION_CHARTS.forEach(function (def) {
+      var agg = {};
+      fs.forEach(function (s) {
+        dispatchCounts(s, def.kind).forEach(function (x) {
+          agg[x.name] = (agg[x.name] || 0) + x.totalCalls;
+        });
+      });
+      var entries = Object.entries(agg)
+        .sort(function (a, b) { return b[1] - a[1]; })
+        .slice(0, 10);
+
+      var invCard = card(def.title);
+      if (entries.length) {
+        chartFn(canvasIn(invCard._body), {
+          type: 'bar',
+          data: {
+            labels: entries.map(function (e) { return e[0]; }),
+            datasets: [{
+              data: entries.map(function (e) { return e[1]; }),
+              backgroundColor: def.color,
+              borderRadius: 4,
+            }],
+          },
+          options: {
+            indexAxis: 'y',
+            plugins: { legend: { display: false } },
+            scales: {
+              x: { grid: { color: GRID }, ticks: { precision: 0 } },
+              y: { grid: { display: false } },
+            },
+          },
+        });
+      } else {
+        invCard._body.appendChild(el('div', 'empty', 'No data.'));
+      }
+      host.appendChild(invCard);
+    });
+  }
+
   // ---- small DOM builders -------------------------------------------------
   function el(tag, cls, html) { var e = document.createElement(tag); if (cls) e.className = cls; if (html != null) e.innerHTML = html; return e; }
   function card(title, sub) {
@@ -405,92 +492,8 @@
     host.appendChild(el('h2', 'view-title', 'Tools & Models'));
     host.appendChild(el('p', 'view-sub', 'Tool usage across sessions and model token/cost distribution.'));
     if (!fs.length) { host.appendChild(el('div', 'empty', 'No sessions in view.')); return; }
-
-    // aggregate tools across sessions
-    var toolAgg = new Map();
-    fs.forEach(function (s) {
-      (s.tools || []).forEach(function (t) {
-        var cur = toolAgg.get(t.toolName) || { total: 0, success: 0, failure: 0 };
-        cur.total += t.totalCalls; cur.success += t.successCount; cur.failure += t.failureCount;
-        toolAgg.set(t.toolName, cur);
-      });
-    });
-    var tools = Array.from(toolAgg.entries()).map(function (e) { return { name: e[0], total: e[1].total, success: e[1].success, rate: e[1].total ? Math.round((e[1].success / e[1].total) * 100) : 0 }; })
-      .sort(function (a, b) { return b.total - a.total; });
-    var maxTool = tools.length ? tools[0].total : 1;
-
-    var row = el('div', 'grid-2 mb16');
-    var toolCard = card('Tool usage & success rate');
-    tools.slice(0, 12).forEach(function (t) {
-      var bar = el('div', 'bar-row');
-      var color = t.rate >= 90 ? '#259F4C' : (t.rate >= 70 ? '#F5A534' : '#F9303C');
-      bar.innerHTML = '<span class="nm">' + esc(t.name) + '</span><div class="bar-track"><div class="bar-fill" style="width:' + Math.max(3, (t.total / maxTool) * 100) + '%;background:' + color + '"></div></div><span class="vl">' + fmtNum(t.total) + ' · ' + t.rate + '%</span>';
-      toolCard._body.appendChild(bar);
-    });
-    if (!tools.length) toolCard._body.appendChild(el('div', 'empty', 'No per-tool data.'));
-    row.appendChild(toolCard);
-
-    // models by tokens (from perModelCost)
-    var modelAgg = new Map();
-    fs.forEach(function (s) { (s.perModelCost || []).forEach(function (m) { modelAgg.set(m.model, (modelAgg.get(m.model) || 0) + (m.tokens ? m.tokens.total : 0)); }); });
-    var modelCard = card('Tokens by model');
-    var mEntries = Array.from(modelAgg.entries()).sort(function (a, b) { return b[1] - a[1]; }).slice(0, 8);
-    if (mEntries.length) {
-      makeChart(canvasIn(modelCard._body), {
-        type: 'bar',
-        data: { labels: mEntries.map(function (e) { return e[0]; }), datasets: [{ data: mEntries.map(function (e) { return e[1]; }), backgroundColor: mEntries.map(function (_, i) { return PALETTE[i % PALETTE.length]; }), borderRadius: 5 }] },
-        options: { indexAxis: 'y', plugins: { legend: { display: false }, tooltip: { callbacks: { label: function (c) { return fmtTokens(c.parsed.x) + ' tokens'; } } } }, scales: { x: { grid: { color: GRID }, ticks: { callback: function (v) { return fmtTokens(v); } } }, y: { grid: { display: false } } } }
-      });
-    } else {
-      modelCard._body.appendChild(el('div', 'empty', 'No token data (sessions unpriced or no native logs).'));
-    }
-    row.appendChild(modelCard);
-    host.appendChild(row);
-
-    // ── Named invocation charts ──────────────────────────────────────────────
-    var invocationDefs = [
-      { field: 'skillInvocations',   title: 'Skills invoked',  color: '#7c4fff' },
-      { field: 'agentInvocations',   title: 'Agent subtypes',  color: '#ff6b6b' },
-      { field: 'commandInvocations', title: 'Slash commands',  color: '#4a9eff' },
-    ];
-
-    invocationDefs.forEach(function (def) {
-      var agg = {};
-      fs.forEach(function (s) {
-        (s[def.field] || []).forEach(function (x) {
-          agg[x.name] = (agg[x.name] || 0) + x.totalCalls;
-        });
-      });
-      var entries = Object.entries(agg)
-        .sort(function (a, b) { return b[1] - a[1]; })
-        .slice(0, 10);
-
-      var invCard = card(def.title);
-      if (entries.length) {
-        makeChart(canvasIn(invCard._body), {
-          type: 'bar',
-          data: {
-            labels: entries.map(function (e) { return e[0]; }),
-            datasets: [{
-              data: entries.map(function (e) { return e[1]; }),
-              backgroundColor: def.color,
-              borderRadius: 4,
-            }],
-          },
-          options: {
-            indexAxis: 'y',
-            plugins: { legend: { display: false } },
-            scales: {
-              x: { grid: { color: GRID }, ticks: { precision: 0 } },
-              y: { grid: { display: false } },
-            },
-          },
-        });
-      } else {
-        invCard._body.appendChild(el('div', 'empty', 'No data.'));
-      }
-      host.appendChild(invCard);
-    });
+    appendToolsAndModels(host, fs, makeChart);
+    appendInvocationCharts(host, fs, makeChart);
   };
 
   VIEWS.activity = function (host, fs) {
@@ -819,10 +822,17 @@
   };
 
   // ---- session-detail modal ----------------------------------------------
-  var modalChart = null; // owned by the modal; NOT in the global charts[] (decoupled from destroyCharts()).
+  var modalCharts = []; // owned by the modal; NOT in the global charts[] (decoupled from destroyCharts()).
   var modalEsc = null;
+  function makeModalChart(canvas, config) {
+    if (!window.Chart) return null;
+    var c = new Chart(canvas, config);
+    modalCharts.push(c);
+    return c;
+  }
   function closeSessionModal() {
-    if (modalChart) { try { modalChart.destroy(); } catch (e) {} modalChart = null; }
+    modalCharts.forEach(function (c) { try { c.destroy(); } catch (e) {} });
+    modalCharts = [];
     if (modalEsc) { document.removeEventListener('keydown', modalEsc); modalEsc = null; }
     var ov = document.getElementById('session-modal'); if (ov && ov.parentNode) ov.parentNode.removeChild(ov);
   }
@@ -870,33 +880,139 @@
     row.appendChild(el('div', 'tl-label' + (strong ? ' tl-label-strong' : ''), esc(label)));
     var track = el('div', 'tl-track');
     var bar = el('div', 'tl-bar');
-    bar.style.left = leftPct + '%'; bar.style.width = wPct + '%'; bar.style.background = color;
-    if (barText) bar.innerHTML = '<span class="tl-bar-text">' + esc(barText) + '</span>'; // only wide (session) bar
+    bar.style.left = 'calc(min(' + leftPct + '%, 100% - 28px))'; bar.style.width = wPct + '%'; bar.style.background = color;
+    if (barText) {
+      bar.classList.add('tl-bar-has-text');
+      bar.innerHTML = '<span class="tl-bar-text">' + esc(barText) + '</span>';
+    }
     bar.title = label + ' · ' + durText; // .title property = safe (not parsed as HTML)
     track.appendChild(bar); row.appendChild(track);
     row.appendChild(el('div', 'tl-dur', esc(durText)));
     return row;
   }
-  // Gantt of top-level agent dispatches: session span on top, each dispatch positioned by start.
+  // Precise wall-clock timing for short timeline steps. The general report formatter rounds
+  // sub-minute values up to one minute, which is useful for sessions but misleading here.
+  function fmtTimelineDuration(ms) {
+    ms = Math.max(0, ms || 0);
+    if (ms < 1000) return Math.round(ms) + 'ms';
+    if (ms < 60000) return (Math.round(ms / 100) / 10) + 's';
+    if (ms < 3600000) return Math.floor(ms / 60000) + 'm ' + Math.round((ms % 60000) / 1000) + 's';
+    return Math.floor(ms / 3600000) + 'h ' + Math.round((ms % 3600000) / 60000) + 'm';
+  }
+  // Side panel content for a selected timeline step.
+  function tlDetailEl(d) {
+    var panel = el('div', '');
+    if (!d) {
+      panel.appendChild(el('div', 'tl-side-empty', 'Click a timeline step to see details.'));
+      return panel;
+    }
+    var color = PALETTE[hashStr(d.kind + ':' + d.name) % PALETTE.length];
+    var nameEl = el('div', 'tl-side-name');
+    var dot = el('span', 'tl-side-dot'); dot.style.background = color;
+    nameEl.appendChild(dot);
+    nameEl.appendChild(document.createTextNode(d.kind + ' · ' + d.name));
+    panel.appendChild(nameEl);
+    var hasCost = d.costUSD != null;
+    var hasTok = d.tokens != null;
+    panel.appendChild(statsEl([
+      ['Cost', hasCost ? fmtUSD(d.costUSD) : '—', ''],
+      ['Tokens', hasTok ? fmtTokens(d.tokens.total) : '—', ''],
+      ['Duration', fmtTimelineDuration(d.durationMs), ''],
+    ]));
+    if (hasTok) {
+      var tok = d.tokens;
+      var total = Math.max(tok.total, 1);
+      var barEl = el('div', 'tl-tok-bar');
+      var segs = [
+        { val: tok.input,         color: '#7C5CFC' },
+        { val: tok.output,        color: '#F5A534' },
+        { val: tok.cacheRead,     color: '#259F4C' },
+        { val: tok.cacheCreation, color: '#3B82F6' },
+      ].filter(function(s) { return s.val > 0; });
+      segs.forEach(function(s) {
+        var seg = el('div', 'tl-tok-seg');
+        seg.style.flex = String(s.val / total * 100);
+        seg.style.background = s.color;
+        barEl.appendChild(seg);
+      });
+      var tokSec = el('div', 'tl-side-section');
+      tokSec.appendChild(el('div', 'tl-side-label', 'Token breakdown'));
+      tokSec.appendChild(barEl);
+      tokSec.appendChild(statsEl([
+        ['Input',       fmtTokens(tok.input),         ''],
+        ['Output',      fmtTokens(tok.output),        ''],
+        ['Cache read',  fmtTokens(tok.cacheRead),     ''],
+        ['Cache write', fmtTokens(tok.cacheCreation), ''],
+      ]));
+      panel.appendChild(tokSec);
+    }
+    if (d.tools && d.tools.length) {
+      var toolSec = el('div', 'tl-side-section');
+      toolSec.appendChild(el('div', 'tl-side-label', 'Tools called'));
+      var chips = el('div', 'modal-chips');
+      d.tools.forEach(function(t) {
+        chips.appendChild(el('span', 'chip', esc(t.name) + '<b>\xd7' + fmtNum(t.calls) + '</b>'));
+      });
+      toolSec.appendChild(chips);
+      panel.appendChild(toolSec);
+    }
+    return panel;
+  }
+  // Gantt of top-level agent dispatches: session span on top, each agent bar positioned
+  // by wall-clock start time relative to the session start (proportional scaling).
+  // Skills and commands are excluded — they have no separate transcript or cost to show.
+  // min-width 28px (CSS) keeps short agents visible and clickable without distorting the scale.
   function timelineEl(s) {
-    var agents = (s.dispatches || []).filter(function (d) { return d.kind === 'agent'; });
-    var start = s.startTime;
-    var end = start + (s.durationMs || 0);
-    (s.dispatches || []).forEach(function (d) { var e = d.start + (d.durationMs || 0); if (e > end) end = e; });
-    var span = Math.max(1, end - start);
-    var wrap = el('div', 'timeline');
-    wrap.appendChild(tlRow('session', '#259F4C', 0, 100, fmtDuration(s.durationMs || 0), fmtUSD(s.costUSD), true));
+    var dispatches = (s.dispatches || []).filter(function (d) { return d.kind === 'agent'; }).sort(function (a, b) { return a.start - b.start; });
+    // Scale bars to the agent activity window, not the full session duration.
+    // Agent bars fill the track proportionally relative to each other; absolute
+    // start offset (vs. session start) is shown in the side panel detail view.
+    var actStart = dispatches.length ? dispatches.reduce(function (m, d) { return Math.min(m, d.start); }, Infinity) : s.startTime;
+    var actEnd = dispatches.length ? dispatches.reduce(function (m, d) { return Math.max(m, d.start + (d.durationMs || 0)); }, -Infinity) : s.startTime + s.durationMs;
+    var ganttSpan = Math.max(1, actEnd - actStart);
+
+    var container = el('div', 'tl-container');
+    var gantt = el('div', 'tl-gantt timeline');
+    var sidePane = el('div', 'tl-side');
+
+    var selected = dispatches[0] || null;
+    sidePane.appendChild(tlDetailEl(selected));
+
+    function selectDispatch(d, barEl) {
+      gantt.querySelectorAll('.tl-bar[data-dispatch]').forEach(function(b) {
+        b.style.outline = b === barEl ? '2px solid rgba(255,255,255,0.55)' : 'none';
+      });
+      sidePane.innerHTML = '';
+      sidePane.appendChild(tlDetailEl(d));
+    }
+
+    gantt.appendChild(tlRow('session', '#259F4C', 0, 100, fmtTimelineDuration(s.durationMs), fmtUSD(s.costUSD), true));
+
     var occ = {};
-    agents.forEach(function (d) {
-      var total = agents.filter(function (x) { return x.name === d.name; }).length;
-      occ[d.name] = (occ[d.name] || 0) + 1;
-      var label = d.name + (total > 1 ? ' #' + occ[d.name] : '');
-      var leftPct = ((d.start - start) / span) * 100;
-      var wPct = Math.max(((d.durationMs || 0) / span) * 100, 1.5);
-      if (leftPct + wPct > 100) leftPct = Math.max(0, 100 - wPct);
-      wrap.appendChild(tlRow(label, PALETTE[hashStr(d.name) % PALETTE.length], leftPct, wPct, fmtDuration(d.durationMs || 0), '', false));
+    dispatches.forEach(function (d) {
+      var key = d.kind + ':' + d.name;
+      var total = dispatches.filter(function (x) { return x.kind === d.kind && x.name === d.name; }).length;
+      occ[key] = (occ[key] || 0) + 1;
+      var label = d.kind + ' · ' + d.name + (total > 1 ? ' #' + occ[key] : '');
+      var leftPct = Math.max(0, (d.start - actStart) / ganttSpan * 100);
+      var wPct = (d.durationMs || 0) / ganttSpan * 100;
+      if (leftPct + wPct > 100) wPct = Math.max(0, 100 - leftPct);
+      var barText = d.costUSD != null && wPct >= 8 ? fmtUSD(d.costUSD) : '';
+      var color = PALETTE[hashStr(key) % PALETTE.length];
+      var row = tlRow(label, color, leftPct, wPct, fmtTimelineDuration(d.durationMs), barText, false);
+      var bar = row.querySelector('.tl-bar');
+      if (bar) {
+        bar.setAttribute('data-dispatch', key);
+        if (d === selected) bar.style.outline = '2px solid rgba(255,255,255,0.55)';
+      }
+      row.style.cursor = 'pointer';
+      row.addEventListener('click', function () { selectDispatch(d, bar); });
+      gantt.appendChild(row);
     });
-    return wrap;
+
+    container.appendChild(gantt);
+    container.appendChild(sidePane);
+    return container;
   }
   function openSessionModal(s, onBack) {
     if (!s) return;
@@ -966,7 +1082,7 @@
       var t0 = series[0].t;
       var labels = series.map(function (p) { return useTs ? fmtDuration(Math.max(0, p.t - t0)) : ('turn ' + p.t); });
       var cv = canvasIn(growth._body, 220);
-      modalChart = new Chart(cv, {
+      makeModalChart(cv, {
         type: 'line',
         data: { labels: labels, datasets: [
           { label: 'Cost ($)', data: series.map(function (p) { return Math.round(p.cost * 10000) / 10000; }), borderColor: '#7C5CFC', backgroundColor: 'rgba(124,92,252,0.12)', fill: true, yAxisID: 'y', tension: 0.25, pointRadius: 0 },
@@ -982,23 +1098,20 @@
     }
     body.appendChild(growth);
 
-    // Timeline — Gantt of top-level agent dispatches with durations (per-agent cost is not captured).
-    var hasAgents = (s.dispatches || []).some(function (d) { return d.kind === 'agent'; });
-    var tlCard = card('Timeline', hasAgents ? 'agent dispatches over the session · durations (per-agent cost is not captured)' : '');
-    if (hasAgents) {
+    // Timeline — Gantt of all top-level agent, skill, and command dispatches.
+    var hasDispatches = (s.dispatches || []).length > 0;
+    var hasCostData = (s.dispatches || []).some(function (d) { return d.kind === 'agent' && d.costUSD != null; });
+    var tlSubtitle = hasDispatches ? (hasCostData ? 'click a step for cost, token & timing details · long idle gaps compressed' : 'click a step for timing details · long idle gaps compressed') : '';
+    var tlCard = card('Timeline', tlSubtitle);
+    if (hasDispatches) {
       tlCard._body.appendChild(timelineEl(s));
     } else {
-      tlCard._body.appendChild(el('div', 'empty', 'No sub-agent dispatches recorded for this session.'));
+      tlCard._body.appendChild(el('div', 'empty', 'No agent, skill, or command dispatches recorded for this session.'));
     }
     body.appendChild(tlCard);
 
-    // Skills & commands — invoked names + counts.
-    var scCard = card('Skills & commands', 'invoked by name');
-    var cols = el('div', 'dispatch-cols');
-    cols.appendChild(chipsEl('Skills', dispatchCounts(s, 'skill')));
-    cols.appendChild(chipsEl('Commands', dispatchCounts(s, 'command')));
-    scCard._body.appendChild(cols);
-    body.appendChild(scCard);
+    appendToolsAndModels(body, [s], makeModalChart);
+    appendInvocationCharts(body, [s], makeModalChart);
 
     modal.appendChild(body);
     ov.appendChild(modal);

--- a/src/cli/commands/analytics/report/template.html
+++ b/src/cli/commands/analytics/report/template.html
@@ -163,9 +163,21 @@
     .tl-label { width: 168px; flex-shrink: 0; font-size: 12px; color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tl-label-strong { font-weight: 700; }
     .tl-track { position: relative; flex: 1; height: 22px; background: var(--color-bg-tertiary); border-radius: 5px; overflow: hidden; }
-    .tl-bar { position: absolute; top: 0; height: 100%; min-width: 3px; border-radius: 5px; display: flex; align-items: center; padding: 0 8px; box-sizing: border-box; }
+    .tl-bar { position: absolute; top: 0; height: 100%; min-width: 28px; border-radius: 5px; display: flex; align-items: center; padding: 0; box-sizing: border-box; }
+    .tl-bar-has-text { padding: 0 8px; }
     .tl-bar-text { font-size: 10.5px; color: #fff; font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 600; }
-    .tl-dur { width: 58px; flex-shrink: 0; text-align: right; font-size: 11px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+    .tl-dur { width: 72px; flex-shrink: 0; text-align: right; font-size: 10.5px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+    /* timeline split layout: gantt left + side panel right */
+    .tl-container { display: flex; gap: 16px; align-items: flex-start; }
+    .tl-gantt { flex: 1; min-width: 0; }
+    .tl-side { width: 230px; flex-shrink: 0; border-left: 1px solid var(--color-border-structural); padding-left: 14px; min-height: 60px; }
+    .tl-side-empty { font-size: 12px; color: var(--color-text-muted); }
+    .tl-side-name { font-size: 12px; font-weight: 700; color: var(--color-text-primary); margin-bottom: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; gap: 6px; }
+    .tl-side-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .tl-side-section { margin-top: 8px; }
+    .tl-side-label { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 4px; }
+    .tl-tok-bar { display: flex; gap: 2px; height: 5px; border-radius: 3px; overflow: hidden; margin-bottom: 4px; }
+    .tl-tok-seg { border-radius: 2px; }
 
     /* session-detail modal */
     .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.62); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal, 50); padding: 24px; }
@@ -195,9 +207,21 @@
     .tl-label { width: 168px; flex-shrink: 0; font-size: 12px; color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tl-label-strong { font-weight: 700; }
     .tl-track { position: relative; flex: 1; height: 22px; background: var(--color-bg-tertiary); border-radius: 5px; overflow: hidden; }
-    .tl-bar { position: absolute; top: 0; height: 100%; min-width: 3px; border-radius: 5px; display: flex; align-items: center; padding: 0 8px; box-sizing: border-box; }
+    .tl-bar { position: absolute; top: 0; height: 100%; min-width: 28px; border-radius: 5px; display: flex; align-items: center; padding: 0; box-sizing: border-box; }
+    .tl-bar-has-text { padding: 0 8px; }
     .tl-bar-text { font-size: 10.5px; color: #fff; font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 600; }
-    .tl-dur { width: 58px; flex-shrink: 0; text-align: right; font-size: 11px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+    .tl-dur { width: 72px; flex-shrink: 0; text-align: right; font-size: 10.5px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+    /* timeline split layout: gantt left + side panel right */
+    .tl-container { display: flex; gap: 16px; align-items: flex-start; }
+    .tl-gantt { flex: 1; min-width: 0; }
+    .tl-side { width: 230px; flex-shrink: 0; border-left: 1px solid var(--color-border-structural); padding-left: 14px; min-height: 60px; }
+    .tl-side-empty { font-size: 12px; color: var(--color-text-muted); }
+    .tl-side-name { font-size: 12px; font-weight: 700; color: var(--color-text-primary); margin-bottom: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; gap: 6px; }
+    .tl-side-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .tl-side-section { margin-top: 8px; }
+    .tl-side-label { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 4px; }
+    .tl-tok-bar { display: flex; gap: 2px; height: 5px; border-radius: 3px; overflow: hidden; margin-bottom: 4px; }
+    .tl-tok-seg { border-radius: 2px; }
 
     /* table alignment — the design-system `.table thead tr th` (text-align:left, higher
        specificity) was overriding `.td-number` on numeric <th>, so numeric headers stayed


### PR DESCRIPTION
## Summary

- **Per-agent cost & tokens**: Reads `agent-<id>.meta.json` to match each `Agent` tool_use to its sub-agent transcript, then prices token usage per model and attaches `costUSD` / `tokens` to each dispatch event
- **Clickable Gantt**: Timeline bars are now clickable; selecting a bar opens a side panel with the agent's full cost, token breakdown (input/output/cache), duration, start offset, and top tool call counts
- **Timeline layout fixes**: Gantt scoped to agent-only bars (skills/commands excluded per spec); scale uses agent activity window so bars fill the track; `min-width: 28px` with `calc(min(..., 100%-28px))` prevents right-edge clipping; `tl-dur` column narrowed from 120px to 72px

## Code-review fixes applied

- Removed `description` from agent dispatch name fallback (prevented long/sensitive text leaking into reports)
- `costUSD` now omitted (not set to `$0`) when no model has a pricing entry
- Reverted unrelated `settings.json` telemetry additions to keep them out of this PR scope

## Test plan

- [ ] Open analytics report for a session that has sub-agent dispatches — verify agent bars show cost and token data in the side panel
- [ ] Click each agent bar — verify side panel updates with that agent's breakdown
- [ ] Verify `costUSD` is absent (not `$0`) for agents whose model is not in the pricing table
- [ ] Verify short agents near the session end are visible and clickable (not clipped)
- [ ] Verify skills and commands do not appear as Gantt bars
- [ ] Run `npm run lint && npm run build && npm test` — confirm 2161 tests pass (1 pre-existing failure in `skills.test.ts` unrelated to this branch)