### PR TITLE
ci(ci): use repo vars for integration test env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,12 @@ jobs:
         env:
           CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
           CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
-          CI_AGENT_MAX_WORKERS: ${{ secrets.CI_AGENT_MAX_WORKERS }}
-          CI_CODEMIE_AUTH_CLIENT_ID: ${{ secrets.CI_CODEMIE_AUTH_CLIENT_ID }}
-          CI_CODEMIE_AUTH_URL: ${{ secrets.CI_CODEMIE_AUTH_URL }}
-          CI_CODEMIE_MODEL: ${{ secrets.CI_CODEMIE_MODEL }}
-          CI_CODEMIE_URL: ${{ secrets.CI_CODEMIE_URL }}
-          CI_IS_LOCAL_RUN: ${{ secrets.CI_IS_LOCAL_RUN }}
+          CI_AGENT_MAX_WORKERS: ${{ vars.CI_AGENT_MAX_WORKERS }}
+          CI_CODEMIE_AUTH_CLIENT_ID: ${{ vars.CI_CODEMIE_AUTH_CLIENT_ID }}
+          CI_CODEMIE_AUTH_URL: ${{ vars.CI_CODEMIE_AUTH_URL }}
+          CI_CODEMIE_MODEL: ${{ vars.CI_CODEMIE_MODEL }}
+          CI_CODEMIE_URL: ${{ vars.CI_CODEMIE_URL }}
+          CI_IS_LOCAL_RUN: ${{ vars.CI_IS_LOCAL_RUN }}
         run: npm run test:integration
 
   test-windows:
@@ -228,10 +228,10 @@ jobs:
         env:
           CI_CODEMIE_USERNAME: ${{ secrets.CI_CODEMIE_USERNAME }}
           CI_CODEMIE_PASSWORD: ${{ secrets.CI_CODEMIE_PASSWORD }}
-          CI_AGENT_MAX_WORKERS: ${{ secrets.CI_AGENT_MAX_WORKERS }}
-          CI_CODEMIE_AUTH_CLIENT_ID: ${{ secrets.CI_CODEMIE_AUTH_CLIENT_ID }}
-          CI_CODEMIE_AUTH_URL: ${{ secrets.CI_CODEMIE_AUTH_URL }}
-          CI_CODEMIE_MODEL: ${{ secrets.CI_CODEMIE_MODEL }}
-          CI_CODEMIE_URL: ${{ secrets.CI_CODEMIE_URL }}
-          CI_IS_LOCAL_RUN: ${{ secrets.CI_IS_LOCAL_RUN }}
+          CI_AGENT_MAX_WORKERS: ${{ vars.CI_AGENT_MAX_WORKERS }}
+          CI_CODEMIE_AUTH_CLIENT_ID: ${{ vars.CI_CODEMIE_AUTH_CLIENT_ID }}
+          CI_CODEMIE_AUTH_URL: ${{ vars.CI_CODEMIE_AUTH_URL }}
+          CI_CODEMIE_MODEL: ${{ vars.CI_CODEMIE_MODEL }}
+          CI_CODEMIE_URL: ${{ vars.CI_CODEMIE_URL }}
+          CI_IS_LOCAL_RUN: ${{ vars.CI_IS_LOCAL_RUN }}
         run: npm run test:integration


### PR DESCRIPTION
## Summary
Switch integration test environment variables from `secrets.*` to `vars.*` for non-sensitive configuration values in both Linux and Windows CI jobs.

## Changes
- Replace `secrets.CI_AGENT_MAX_WORKERS` → `vars.CI_AGENT_MAX_WORKERS`
- Replace `secrets.CI_CODEMIE_AUTH_CLIENT_ID` → `vars.CI_CODEMIE_AUTH_CLIENT_ID`
- Replace `secrets.CI_CODEMIE_AUTH_URL` → `vars.CI_CODEMIE_AUTH_URL`
- Replace `secrets.CI_CODEMIE_MODEL` → `vars.CI_CODEMIE_MODEL`
- Replace `secrets.CI_CODEMIE_URL` → `vars.CI_CODEMIE_URL`
- Replace `secrets.CI_IS_LOCAL_RUN` → `vars.CI_IS_LOCAL_RUN`

## Testing
- [ ] Tests added/updated
- [ ] Manual testing done

## Checklist
- [ ] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [ ] No merge conflicts with `main`