### PR TITLE
ci(ci): remove pull_request_target and add integration test env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
-  pull_request_target:
-    branches: [ '**' ]
   workflow_call:
 
 jobs:
@@ -14,7 +12,7 @@ jobs:
   validate-commits:
     name: Validate Commits & PR
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout code
@@ -187,6 +185,12 @@ jobs:
         env:
           CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
           CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
+          CI_AGENT_MAX_WORKERS: ${{ secrets.CI_AGENT_MAX_WORKERS }}
+          CI_CODEMIE_AUTH_CLIENT_ID: ${{ secrets.CI_CODEMIE_AUTH_CLIENT_ID }}
+          CI_CODEMIE_AUTH_URL: ${{ secrets.CI_CODEMIE_AUTH_URL }}
+          CI_CODEMIE_MODEL: ${{ secrets.CI_CODEMIE_MODEL }}
+          CI_CODEMIE_URL: ${{ secrets.CI_CODEMIE_URL }}
+          CI_IS_LOCAL_RUN: ${{ secrets.CI_IS_LOCAL_RUN }}
         run: npm run test:integration
 
   test-windows:
@@ -224,4 +228,10 @@ jobs:
         env:
           CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
           CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
+          CI_AGENT_MAX_WORKERS: ${{ secrets.CI_AGENT_MAX_WORKERS }}
+          CI_CODEMIE_AUTH_CLIENT_ID: ${{ secrets.CI_CODEMIE_AUTH_CLIENT_ID }}
+          CI_CODEMIE_AUTH_URL: ${{ secrets.CI_CODEMIE_AUTH_URL }}
+          CI_CODEMIE_MODEL: ${{ secrets.CI_CODEMIE_MODEL }}
+          CI_CODEMIE_URL: ${{ secrets.CI_CODEMIE_URL }}
+          CI_IS_LOCAL_RUN: ${{ secrets.CI_IS_LOCAL_RUN }}
         run: npm run test:integration


### PR DESCRIPTION
## Summary
Removes the `pull_request_target` trigger added in #372 (same-repo PRs work fine with `pull_request`) and expands the secrets passed to integration tests so all required env vars are available.

## Changes
- Remove `pull_request_target` trigger — `pull_request` is sufficient for same-repo PRs
- Restore `event_name` conditions to `pull_request` only
- Add 6 new env vars to both Ubuntu and Windows integration test steps:
  - `CI_AGENT_MAX_WORKERS`
  - `CI_CODEMIE_AUTH_CLIENT_ID`
  - `CI_CODEMIE_AUTH_URL`
  - `CI_CODEMIE_MODEL`
  - `CI_CODEMIE_URL`
  - `CI_IS_LOCAL_RUN`

## Checklist
- [x] Self-reviewed
- [x] No breaking changes