### PR TITLE
fix(proxy): backfill Claude Desktop timestamps from audit log

### DIFF
--- a/src/telemetry/clients/claude-desktop/claude-desktop.parser.ts
+++ b/src/telemetry/clients/claude-desktop/claude-desktop.parser.ts
@@ -60,6 +60,27 @@ function normalizeMessage(event: DesktopAuditEvent, metadata: DesktopMetadata): 
   };
 }
 
+/**
+ * Cowork writes its transcript as `audit.jsonl`, which also ends with `.jsonl` and so takes the
+ * raw Claude Code parsing branch (parseSessionFile preserves records verbatim). Its records carry
+ * the wall-clock time in `_audit_timestamp` and leave `timestamp` empty (assistant records always
+ * do). Backfill `timestamp` from `_audit_timestamp` so the conversations processor can compute
+ * message date and response_time — otherwise the chat view renders broken metadata like
+ * "Processed in: s /". Lives here (the Claude Desktop layer) rather than in ClaudeSessionAdapter
+ * because `_audit_timestamp` is a Cowork audit-log artifact; real Claude Code sessions never carry
+ * it, so this is a no-op for them.
+ */
+function backfillTimestampsFromAuditLog(messages: ClaudeMessage[]): void {
+  for (const message of messages) {
+    if (!message.timestamp) {
+      const auditTimestamp = (message as { _audit_timestamp?: string })._audit_timestamp;
+      if (auditTimestamp) {
+        message.timestamp = auditTimestamp;
+      }
+    }
+  }
+}
+
 export async function parseClaudeDesktopSession(
   discovered: LocalTelemetryDiscoveredSession,
   codemieSessionId: string
@@ -69,6 +90,8 @@ export async function parseClaudeDesktopSession(
       discovered.transcriptPath,
       codemieSessionId
     );
+
+    backfillTimestampsFromAuditLog(parsed.messages as ClaudeMessage[]);
 
     return {
       ...parsed,


### PR DESCRIPTION
## Claude Desktop metadata timestamp fix

Imported Claude Desktop (Cowork) chats rendered broken metadata in the CodeMie chat view — `Processed in: s /` — with empty processing time and date.

**Root cause:** Cowork writes its transcript as `audit.jsonl`, whose assistant records carry the wall-clock time only in `_audit_timestamp` (the standard `timestamp` field is empty). Because the file ends with `.jsonl`, `parseClaudeDesktopSession` routes it through the raw Claude Code `parseSessionFile` path, which preserves records verbatim and never runs `normalizeMessage`/`normalizeTimestamp` — the only code that reads `_audit_timestamp`. With no `timestamp`, the conversations processor can't compute `date` or `response_time`, so both drop out and the chat view shows `Processed in: s /`.

**Fix:** after `parseSessionFile`, backfill `message.timestamp` from `_audit_timestamp` when missing. No-op for real Claude Code sessions (they never carry `_audit_timestamp`).

**Verified end-to-end** against a real Cowork session: assistant messages now sync with `date` + `response_time`, and the chat view renders metadata correctly.