### PR TITLE
ci(ci): use pull_request_target and pass secrets to integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ 'main' ]
-  pull_request:
+  pull_request_target:
     branches: [ '**' ]
   workflow_call:
 
@@ -12,7 +12,7 @@ jobs:
   validate-commits:
     name: Validate Commits & PR
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
 
     steps:
       - name: Checkout code
@@ -92,12 +92,13 @@ jobs:
     name: Secrets Detection
     runs-on: ubuntu-latest
     # Run in parallel with validate-commits
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Run Gitleaks
@@ -119,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -151,10 +154,13 @@ jobs:
     name: Test (Ubuntu)
     runs-on: ubuntu-latest
     needs: [build]
+    environment: integration
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -176,16 +182,22 @@ jobs:
         run: npm run test:unit
 
       - name: Run integration tests
+        env:
+          CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
+          CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
         run: npm run test:integration
 
   test-windows:
     name: Test (Windows)
     runs-on: windows-latest
     needs: [build]
+    environment: integration
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -207,4 +219,7 @@ jobs:
         run: npm run test:unit
 
       - name: Run integration tests
+        env:
+          CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
+          CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
         run: npm run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ 'main' ]
+  pull_request:
+    branches: [ '**' ]
   pull_request_target:
     branches: [ '**' ]
   workflow_call:
@@ -12,7 +14,7 @@ jobs:
   validate-commits:
     name: Validate Commits & PR
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
 
     steps:
       - name: Checkout code
@@ -92,7 +94,7 @@ jobs:
     name: Secrets Detection
     runs-on: ubuntu-latest
     # Run in parallel with validate-commits
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Fixes CI for fork PRs where `CI_CODEMIE_USERNAME` and `CI_CODEMIE_PASSWORD` secrets were never available. GitHub blocks secrets for the `pull_request` trigger on fork repos by design. Switching to `pull_request_target` with an `integration` environment (required reviewers) allows secrets to flow while keeping security controlled via manual approval.

## Changes
- Change `pull_request` → `pull_request_target` trigger
- Update all `event_name == 'pull_request'` conditions to `pull_request_target`
- Add explicit `ref: ${{ github.event.pull_request.head.sha || github.sha }}` to all checkout steps so fork code is checked out
- Add `environment: integration` to `test-ubuntu` and `test-windows` jobs (gates secrets access behind required reviewer approval)
- Pass `CI_CODEMIE_USERNAME` and `CI_CODEMIE_PASSWORD` secrets to integration test steps

## Testing
- [ ] Merge this PR and re-run CI on fork PR #334 to confirm secrets are available
- [ ] Verify environment approval gate triggers for fork PRs

## Checklist
- [x] Code follows project standards
- [x] No merge conflicts with `main`