### PR TITLE
ci(ci): skip gitleaks on pull_request_target (unsupported by action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
   secrets-detection:
     name: Secrets Detection
     runs-on: ubuntu-latest
-    # Run in parallel with validate-commits
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    # Run in parallel with validate-commits (pull_request_target not supported by gitleaks-action)
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
The `gitleaks/gitleaks-action` does not support the `pull_request_target` event and errors immediately. Scoping `secrets-detection` back to `pull_request` only fixes this — fork PRs are covered by the `integration` environment approval gate instead.

## Changes
- `secrets-detection` job condition: `pull_request_target` removed, `pull_request` only

## Checklist
- [x] Self-reviewed
- [x] No breaking changes