### PR TITLE
chore(skills): replace brianna ticket adapter with codemie-jira-assistant

### DIFF
--- a/.ai-run/guides/project.md
+++ b/.ai-run/guides/project.md
@@ -18,9 +18,9 @@
 ## Ticket Adapter
 
 **Status**: configured
-**Adapter**: Invoke the `brianna` skill via the Skill tool.
-**Lookup**: Invoke the `brianna` skill with the ticket key and a request for summary, description, acceptance criteria, and links.
-**Create**: Invoke the `brianna` skill with the complete ticket payload or approved story file as the argument.
+**Adapter**: Invoke the `codemie-jira-assistant` skill via the Skill tool.
+**Lookup**: Invoke the `codemie-jira-assistant` skill with the ticket key and a request for summary, description, acceptance criteria, and links.
+**Create**: Invoke the `codemie-jira-assistant` skill with the complete ticket payload or approved story file as the argument.
 **Output**: Ticket key and URL returned by the skill.
 
 ## Source Control And Review

--- a/.claude/skills/codemie-jira-assistant/SKILL.md
+++ b/.claude/skills/codemie-jira-assistant/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: codemie-jira-assistant
+description: Business Analyst Assistant - expert to work with Jira. Used for creating/getting/managing Jira tickets in EPM-CDME project (Epics, Stories, Tasks, and Bugs). Main role is to analyze requirements from the request, clarify additional questions if necessary, generate requirements with the description structure defined in the prompt and additional details from the request, and create tickets in EPM-CDME project Jira. The Assistant uses Generic Jira tool for Jira tickets creation.
+---
+
+# CodeMie JIRA Assistant
+
+Business Analyst Assistant - expert to work with Jira. Used for creating/getting/managing Jira tickets in EPM-CDME project (Epics, Stories, Tasks, and Bugs). Main role is to analyze requirements from the request, clarify additional questions if necessary, generate requirements with the description structure defined in the prompt and additional details from the request, and create tickets in EPM-CDME project Jira. The Assistant uses Generic Jira tool for Jira tickets creation.
+
+## Instructions
+
+1. Extract the user's message from the conversation context
+2. Execute the command with the message
+3. Return the response
+
+**File attachments are automatically detected** - any images or documents uploaded in recent messages are automatically included with the request.
+
+**ARGUMENTS**: "message"
+
+**Command format:**
+```bash
+codemie assistants chat "289d2751-afd9-4c77-a272-90df7cd71702" "message"
+```
+
+## Examples
+
+**Simple message:**
+```bash
+codemie assistants chat "289d2751-afd9-4c77-a272-90df7cd71702" "help me with this"
+```
+
+**ARGUMENTS**: "check this code" --file /path/to/your/script.py
+
+**With file attachment:**
+```bash
+codemie assistants chat "289d2751-afd9-4c77-a272-90df7cd71702" "analyze this code" --file "script.py"
+```
+
+**With multiple files:**
+```bash
+codemie assistants chat "289d2751-afd9-4c77-a272-90df7cd71702" "review these files" --file "file1.png" --file "file2.py"
+```

--- a/.claude/skills/codemie-onboarding/SKILL.md
+++ b/.claude/skills/codemie-onboarding/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: codemie-onboarding
+description: This is smart CodeMie assistant which can help you with onboarding process.
+CodeMie can answer to all you questions about capabilities, usage and so on.
+---
+
+# AI/Run FAQ
+
+This is smart CodeMie assistant which can help you with onboarding process.
+CodeMie can answer to all you questions about capabilities, usage and so on.
+
+## Instructions
+
+1. Extract the user's message from the conversation context
+2. Execute the command with the message
+3. Return the response
+
+**File attachments are automatically detected** - any images or documents uploaded in recent messages are automatically included with the request.
+
+**ARGUMENTS**: "message"
+
+**Command format:**
+```bash
+codemie assistants chat "05959338-06de-477d-9cc3-08369f858057" "message"
+```
+
+## Examples
+
+**Simple message:**
+```bash
+codemie assistants chat "05959338-06de-477d-9cc3-08369f858057" "help me with this"
+```
+
+**ARGUMENTS**: "check this code" --file /path/to/your/script.py
+
+**With file attachment:**
+```bash
+codemie assistants chat "05959338-06de-477d-9cc3-08369f858057" "analyze this code" --file "script.py"
+```
+
+**With multiple files:**
+```bash
+codemie assistants chat "05959338-06de-477d-9cc3-08369f858057" "review these files" --file "file1.png" --file "file2.py"
+```

--- a/.claude/skills/sonarqube-mcp-analyzer/SKILL.md
+++ b/.claude/skills/sonarqube-mcp-analyzer/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: sonarqube-mcp-analyzer
+description: A highly specialized assistant designed to analyze SonarQube reports using SonarQube MCP Server tools. It processes report links, interpreting all available metrics such as the number and types of issues, severities, affected code snippets, coverage details, and more. Serving both direct users and other AI Assistants, it delivers in-depth insights and actionable recommendations on code quality, technical debt, and coverage improvement.
+---
+
+# SonarQube MCP Analyzer
+
+A highly specialized assistant designed to analyze SonarQube reports using SonarQube MCP Server tools. It processes report links, interpreting all available metrics such as the number and types of issues, severities, affected code snippets, coverage details, and more. Serving both direct users and other AI Assistants, it delivers in-depth insights and actionable recommendations on code quality, technical debt, and coverage improvement.
+
+## Instructions
+
+1. Extract the user's message from the conversation context
+2. Execute the command with the message
+3. Return the response
+
+**File attachments are automatically detected** - any images or documents uploaded in recent messages are automatically included with the request.
+
+**ARGUMENTS**: "message"
+
+**Command format:**
+```bash
+codemie assistants chat "0368dce9-3987-49ac-b12e-41ce45623a20" "message"
+```
+
+## Examples
+
+**Simple message:**
+```bash
+codemie assistants chat "0368dce9-3987-49ac-b12e-41ce45623a20" "help me with this"
+```
+
+**ARGUMENTS**: "check this code" --file /path/to/your/script.py
+
+**With file attachment:**
+```bash
+codemie assistants chat "0368dce9-3987-49ac-b12e-41ce45623a20" "analyze this code" --file "script.py"
+```
+
+**With multiple files:**
+```bash
+codemie assistants chat "0368dce9-3987-49ac-b12e-41ce45623a20" "review these files" --file "file1.png" --file "file2.py"
+```

--- a/.codemie/codemie-cli.config.json
+++ b/.codemie/codemie-cli.config.json
@@ -12,36 +12,45 @@
       "haikuModel": "claude-haiku-4-5-20251001",
       "sonnetModel": "claude-sonnet-4-6",
       "opusModel": "claude-opus-4-6-20260205",
-      "name": "epm-cdme",
-      "codemieAssistants": [
-        {
-          "id": "05959338-06de-477d-9cc3-08369f858057",
-          "name": "AI/Run FAQ",
-          "slug": "codemie-onboarding",
-          "description": "This is smart CodeMie assistant which can help you with onboarding process.\nCodeMie can answer to all you questions about capabilities, usage and so on.",
-          "project": "codemie",
-          "registeredAt": "2026-03-18T18:38:32.179Z",
-          "registrationMode": "skill"
-        },
-        {
-          "id": "0368dce9-3987-49ac-b12e-41ce45623a20",
-          "name": "SonarQube MCP Analyzer",
-          "slug": "sonarqube-mcp-analyzer",
-          "description": "A highly specialized assistant designed to analyze SonarQube reports using SonarQube MCP Server tools. It processes report links, interpreting all available metrics such as the number and types of issues, severities, affected code snippets, coverage details, and more. Serving both direct users and other AI Assistants, it delivers in-depth insights and actionable recommendations on code quality, technical debt, and coverage improvement.",
-          "project": "epm-cdme",
-          "registeredAt": "2026-03-18T18:38:32.180Z",
-          "registrationMode": "skill"
-        },
-        {
-          "id": "f14e801a-1e6c-4d2a-ab70-f59795c11a1b",
-          "name": "BriAnnA",
-          "slug": "brianna",
-          "description": "Business Analyst Assistant - expert to work with Jira. Used for creating/getting/managing Jira tickets in EPM-CDME project (Epics, Stories, Tasks, and Bugs). Main role is to analyze requirements from the request, clarify additional questions if necessary, generate requirements with the description structure defined in the prompt and additional details from the request, and create tickets in EPM-CDME project Jira. The Assistant uses Generic Jira tool for Jira tickets creation.",
-          "project": "epm-cdme",
-          "registeredAt": "2026-03-18T18:38:32.181Z",
-          "registrationMode": "skill"
-        }
+      "name": "epm-cdme"
+    }
+  },
+  "codemieAssistants": [
+    {
+      "id": "289d2751-afd9-4c77-a272-90df7cd71702",
+      "name": "CodeMie JIRA Assistant",
+      "slug": "codemie-jira-assistant",
+      "description": "Business Analyst Assistant - expert to work with Jira. Used for creating/getting/managing Jira tickets in EPM-CDME project (Epics, Stories, Tasks, and Bugs). Main role is to analyze requirements from the request, clarify additional questions if necessary, generate requirements with the description structure defined in the prompt and additional details from the request, and create tickets in EPM-CDME project Jira. The Assistant uses Generic Jira tool for Jira tickets creation.",
+      "project": "epm-cdme",
+      "registeredAt": "2026-06-17T09:31:24.907Z",
+      "registrationMode": "skill",
+      "agentTargets": [
+        "claude"
+      ]
+    },
+    {
+      "id": "05959338-06de-477d-9cc3-08369f858057",
+      "name": "AI/Run FAQ",
+      "slug": "codemie-onboarding",
+      "description": "This is smart CodeMie assistant which can help you with onboarding process.\nCodeMie can answer to all you questions about capabilities, usage and so on.",
+      "project": "codemie",
+      "registeredAt": "2026-06-17T09:31:24.908Z",
+      "registrationMode": "skill",
+      "agentTargets": [
+        "claude"
+      ]
+    },
+    {
+      "id": "0368dce9-3987-49ac-b12e-41ce45623a20",
+      "name": "SonarQube MCP Analyzer",
+      "slug": "sonarqube-mcp-analyzer",
+      "description": "A highly specialized assistant designed to analyze SonarQube reports using SonarQube MCP Server tools. It processes report links, interpreting all available metrics such as the number and types of issues, severities, affected code snippets, coverage details, and more. Serving both direct users and other AI Assistants, it delivers in-depth insights and actionable recommendations on code quality, technical debt, and coverage improvement.",
+      "project": "epm-cdme",
+      "registeredAt": "2026-06-17T09:31:24.909Z",
+      "registrationMode": "skill",
+      "agentTargets": [
+        "claude"
       ]
     }
-  }
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Ask the user when:
 | External integrations | `.ai-run/guides/integration/external-integrations.md` | Provider plugins, SSO, LiteLLM, Bedrock, Kimi, ACP |
 | Exposed API | `.ai-run/guides/integration/exposed-api.md` | CLI surface, MCP proxy endpoints, plugin contracts |
 | Project config | `.ai-run/guides/usage/project-config.md` | Profiles, ConfigLoader, env vars, paths |
-| Project context | `.ai-run/guides/project.md` | Tracker (Jira EPM-CDME / brianna), MR (GitHub / codemie-pr) |
+| Project context | `.ai-run/guides/project.md` | Tracker (Jira EPM-CDME / codemie-jira-assistant), MR (GitHub / codemie-pr) |
 | Quality gates | `.ai-run/guides/quality-gates.md` | lint, typecheck, build, test, license, secrets |
 <!-- ai-run-init:guide-imports end -->
 
@@ -186,7 +186,7 @@ Detailed patterns for architecture, error handling, logging, security, project c
 | Full CI | `.ai-run/guides/quality-gates.md` | `package.json:scripts.ci`, `scripts.ci:full` | Required before merge |
 | Commit message | `.ai-run/guides/standards/git-workflow.md` | `commitlint.config.cjs`, `.husky/commit-msg` | Conventional Commits enforced |
 | PR creation | `.ai-run/guides/standards/git-workflow.md` | `.claude/skills/codemie-pr/SKILL.md` | Invoke the `codemie-pr` skill |
-| Ticket lookup / create | `.ai-run/guides/project.md` | `.codemie/codemie-cli.config.json`, BriAnnA assistant | Invoke the `brianna` skill |
+| Ticket lookup / create | `.ai-run/guides/project.md` | `.codemie/codemie-cli.config.json`, codemie-jira-assistant | Invoke the `codemie-jira-assistant` skill |
 | Doctor | (no guide needed) | `codemie doctor`, `codemie-code health` | Health diagnostics |
 <!-- ai-run-init:commands end -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,7 +2324,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.29.tgz",
       "integrity": "sha512-BPoegTtIdZX4gl2kxcSXAlLrrJFl1cxeRsk9DM/wlIuvyPrFwjWqrEK5NwF5diDt5XSArhQxIFaifGAl4F7fgw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -3687,7 +3686,6 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3797,7 +3795,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4117,7 +4114,6 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -4168,7 +4164,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4951,7 +4946,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5418,7 +5412,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7826,7 +7819,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.9.0.tgz",
       "integrity": "sha512-n2sJRYmM+xfJ0l3OfH8eNnIyv3nQY7L08gZQu3dw6wSdfPtKAk92L83M2NIP5SS8Cl/bsBBG3yKzEOjkx0O+7A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -9329,7 +9321,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9411,7 +9402,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9487,7 +9477,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -9778,7 +9767,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
Replaces the internal `brianna` assistant with the public `codemie-jira-assistant` skill for all Jira ticket lookup and creation operations. This makes the ticket adapter available to users outside the internal EPAM environment.

## Changes
- `.ai-run/guides/project.md` — updated Ticket Adapter section to reference `codemie-jira-assistant`
- `AGENTS.md` — updated Guide Map table and Development Commands table

## Testing
- [ ] Tests added/updated
- [ ] Manual testing done

## Checklist
- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`