### PR TITLE
feat(skills): sync msgraph plugin with installed runtime adjustments

### DIFF
--- a/docs/superpowers/tasks/2026-06-18-msgraph-skill-sync-incorporate-global-adjustments/plan.md
+++ b/docs/superpowers/tasks/2026-06-18-msgraph-skill-sync-incorporate-global-adjustments/plan.md
@@ -1,0 +1,691 @@
+# msgraph Skill Sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the 13 substantive adjustments present in the codemie-installed msgraph plugin (`~/.codemie/claude-plugin/skills/msgraph/`) back into the codemie-code source-of-truth at `src/agents/plugins/claude/plugin/skills/msgraph/`, so the in-repo plugin source matches the runtime behaviour users already have.
+
+**Architecture:** Mechanical, line-for-line code port from a known-good runtime copy. No new features designed in this plan — every change is a verbatim copy of code that already runs successfully via the installed plugin. Verification is by normalised diff: after the port, `diff <(normalise src) <(normalise installed)` of both `SKILL.md` and `scripts/msgraph.js` must be empty.
+
+**Tech Stack:** Node.js CLI (vanilla `https`/`URLSearchParams`, no deps). Microsoft Graph v1.0 REST. Plugin loaded by Claude via `${CLAUDE_PLUGIN_ROOT}` placeholder.
+
+**Note on tests:** Per `AGENTS.md` rule 2 ("Tests Only On Explicit Request") and the absence of any existing Vitest coverage targeting plugin skill scripts, every task below is marked `Test-first: no`. Behaviour is already validated in production (the installed plugin is in active use). Verification is the post-port normalised diff.
+
+---
+
+## Files
+
+- **Modify:** `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (1612 → ~1728 LOC, +136/-20 across 13 hunks)
+- **Modify:** `src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md` (+3 lines in `### Channels` section)
+- **Reference (read-only):** `~/.codemie/claude-plugin/skills/msgraph/scripts/msgraph.js`
+- **Reference (read-only):** `~/.codemie/claude-plugin/skills/msgraph/SKILL.md`
+- **Build artefact (regenerated, not hand-edited):** `dist/agents/plugins/claude/plugin/skills/msgraph/**`
+- **Out of scope:** `/Users/Nikita_Levyankov/repos/codemie-ai/codemie-public-skills/skills/productivity/msgraph/**`
+
+---
+
+## Task 1: Set up isolated work environment
+
+**Files:** none modified; branch + worktree state only.
+
+- [ ] **Step 1: Confirm current dirty state is unrelated**
+  Run: `git status --porcelain`
+  Expected: only files under `.ai-run/`, `.codemie/`, `.gitignore`, `AGENTS.md`, `package*.json`, `.claude/skills/playwright-cli/`, `tests/e2e/` — none touching `src/agents/plugins/claude/plugin/skills/msgraph/`.
+
+- [ ] **Step 2: Stash unrelated work**
+  Run: `git stash push -u -m "EPMCDME-12772 WIP — set aside for msgraph sync"`
+  Expected: `Saved working directory and index state On feature/EPMCDME-12772: …`.
+
+- [ ] **Step 3: Refresh main**
+  Run: `git fetch origin && git checkout main && git pull --ff-only origin main`
+  Expected: `Already up to date.` or fast-forward.
+
+- [ ] **Step 4: Create the feature branch**
+  Run: `git checkout -b feature/msgraph-skill-sync-incorporate-installed-adjustments`
+  Expected: `Switched to a new branch 'feature/msgraph-skill-sync-incorporate-installed-adjustments'`.
+  Note: no Jira ticket is currently associated. If a ticket is required by the org's git workflow, run the `brianna` skill to create one and rename the branch to `feature/EPMCDME-<id>-msgraph-skill-sync` before the first commit.
+
+- [ ] **Step 5: Commit** — nothing to commit at this step; branch is empty.
+
+---
+
+## Task 2: Port `httpsRequest` to expose response headers in errors
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` around line 71
+
+**Test-first:** no — port of in-production code; verification by post-port diff.
+
+- [ ] **Step 1: Edit the file**
+  In the `httpsRequest` rejection branch (the `if (res.statusCode >= 400)` arm), add a line populating `err.headers` from the response headers. The final shape:
+  ```js
+  err.statusCode   = res.statusCode;
+  err.responseBody = text;
+  err.responseUrl  = urlStr;
+  err.headers      = res.headers;
+  return reject(err);
+  ```
+
+- [ ] **Step 2: Verify the hunk applied**
+  Run: `grep -n 'err.headers' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: one match around line 74.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): expose response headers on httpsRequest errors"
+  ```
+
+---
+
+## Task 3: Port `graphGet` retry-on-429 loop
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (`graphGet` body around line 97)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Replace the `graphGet` body**
+  Replace the existing two-line implementation:
+  ```js
+  async function graphGet(endpoint, token, params = {}) {
+    const qs  = new URLSearchParams(params).toString();
+    const url = `${GRAPH_BASE}${endpoint}${qs ? '?' + qs : ''}`;
+    const res = await httpsRequest(url, { headers: { Authorization: `Bearer ${token}` } });
+    return JSON.parse(res.body);
+  }
+  ```
+  with the retry-aware version:
+  ```js
+  async function graphGet(endpoint, token, params = {}) {
+    const qs  = new URLSearchParams(params).toString();
+    const url = `${GRAPH_BASE}${endpoint}${qs ? '?' + qs : ''}`;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const res = await httpsRequest(url, { headers: { Authorization: `Bearer ${token}` } });
+        return JSON.parse(res.body);
+      } catch (e) {
+        if (e.statusCode === 429 && attempt < 2) {
+          const ra = parseInt(e.headers?.['retry-after'] || '', 10);
+          const waitS = Number.isFinite(ra) && ra > 0 ? Math.min(60, ra) : Math.min(30, 2 ** attempt * 2);
+          await new Promise(r => setTimeout(r, waitS * 1000));
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+  ```
+
+- [ ] **Step 2: Verify**
+  Run: `grep -n 'retry-after' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: one match in `graphGet`.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): retry graphGet on HTTP 429 with Retry-After honour"
+  ```
+
+---
+
+## Task 4: Port `emails --conversation` flag + extend default `$select`
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (emails handler, lines ~486–491)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Insert the `--conversation` branch**
+  Inside the emails handler, immediately after `const limit  = parseInt(args.limit) || 10;` and before the existing `const params = { … };`, insert:
+  ```js
+  if (args.conversation) {
+    // Graph rejects $orderby with $filter on conversationId ("InefficientFilter").
+    // Pull more rows than asked and sort client-side.
+    const cv = await graphGet('/me/messages', token, {
+      $filter: `conversationId eq '${args.conversation}'`,
+      $top:    Math.max(limit, 25),
+      $select: 'id,subject,from,sentDateTime,receivedDateTime,isRead,bodyPreview,conversationId',
+    });
+    let msgs = cv.value || [];
+    msgs.sort((a, b) => (b.sentDateTime || b.receivedDateTime || '').localeCompare(a.sentDateTime || a.receivedDateTime || ''));
+    msgs = msgs.slice(0, limit);
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    if (!msgs.length) { console.log('No messages in this conversation.'); return; }
+    console.log(`\n${'Sent'.padEnd(16)}  ${'From'.padEnd(28)}  Subject`);
+    console.log('─'.repeat(80));
+    for (const m of msgs) {
+      const from = (m.from?.emailAddress?.name || '').slice(0, 28).padEnd(28);
+      console.log(`${fmtDt(m.sentDateTime || m.receivedDateTime).padEnd(16)}  ${from}  ${(m.subject || '(no subject)').slice(0, 40)}`);
+    }
+    return;
+  }
+  ```
+
+- [ ] **Step 2: Extend default `$select`**
+  Locate `$select:  'id,subject,from,receivedDateTime,isRead,hasAttachments,importance',` and change to:
+  ```js
+  $select:  'id,subject,from,receivedDateTime,isRead,hasAttachments,importance,bodyPreview,conversationId',
+  ```
+
+- [ ] **Step 3: Verify**
+  Run: `grep -n 'conversationId' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: ≥3 matches.
+
+- [ ] **Step 4: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): emails --conversation CONV_ID + bodyPreview in default select"
+  ```
+
+---
+
+## Task 5: Port `teams --chats` to use `lastMessagePreview`
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (teams handler around line 643)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Replace the `--chats` branch**
+  Replace the existing block:
+  ```js
+  if (args.chats) {
+    const data  = await graphGet('/me/chats', token, { $top: limit, $select: 'id,topic,chatType,lastUpdatedDateTime' });
+    const chats = data.value || [];
+    if (args.json) { console.log(JSON.stringify(chats, null, 2)); return; }
+    console.log(`\n${'Chat ID'.padEnd(50)}  ${'Type'.padEnd(10)}  Topic`);
+    console.log('─'.repeat(80));
+    for (const c of chats)
+      console.log(`${(c.id || '').padEnd(50)}  ${(c.chatType || '').padEnd(10)}  ${c.topic || '(direct message)'}`);
+    return;
+  }
+  ```
+  with:
+  ```js
+  if (args.chats) {
+    // $expand=lastMessagePreview returns the true last-message timestamp + body.
+    // Graph's `lastUpdatedDateTime` on the chat is frequently stale (months/years
+    // behind), so callers that need recency MUST read lastMessagePreview.
+    const data  = await graphGet('/me/chats', token, { $top: limit, $expand: 'lastMessagePreview' });
+    const chats = data.value || [];
+    if (args.json) { console.log(JSON.stringify(chats, null, 2)); return; }
+    console.log(`\n${'Chat ID'.padEnd(50)}  ${'Type'.padEnd(10)}  Last msg            Topic`);
+    console.log('─'.repeat(80));
+    for (const c of chats) {
+      const last = c.lastMessagePreview?.createdDateTime || c.lastUpdatedDateTime || '';
+      console.log(`${(c.id || '').padEnd(50)}  ${(c.chatType || '').padEnd(10)}  ${fmtDt(last).padEnd(18)}  ${c.topic || '(direct message)'}`);
+    }
+    return;
+  }
+  ```
+
+- [ ] **Step 2: Verify**
+  Run: `grep -n 'lastMessagePreview' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: ≥2 matches.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): teams --chats reports real last-message time via expand"
+  ```
+
+---
+
+## Task 6: Port `teams --messages` `--max N` pagination
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (teams handler around line 693)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Replace the `--messages` branch**
+  Replace the existing block:
+  ```js
+  if (args.messages) {
+    // Graph returns HTTP 400 if $select is used on the Teams messages endpoint — pass $top only.
+    const data = await graphGet(`/me/chats/${args.messages}/messages`, token, { $top: limit });
+    const msgs = data.value || [];
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    console.log(`\nMessages in chat ${args.messages.slice(0, 20)}...:`);
+    …
+  }
+  ```
+  with the full new branch (rendering loop unchanged from the original):
+  ```js
+  if (args.messages) {
+    // Graph returns HTTP 400 if $select is used on the Teams messages endpoint — pass $top only.
+    // `--max N` paginates via @odata.nextLink up to N messages total (capped per page at 50 by Graph).
+    const max = args.max ? parseInt(args.max, 10) : null;
+    const perPage = max ? Math.min(50, max) : limit;
+    let next = `/me/chats/${args.messages}/messages?$top=${perPage}`;
+    const msgs = [];
+    while (next) {
+      const data = await graphGet(next.replace(GRAPH_BASE, '').replace('https://graph.microsoft.com/v1.0', ''), token, {});
+      for (const m of (data.value || [])) {
+        msgs.push(m);
+        if (max && msgs.length >= max) break;
+      }
+      if (max && msgs.length >= max) break;
+      const nl = data['@odata.nextLink'];
+      if (!nl || !max) break; // no pagination unless --max set
+      next = nl;
+    }
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    console.log(`\nMessages in chat ${args.messages.slice(0, 20)}... (${msgs.length}):`);
+    console.log('─'.repeat(60));
+    for (const m of [...msgs].reverse()) {
+      const sender = m.from?.user?.displayName || 'System';
+      const body   = stripHtml(m.body?.content || '').slice(0, 200);
+      console.log(`[${fmtDt(m.createdDateTime)}] ${sender}: ${body}`);
+    }
+    return;
+  }
+  ```
+  Note: the original branch's rendering loop is preserved verbatim — only the data-fetch portion above it changes.
+
+- [ ] **Step 2: Verify**
+  Run: `grep -n '@odata.nextLink' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: ≥1 match in the teams handler.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): teams --messages --max N paginates via nextLink"
+  ```
+
+---
+
+## Task 7: Port `teams --teams-list` `/me/memberOf` fallback
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (teams handler around line 731)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Replace the `--teams-list` branch**
+  Replace:
+  ```js
+  if (args.teamsList) {
+    const data  = await graphGet('/me/joinedTeams', token, { $select: 'id,displayName,description' });
+    const teams = data.value || [];
+    if (args.json) { console.log(JSON.stringify(teams, null, 2)); return; }
+    for (const t of teams) console.log(`${t.id.slice(0, 36)}  ${t.displayName}`);
+    return;
+  }
+  ```
+  with:
+  ```js
+  if (args.teamsList) {
+    // Prefer /me/joinedTeams (needs Team.ReadBasic.All). Fall back to /me/memberOf
+    // filtered client-side to groups that are also teams (uses Group.Read.All,
+    // which the default scope set already includes).
+    let teams;
+    try {
+      const data = await graphGet('/me/joinedTeams', token, { $select: 'id,displayName,description' });
+      teams = data.value || [];
+    } catch (e) {
+      if (!/403|Forbidden/.test(e.message)) throw e;
+      const data = await graphGet('/me/memberOf', token, { $select: 'id,displayName,description,resourceProvisioningOptions', $top: 200 });
+      teams = (data.value || []).filter(g => Array.isArray(g.resourceProvisioningOptions) && g.resourceProvisioningOptions.includes('Team'));
+    }
+    if (args.json) { console.log(JSON.stringify(teams, null, 2)); return; }
+    for (const t of teams) console.log(`${(t.id || '').slice(0, 36)}  ${t.displayName}`);
+    return;
+  }
+  ```
+
+- [ ] **Step 2: Verify**
+  Run: `grep -n 'resourceProvisioningOptions' src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js`
+  Expected: ≥2 matches.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): teams --teams-list falls back to /me/memberOf on 403"
+  ```
+
+---
+
+## Task 8: Port `channels --list` membershipType + new `channels --members`
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (channels handler around lines 731–746)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Extend `--list` `$select`**
+  Locate the `channels --list` branch and change:
+  ```js
+  const data = await graphGet(`/teams/${args.teamId}/channels`, token, { $select: 'id,displayName,description' });
+  ```
+  to:
+  ```js
+  const data = await graphGet(`/teams/${args.teamId}/channels`, token, { $select: 'id,displayName,description,membershipType' });
+  ```
+
+- [ ] **Step 2: Insert the `--members` branch**
+  Immediately after the `--list` branch closes and before `if (!args.channelId) {`, insert:
+  ```js
+  if (args.members) {
+    // Use the groups endpoint (teamId == groupId) so we don't need Team.ReadBasic.All;
+    // pages through every member of the underlying M365 group.
+    const members = [];
+    let next = `/groups/${args.teamId}/members/microsoft.graph.user`;
+    let params = { $select: 'id,displayName,userPrincipalName,mail', $top: 100 };
+    while (next) {
+      const page = await graphGet(next, token, params);
+      for (const m of page.value || []) members.push(m);
+      const nl = page['@odata.nextLink'];
+      if (!nl) break;
+      // Strip the base + use as endpoint; reuse no extra params (link contains them).
+      next = nl.replace('https://graph.microsoft.com/v1.0', '');
+      params = {};
+    }
+    if (args.json) { console.log(JSON.stringify(members, null, 2)); return; }
+    console.log(`\nTeam members (${members.length}):`);
+    console.log('─'.repeat(60));
+    for (const m of members)
+      console.log(`${(m.displayName || 'N/A').padEnd(34)}  ${m.userPrincipalName || m.mail || ''}`);
+    return;
+  }
+  ```
+
+- [ ] **Step 3: Update the required-args error line**
+  Locate the error-handler block printing the `channels` usage and update:
+  ```js
+  console.log('         --team-id ID --channel-id ID --messages [--limit N]');
+  ```
+  to:
+  ```js
+  console.log('         --team-id ID --channel-id ID --messages [--limit N] [--expand-replies]');
+  ```
+
+- [ ] **Step 4: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): channels --members + membershipType in --list"
+  ```
+
+---
+
+## Task 9: Port `channels --replies MSG_ID` + `channels --messages --expand-replies`
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (channels handler around lines 753–775)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Insert the `--replies` branch**
+  After the `if (!args.channelId) { … }` guard (so we know `channelId` is present), insert:
+  ```js
+  if (args.replies) {
+    // --replies MSG_ID  →  replies to a specific channel message
+    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages/${args.replies}/replies`, token, { $top: limit });
+    const reps = data.value || [];
+    if (args.json) { console.log(JSON.stringify(reps, null, 2)); return; }
+    console.log(`\nReplies to message ${args.replies.slice(0, 20)}...:`);
+    console.log('─'.repeat(60));
+    for (const r of [...reps].sort((a, b) => (a.createdDateTime || '').localeCompare(b.createdDateTime || ''))) {
+      const rs = r.from?.user?.displayName || 'System';
+      const rb = stripHtml(r.body?.content || '').slice(0, 200);
+      console.log(`[${fmtDt(r.createdDateTime)}] ${rs}: ${rb}`);
+    }
+    return;
+  }
+  ```
+
+- [ ] **Step 2: Replace the `channels --messages` branch**
+  Replace the existing simple version (the original includes a `console.log('─'.repeat(60));` line between the header and the loop):
+  ```js
+  if (args.messages) {
+    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages`, token, { $top: limit });
+    const msgs = data.value || [];
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    console.log(`\nMessages in channel ${args.channelId.slice(0, 30)}...:`);
+    console.log('─'.repeat(60));
+    for (const m of [...msgs].reverse()) {
+      const sender = m.from?.user?.displayName || 'System';
+      const body   = stripHtml(m.body?.content || '').slice(0, 200);
+      console.log(`[${fmtDt(m.createdDateTime)}] ${sender}: ${body}`);
+    }
+    return;
+  }
+  ```
+  with the expand-replies-aware version:
+  ```js
+  if (args.messages) {
+    const params = { $top: limit };
+    if (args.expandReplies) params.$expand = 'replies';
+    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages`, token, params);
+    const msgs = data.value || [];
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    console.log(`\nMessages in channel ${args.channelId.slice(0, 30)}...:`);
+    console.log('─'.repeat(60));
+    for (const m of [...msgs].reverse()) {
+      const sender = m.from?.user?.displayName || 'System';
+      const body   = stripHtml(m.body?.content || '').slice(0, 200);
+      console.log(`[${fmtDt(m.createdDateTime)}] ${sender}: ${body}`);
+      if (args.expandReplies && Array.isArray(m.replies) && m.replies.length) {
+        const replies = [...m.replies].sort((a, b) => (a.createdDateTime || '').localeCompare(b.createdDateTime || ''));
+        for (const r of replies) {
+          const rs = r.from?.user?.displayName || 'System';
+          const rb = stripHtml(r.body?.content || '').slice(0, 160);
+          console.log(`    └─ [${fmtDt(r.createdDateTime)}] ${rs}: ${rb}`);
+        }
+      }
+    }
+    return;
+  }
+  ```
+
+- [ ] **Step 3: Update the bottom usage banner inside `runChannels`**
+  Add the replies line to the bottom console.log block that prints when no subcommand matched:
+  ```js
+  console.log('channels --team-id ID --list');
+  console.log('         --team-id ID --channel-id ID --messages [--limit N]');
+  console.log('         --team-id ID --channel-id ID --replies MSG_ID [--limit N]');
+  console.log('         --team-id ID --channel-id ID --send MSG');
+  ```
+
+- [ ] **Step 4: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "feat(msgraph): channels --replies + --messages --expand-replies"
+  ```
+
+---
+
+## Task 10: Port `parseArgs` BOOL set and CLI help banner
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (`parseArgs` around line 1487, help banner around lines 1523/1531)
+
+**Test-first:** no — port.
+
+- [ ] **Step 1: Update the BOOL set**
+  Locate the `BOOL` declaration in `parseArgs` and replace:
+  ```js
+  const BOOL = new Set(['json','unread','sites','chats','teamsList','contacts',
+    'manager','reports','availability','notebooks','list','messages','vtt','help','force',
+    'plans','buckets','tasks','myTasks','lists','insights']);
+  ```
+  with:
+  ```js
+  const BOOL = new Set(['json','unread','sites','chats','teamsList','contacts',
+    'manager','reports','availability','notebooks','list','vtt','help','force',
+    'plans','buckets','tasks','myTasks','lists','insights','expandReplies','members']);
+  ```
+  Note: this removes `'messages'` (it's a value-taking flag everywhere — passing `--messages CHAT_ID` should populate `args.messages = "CHAT_ID"`) and adds `'expandReplies'` + `'members'`.
+
+- [ ] **Step 2: Update help banner — `emails` line**
+  Locate:
+  ```
+    emails [--limit N] [--unread] [--search Q] [--folder NAME]
+           [--read ID] [--send TO --subject S --body B] [--json]
+  ```
+  and change the second line to:
+  ```
+           [--read ID] [--conversation CONV_ID] [--send TO --subject S --body B] [--json]
+  ```
+
+- [ ] **Step 3: Update help banner — `channels` block**
+  Locate:
+  ```
+    channels --team-id ID --list
+             --team-id ID --channel-id ID --messages [--limit N]
+             --team-id ID --channel-id ID --send MSG [--json]
+  ```
+  and change to:
+  ```
+    channels --team-id ID --list
+             --team-id ID --members
+             --team-id ID --channel-id ID --messages [--limit N] [--expand-replies]
+             --team-id ID --channel-id ID --replies MSG_ID [--limit N]
+             --team-id ID --channel-id ID --send MSG [--json]
+  ```
+
+- [ ] **Step 4: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+  git commit -m "fix(msgraph): correct parseArgs BOOL set + document new flags in help"
+  ```
+
+---
+
+## Task 11: Port the `SKILL.md` `--expand-replies` documentation block
+
+**Files:**
+- Modify: `src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md` (`### Channels` section)
+
+**Test-first:** no — pure documentation port.
+
+- [ ] **Step 1: Insert the new doc block**
+  Locate the existing block:
+  ```
+  # Read recent messages in a channel
+  node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --messages
+
+  # Post a message to a channel
+  ```
+  and insert between them:
+  ```
+  # Read messages with their reply threads (needed to detect unanswered/clarification-only threads)
+  node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --messages --expand-replies --json
+  ```
+  Note: use the `${CLAUDE_PLUGIN_ROOT}` placeholder — **NOT** the hardcoded `/Users/Nikita_Levyankov/.codemie/claude-plugin/...` path that exists in the installed copy. The hardcoded paths in the installed SKILL.md are installation artefacts and must not be ported back.
+
+- [ ] **Step 2: Verify**
+  Run: `grep -n 'expand-replies' src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md`
+  Expected: 1 match.
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md
+  git commit -m "docs(msgraph): document --expand-replies usage for channel messages"
+  ```
+
+---
+
+## Task 12: Verify the port via normalised diff
+
+**Files:** none modified; verification only.
+
+**Test-first:** no — this IS the verification.
+
+- [ ] **Step 1: SKILL.md diff (paths normalised)**
+  Run:
+  ```bash
+  diff <(sed 's|${CLAUDE_PLUGIN_ROOT}/skills/msgraph|XPATHX|g; s|/Users/Nikita_Levyankov/.codemie/claude-plugin/skills/msgraph|XPATHX|g' src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md) \
+       <(sed 's|${CLAUDE_PLUGIN_ROOT}/skills/msgraph|XPATHX|g; s|/Users/Nikita_Levyankov/.codemie/claude-plugin/skills/msgraph|XPATHX|g' ~/.codemie/claude-plugin/skills/msgraph/SKILL.md)
+  ```
+  Expected: empty output (zero diff after path normalisation).
+
+- [ ] **Step 2: scripts/msgraph.js diff**
+  Run:
+  ```bash
+  diff src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js ~/.codemie/claude-plugin/skills/msgraph/scripts/msgraph.js
+  ```
+  Expected: empty output. If any hunks remain, identify the missing port and apply it in a follow-up commit before moving on.
+
+- [ ] **Step 3: Smoke-test the script parses**
+  Run:
+  ```bash
+  node src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js --help
+  ```
+  Expected: the help banner prints with the new `--conversation`, `--members`, `--expand-replies`, `--replies` entries visible. No syntax error from Node.
+
+- [ ] **Step 4: Smoke-test a real call (read-only)**
+  Run:
+  ```bash
+  node src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js status
+  ```
+  Expected: prints either "Logged in as …" or "Not logged in" — no stack trace.
+
+- [ ] **Step 5: Commit** — nothing to commit; verification only.
+
+---
+
+## Task 13: Run quality gates
+
+**Files:** none modified; tooling only.
+
+**Test-first:** no — these are gates, not tests of the port.
+
+- [ ] **Step 1: Lint**
+  Run: `npm run lint`
+  Expected: exit 0, no warnings (zero-warning policy per AGENTS.md / quality-gates.md).
+  If lint fails on the ported file, fix the violations inline and re-run.
+
+- [ ] **Step 2: Typecheck**
+  Run: `npm run typecheck`
+  Expected: exit 0.
+  (The msgraph script is plain `.js`; the typecheck still needs to succeed for the rest of the repo.)
+
+- [ ] **Step 3: Build**
+  Run: `npm run build`
+  Expected: exit 0; `dist/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` regenerated with size matching the new src (~1728 LOC).
+  Verification: `wc -l dist/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` reports ~1728.
+
+- [ ] **Step 4: Commit any build artefacts the build script writes**
+  Run: `git status --porcelain`
+  If `dist/` is in `.gitignore` (likely), no commit needed. If `dist/` is tracked, run:
+  ```bash
+  git add dist/agents/plugins/claude/plugin/skills/msgraph
+  git commit -m "build: regenerate dist/msgraph after src sync"
+  ```
+
+- [ ] **Step 5: License + secret scan (if part of project gates)**
+  Run: `npm run check:pre-commit`
+  Expected: exit 0.
+  Per AGENTS.md: do not bypass with `--no-verify` if it fails — investigate and fix.
+
+---
+
+## Task 14: Final review and hand-off
+
+**Files:** none modified.
+
+**Test-first:** no.
+
+- [ ] **Step 1: Branch summary**
+  Run: `git log --oneline main..HEAD`
+  Expected: ~10 commits (Tasks 2–11 each produced one).
+
+- [ ] **Step 2: Diff summary vs main**
+  Run: `git diff --stat main..HEAD`
+  Expected: only `src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js` (+~136/-~20), `src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md` (+3/-0), and any regenerated `dist/` files.
+
+- [ ] **Step 3: Confirm no public-skills drift introduced**
+  Run: `diff -q src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js /Users/Nikita_Levyankov/repos/codemie-ai/codemie-public-skills/skills/productivity/msgraph/scripts/msgraph.js`
+  Expected: files differ (this is the expected drift between codemie-code and the public mirror; a follow-up sync is out of scope per the user's decision).
+  Document the drift in the PR description so a follow-up PR can mirror it.
+
+- [ ] **Step 4: Restore EPMCDME-12772 work (only if user wants to switch back)**
+  This is a hand-off step — do not run unconditionally.
+  ```bash
+  git checkout feature/EPMCDME-12772
+  git stash pop
+  ```
+
+- [ ] **Step 5: Hand off**
+  Print: "Branch `feature/msgraph-skill-sync-incorporate-installed-adjustments` is ready. Invoke `sdlc-factory:mr-creator` to open the PR, and add a follow-up note recommending a separate sync into `codemie-public-skills`."

--- a/docs/superpowers/tasks/2026-06-18-msgraph-skill-sync-incorporate-global-adjustments/technical-analysis.md
+++ b/docs/superpowers/tasks/2026-06-18-msgraph-skill-sync-incorporate-global-adjustments/technical-analysis.md
@@ -1,0 +1,60 @@
+# Technical Analysis: msgraph skill sync
+
+## Investigation
+
+Three copies of the msgraph skill exist on this machine. We compared all three after normalising path differences (the only difference between the placeholder `${CLAUDE_PLUGIN_ROOT}/skills/msgraph` and the user-specific `/Users/Nikita_Levyankov/.codemie/claude-plugin/skills/msgraph`).
+
+| Location | Role | SKILL.md md5 (normalised) | scripts/msgraph.js LOC |
+|---|---|---|---|
+| `codemie-code/src/agents/plugins/claude/plugin/skills/msgraph/` | Source of truth in repo | `408f159fc8a69e2339e5042cc1b6075a` | 1612 |
+| `codemie-public-skills/skills/productivity/msgraph/` | Public mirror | (byte-identical to src) | 1612 |
+| `~/.claude/skills/msgraph/` | Truly global skill | `408f159fc8a69e2339e5042cc1b6075a` (== src) | (no scripts dir) |
+| `~/.codemie/claude-plugin/skills/msgraph/` | codemie-installed plugin | `a83daa91c3fafa4433cf43140a7c5414` | **1728 (+116)** |
+
+The `~/.claude/skills/msgraph/` copy that the user labelled "global" has **no functional adjustments** — it is content-identical to source-of-truth modulo a hardcoded user path. The genuine adjustments live in the codemie-installed plugin at `~/.codemie/claude-plugin/skills/msgraph/`. The decision to treat that as the source for this port was confirmed by the user.
+
+The public-skills mirror is byte-identical to codemie-code/src, so we only need to port to codemie-code/src for now (per user decision).
+
+## Codebase Findings
+
+### scripts/msgraph.js — installed vs src
+
+13 substantive change regions, +136 lines / -20 lines:
+
+1. **`httpsRequest` error object** (`@@ -71`): expose `err.headers = res.headers` so callers can read `Retry-After`.
+2. **`graphGet` retry loop** (`@@ -97`): 3-attempt loop, honours `Retry-After` on HTTP 429, exponential backoff fallback (capped at 60 s).
+3. **`emails` — `--conversation CONV_ID`** (`@@ -486` new branch): fetch all messages in a thread (`$filter conversationId eq …`), sort client-side because Graph rejects `$orderby + $filter conversationId` ("InefficientFilter").
+4. **`emails` default `$select`** (`@@ -491` line): add `bodyPreview` and `conversationId` to the default listing so output carries preview text + thread anchor.
+5. **`teams --chats`** (`@@ -643`): switch to `$expand=lastMessagePreview`. Graph's chat-level `lastUpdatedDateTime` is frequently stale by months/years; the preview carries the real last-message timestamp. New "Last msg" column in the table output.
+6. **`teams --messages …`** (`@@ -693`): add `--max N` pagination via `@odata.nextLink` (capped at 50 per page by Graph). Output now shows total count.
+7. **`teams --teams-list`** (`@@ -731`): fall back to `/me/memberOf` filtered to groups whose `resourceProvisioningOptions` includes `Team` when `/me/joinedTeams` returns 403. Avoids needing `Team.ReadBasic.All` scope.
+8. **`channels --list` `$select`** (`@@ -731`): add `membershipType` field.
+9. **`channels --members`** (`@@ -746` new): list team members via `/groups/{teamId}/members/microsoft.graph.user` (teamId == groupId), paginated. Uses `Group.Read.All` only.
+10. **`channels --replies MSG_ID`** (`@@ -753` new): list replies to one channel message, chronologically.
+11. **`channels --messages --expand-replies`** (`@@ -761`): `$expand=replies` then render the reply tree under each message (max 160-char preview, sorted by `createdDateTime`).
+12. **`parseArgs` BOOL set** (`@@ -1487`): remove `'messages'` (was a parsing bug — `--messages CHAT_ID` set `args.messages=true` and dropped CHAT_ID); add `'expandReplies'` and `'members'`.
+13. **CLI help banner** (`@@ -1523`, `@@ -1531`): documents `--conversation`, `--members`, `--expand-replies`, `--replies`.
+
+### SKILL.md — installed vs src
+
+One change region, +3 lines:
+
+* **`### Channels` section** (between `--messages` and `--send` examples): adds a documented invocation
+  ```
+  # Read messages with their reply threads (needed to detect unanswered/clarification-only threads)
+  node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --messages --expand-replies --json
+  ```
+
+The other ~60 path-only differences in SKILL.md (hardcoded `/Users/…` instead of `${CLAUDE_PLUGIN_ROOT}`) are **installation artefacts and must NOT be ported back** — they would break portability for every other user of the plugin.
+
+### README.md — installed vs src
+
+Byte-identical. No port needed.
+
+## Risk Indicators
+
+1. **No existing test coverage** for `scripts/msgraph.js`. The skill is a standalone Node CLI; the project's Vitest suite does not target plugin skill scripts. AGENTS.md tests-on-explicit-request rule already implies we do not add tests here.
+2. **Parser-bug change is behaviour-altering** (item 12 above). The src treats `--messages` as boolean; the installed plugin treats it as a value-taking flag. Any caller that was relying on the buggy behaviour (passing `--messages CHAT_ID` and somehow handling the resulting 404) will see a behaviour change — but the SKILL.md doc has always told users to invoke it as `--messages CHAT_ID`, so the buggy path is unlikely to be load-bearing.
+3. **Build artefact divergence**: `dist/agents/plugins/claude/plugin/skills/msgraph/` is generated from src by the build pipeline. After the src port, a `npm run build` must regenerate the dist copy so the bundled CLI ships the new version. We will rely on the project's existing build script rather than hand-editing `dist/`.
+4. **codemie-public-skills mirror will drift** after this port. The user explicitly scoped this to codemie-code; a follow-up sync to the public-skills mirror is out of scope but noted here for visibility.
+5. **No new Microsoft Graph scopes required** by any added feature. `lastMessagePreview`, `$expand=replies`, `--conversation`, `/groups/{teamId}/members` all use scopes already requested by the existing auth flow (`User.Read`, `Mail.Read`, `Chat.Read`, `ChannelMessage.Read.All`, `Group.Read.All`, etc.).

--- a/src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/SKILL.md
@@ -264,6 +264,9 @@ node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id 
 # Read recent messages in a channel
 node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --messages
 
+# Read messages with their reply threads (needed to detect unanswered/clarification-only threads)
+node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --messages --expand-replies --json
+
 # Post a message to a channel
 node ${CLAUDE_PLUGIN_ROOT}/skills/msgraph/scripts/msgraph.js channels --team-id TEAM_ID --channel-id CHANNEL_ID --send "Hello channel!"
 ```

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -71,6 +71,7 @@ function httpsRequest(urlStr, options = {}, body = null) {
           err.statusCode   = res.statusCode;
           err.responseBody = text;
           err.responseUrl  = urlStr;
+          err.headers      = res.headers;
           return reject(err);
         }
         resolve({ status: res.statusCode, body: text, headers: res.headers });

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -98,8 +98,20 @@ async function oauthPost(urlStr, params) {
 async function graphGet(endpoint, token, params = {}) {
   const qs  = new URLSearchParams(params).toString();
   const url = `${GRAPH_BASE}${endpoint}${qs ? '?' + qs : ''}`;
-  const res = await httpsRequest(url, { headers: { Authorization: `Bearer ${token}` } });
-  return JSON.parse(res.body);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await httpsRequest(url, { headers: { Authorization: `Bearer ${token}` } });
+      return JSON.parse(res.body);
+    } catch (e) {
+      if (e.statusCode === 429 && attempt < 2) {
+        const ra = parseInt(e.headers?.['retry-after'] || '', 10);
+        const waitS = Number.isFinite(ra) && ra > 0 ? Math.min(60, ra) : Math.min(30, 2 ** attempt * 2);
+        await new Promise(r => setTimeout(r, waitS * 1000));
+        continue;
+      }
+      throw e;
+    }
+  }
 }
 
 async function graphPost(endpoint, token, body) {

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -1598,8 +1598,8 @@ async function cmdTodo(args) {
 // ── CLI Parser ────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
   const BOOL = new Set(['json','unread','sites','chats','teamsList','contacts',
-    'manager','reports','availability','notebooks','list','messages','vtt','help','force',
-    'plans','buckets','tasks','myTasks','lists','insights']);
+    'manager','reports','availability','notebooks','list','vtt','help','force',
+    'plans','buckets','tasks','myTasks','lists','insights','expandReplies','members']);
   const args = { _: [] };
   let i = 0;
   while (i < argv.length) {
@@ -1634,7 +1634,7 @@ Auth:
 Data:
   me [--json]                          Your profile
   emails [--limit N] [--unread] [--search Q] [--folder NAME]
-         [--read ID] [--send TO --subject S --body B] [--json]
+         [--read ID] [--conversation CONV_ID] [--send TO --subject S --body B] [--json]
   calendar [--limit N] [--json]
            [--create TITLE --start DT --end DT [--location L] [--timezone TZ]]
            [--availability --start DT --end DT]
@@ -1642,7 +1642,9 @@ Data:
   teams [--chats] [--messages CHAT_ID] [--send MSG --chat-id ID] [--teams-list]
         [--lookup-user EMAIL] [--dm EMAIL --send MSG] [--json]
   channels --team-id ID --list
-           --team-id ID --channel-id ID --messages [--limit N]
+           --team-id ID --members
+           --team-id ID --channel-id ID --messages [--limit N] [--expand-replies]
+           --team-id ID --channel-id ID --replies MSG_ID [--limit N]
            --team-id ID --channel-id ID --send MSG [--json]
   onedrive [--path P] [--upload FILE [--dest PATH]] [--download ID [--output FILE]]
            [--info ID] [--json]

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -837,8 +837,25 @@ async function cmdChannels(args) {
     process.exit(1);
   }
 
+  if (args.replies) {
+    // --replies MSG_ID  →  replies to a specific channel message
+    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages/${args.replies}/replies`, token, { $top: limit });
+    const reps = data.value || [];
+    if (args.json) { console.log(JSON.stringify(reps, null, 2)); return; }
+    console.log(`\nReplies to message ${args.replies.slice(0, 20)}...:`);
+    console.log('─'.repeat(60));
+    for (const r of [...reps].sort((a, b) => (a.createdDateTime || '').localeCompare(b.createdDateTime || ''))) {
+      const rs = r.from?.user?.displayName || 'System';
+      const rb = stripHtml(r.body?.content || '').slice(0, 200);
+      console.log(`[${fmtDt(r.createdDateTime)}] ${rs}: ${rb}`);
+    }
+    return;
+  }
+
   if (args.messages) {
-    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages`, token, { $top: limit });
+    const params = { $top: limit };
+    if (args.expandReplies) params.$expand = 'replies';
+    const data = await graphGet(`/teams/${args.teamId}/channels/${args.channelId}/messages`, token, params);
     const msgs = data.value || [];
     if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
     console.log(`\nMessages in channel ${args.channelId.slice(0, 30)}...:`);
@@ -847,6 +864,14 @@ async function cmdChannels(args) {
       const sender = m.from?.user?.displayName || 'System';
       const body   = stripHtml(m.body?.content || '').slice(0, 200);
       console.log(`[${fmtDt(m.createdDateTime)}] ${sender}: ${body}`);
+      if (args.expandReplies && Array.isArray(m.replies) && m.replies.length) {
+        const replies = [...m.replies].sort((a, b) => (a.createdDateTime || '').localeCompare(b.createdDateTime || ''));
+        for (const r of replies) {
+          const rs = r.from?.user?.displayName || 'System';
+          const rb = stripHtml(r.body?.content || '').slice(0, 160);
+          console.log(`    └─ [${fmtDt(r.createdDateTime)}] ${rs}: ${rb}`);
+        }
+      }
     }
     return;
   }
@@ -861,6 +886,7 @@ async function cmdChannels(args) {
 
   console.log('channels --team-id ID --list');
   console.log('         --team-id ID --channel-id ID --messages [--limit N]');
+  console.log('         --team-id ID --channel-id ID --replies MSG_ID [--limit N]');
   console.log('         --team-id ID --channel-id ID --send MSG');
 }
 

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -793,19 +793,42 @@ async function cmdChannels(args) {
   if (!args.teamId) {
     console.error('Error: --team-id TEAM_ID is required');
     console.log('channels --team-id ID --list');
-    console.log('         --team-id ID --channel-id ID --messages [--limit N]');
+    console.log('         --team-id ID --channel-id ID --messages [--limit N] [--expand-replies]');
     console.log('         --team-id ID --channel-id ID --send MSG');
     process.exit(1);
   }
 
   if (args.list) {
-    const data     = await graphGet(`/teams/${args.teamId}/channels`, token, { $select: 'id,displayName,description' });
+    const data     = await graphGet(`/teams/${args.teamId}/channels`, token, { $select: 'id,displayName,description,membershipType' });
     const channels = data.value || [];
     if (args.json) { console.log(JSON.stringify(channels, null, 2)); return; }
     console.log(`\n${'ID'.padEnd(50)}  Name`);
     console.log('─'.repeat(80));
     for (const c of channels)
       console.log(`${(c.id || '').padEnd(50)}  ${c.displayName || 'N/A'}`);
+    return;
+  }
+
+  if (args.members) {
+    // Use the groups endpoint (teamId == groupId) so we don't need Team.ReadBasic.All;
+    // pages through every member of the underlying M365 group.
+    const members = [];
+    let next = `/groups/${args.teamId}/members/microsoft.graph.user`;
+    let params = { $select: 'id,displayName,userPrincipalName,mail', $top: 100 };
+    while (next) {
+      const page = await graphGet(next, token, params);
+      for (const m of page.value || []) members.push(m);
+      const nl = page['@odata.nextLink'];
+      if (!nl) break;
+      // Strip the base + use as endpoint; reuse no extra params (link contains them).
+      next = nl.replace('https://graph.microsoft.com/v1.0', '');
+      params = {};
+    }
+    if (args.json) { console.log(JSON.stringify(members, null, 2)); return; }
+    console.log(`\nTeam members (${members.length}):`);
+    console.log('─'.repeat(60));
+    for (const m of members)
+      console.log(`${(m.displayName || 'N/A').padEnd(34)}  ${m.userPrincipalName || m.mail || ''}`);
     return;
   }
 

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -731,10 +731,24 @@ async function cmdTeams(args) {
 
   if (args.messages) {
     // Graph returns HTTP 400 if $select is used on the Teams messages endpoint — pass $top only.
-    const data = await graphGet(`/me/chats/${args.messages}/messages`, token, { $top: limit });
-    const msgs = data.value || [];
+    // `--max N` paginates via @odata.nextLink up to N messages total (capped per page at 50 by Graph).
+    const max = args.max ? parseInt(args.max, 10) : null;
+    const perPage = max ? Math.min(50, max) : limit;
+    let next = `/me/chats/${args.messages}/messages?$top=${perPage}`;
+    const msgs = [];
+    while (next) {
+      const data = await graphGet(next.replace(GRAPH_BASE, '').replace('https://graph.microsoft.com/v1.0', ''), token, {});
+      for (const m of (data.value || [])) {
+        msgs.push(m);
+        if (max && msgs.length >= max) break;
+      }
+      if (max && msgs.length >= max) break;
+      const nl = data['@odata.nextLink'];
+      if (!nl || !max) break; // no pagination unless --max set
+      next = nl;
+    }
     if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
-    console.log(`\nMessages in chat ${args.messages.slice(0, 20)}...:`);
+    console.log(`\nMessages in chat ${args.messages.slice(0, 20)}... (${msgs.length}):`);
     console.log('─'.repeat(60));
     for (const m of [...msgs].reverse()) {
       const sender = m.from?.user?.displayName || 'System';

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -765,10 +765,20 @@ async function cmdTeams(args) {
   }
 
   if (args.teamsList) {
-    const data  = await graphGet('/me/joinedTeams', token, { $select: 'id,displayName,description' });
-    const teams = data.value || [];
+    // Prefer /me/joinedTeams (needs Team.ReadBasic.All). Fall back to /me/memberOf
+    // filtered client-side to groups that are also teams (uses Group.Read.All,
+    // which the default scope set already includes).
+    let teams;
+    try {
+      const data = await graphGet('/me/joinedTeams', token, { $select: 'id,displayName,description' });
+      teams = data.value || [];
+    } catch (e) {
+      if (!/403|Forbidden/.test(e.message)) throw e;
+      const data = await graphGet('/me/memberOf', token, { $select: 'id,displayName,description,resourceProvisioningOptions', $top: 200 });
+      teams = (data.value || []).filter(g => Array.isArray(g.resourceProvisioningOptions) && g.resourceProvisioningOptions.includes('Team'));
+    }
     if (args.json) { console.log(JSON.stringify(teams, null, 2)); return; }
-    for (const t of teams) console.log(`${t.id.slice(0, 36)}  ${t.displayName}`);
+    for (const t of teams) console.log(`${(t.id || '').slice(0, 36)}  ${t.displayName}`);
     return;
   }
 

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -679,13 +679,18 @@ async function cmdTeams(args) {
   const limit = parseInt(args.limit) || 20;
 
   if (args.chats) {
-    const data  = await graphGet('/me/chats', token, { $top: limit, $select: 'id,topic,chatType,lastUpdatedDateTime' });
+    // $expand=lastMessagePreview returns the true last-message timestamp + body.
+    // Graph's `lastUpdatedDateTime` on the chat is frequently stale (months/years
+    // behind), so callers that need recency MUST read lastMessagePreview.
+    const data  = await graphGet('/me/chats', token, { $top: limit, $expand: 'lastMessagePreview' });
     const chats = data.value || [];
     if (args.json) { console.log(JSON.stringify(chats, null, 2)); return; }
-    console.log(`\n${'Chat ID'.padEnd(50)}  ${'Type'.padEnd(10)}  Topic`);
+    console.log(`\n${'Chat ID'.padEnd(50)}  ${'Type'.padEnd(10)}  Last msg            Topic`);
     console.log('─'.repeat(80));
-    for (const c of chats)
-      console.log(`${(c.id || '').padEnd(50)}  ${(c.chatType || '').padEnd(10)}  ${c.topic || '(direct message)'}`);
+    for (const c of chats) {
+      const last = c.lastMessagePreview?.createdDateTime || c.lastUpdatedDateTime || '';
+      console.log(`${(c.id || '').padEnd(50)}  ${(c.chatType || '').padEnd(10)}  ${fmtDt(last).padEnd(18)}  ${c.topic || '(direct message)'}`);
+    }
     return;
   }
 

--- a/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
+++ b/src/agents/plugins/claude/plugin/skills/msgraph/scripts/msgraph.js
@@ -499,9 +499,32 @@ async function cmdEmails(args) {
   }
 
   const limit  = parseInt(args.limit) || 10;
+
+  if (args.conversation) {
+    // Graph rejects $orderby with $filter on conversationId ("InefficientFilter").
+    // Pull more rows than asked and sort client-side.
+    const cv = await graphGet('/me/messages', token, {
+      $filter: `conversationId eq '${args.conversation}'`,
+      $top:    Math.max(limit, 25),
+      $select: 'id,subject,from,sentDateTime,receivedDateTime,isRead,bodyPreview,conversationId',
+    });
+    let msgs = cv.value || [];
+    msgs.sort((a, b) => (b.sentDateTime || b.receivedDateTime || '').localeCompare(a.sentDateTime || a.receivedDateTime || ''));
+    msgs = msgs.slice(0, limit);
+    if (args.json) { console.log(JSON.stringify(msgs, null, 2)); return; }
+    if (!msgs.length) { console.log('No messages in this conversation.'); return; }
+    console.log(`\n${'Sent'.padEnd(16)}  ${'From'.padEnd(28)}  Subject`);
+    console.log('─'.repeat(80));
+    for (const m of msgs) {
+      const from = (m.from?.emailAddress?.name || '').slice(0, 28).padEnd(28);
+      console.log(`${fmtDt(m.sentDateTime || m.receivedDateTime).padEnd(16)}  ${from}  ${(m.subject || '(no subject)').slice(0, 40)}`);
+    }
+    return;
+  }
+
   const params = {
     $top:     limit,
-    $select:  'id,subject,from,receivedDateTime,isRead,hasAttachments,importance',
+    $select:  'id,subject,from,receivedDateTime,isRead,hasAttachments,importance,bodyPreview,conversationId',
     $orderby: 'receivedDateTime desc',
   };
   if (args.search) { params.$search = `"${args.search}"`; delete params.$orderby; }


### PR DESCRIPTION
## Summary

Ports the **+136 / -20** lines of adjustments that the runtime msgraph plugin (`~/.codemie/claude-plugin/skills/msgraph/`) had accumulated over the repo source. The runtime version was already in active use; this PR closes the drift so the repo matches what users actually run.

Tracker: [EPMCDME-12918](https://jiraeu.epam.com/browse/EPMCDME-12918)

## Changes

`scripts/msgraph.js`:

- **Robustness**: `httpsRequest` now exposes `err.headers`; `graphGet` has a 3-attempt retry loop honouring HTTP 429 `Retry-After` (cap 60s, exponential fallback).
- **Emails**: new `--conversation CONV_ID` to read whole threads. Default `$select` extended with `bodyPreview` and `conversationId`.
- **Teams chats**: switched to `$expand=lastMessagePreview` because Graph's `lastUpdatedDateTime` is months-stale; new "Last msg" column.
- **Teams messages**: new `--max N` flag paginating via `@odata.nextLink`.
- **Teams list**: falls back to `/me/memberOf` filtered to Team groups when `/me/joinedTeams` returns 403 (avoids needing `Team.ReadBasic.All`).
- **Channels**: new `--members` (paginated `/groups/{teamId}/members/microsoft.graph.user`), new `--replies MSG_ID`, new `--messages --expand-replies` (inline tree). `--list` `$select` extended with `membershipType`.
- **Parser bug fix**: `--messages CHAT_ID` was being parsed as boolean (CHAT_ID dropped). Removed `messages` from the BOOL set, added `expandReplies` and `members`.
- **CLI help**: documents `--conversation`, `--members`, `--expand-replies`, `--replies`.

`SKILL.md`:

- Channels section: adds the `--expand-replies --json` usage example.

## Impact

| Before | After |
|---|---|
| Drift between repo and installed plugin: +136/-20 LOC | Repo source matches installed runtime byte-for-byte (modulo `${CLAUDE_PLUGIN_ROOT}` placeholder vs hardcoded user path) |
| `teams --chats` "last activity" was stale by months | True last-message timestamp via `lastMessagePreview` |
| `teams --teams-list` failed 403 in tenants without `Team.ReadBasic.All` | Falls back to `/me/memberOf` automatically |
| Graph 429 retries: none | 3 attempts honouring `Retry-After` |
| `--messages CHAT_ID` silently parsed as boolean | Correctly passes the chat id through |

No new Microsoft Graph scopes required — all features use scopes already requested by the existing auth flow.

## Verification

- `diff src/.../msgraph.js ~/.codemie/claude-plugin/skills/msgraph/scripts/msgraph.js` → **empty**
- Normalised diff of `SKILL.md` → **empty**
- `npm run lint` → pass
- `npm run typecheck` → pass
- `npm run build` → `dist/.../msgraph.js` regenerated to **1728 LOC** (matches installed)
- `npm run check:pre-commit` → pass

## Out of scope

`codemie-public-skills/skills/productivity/msgraph/` still drifts from `codemie-code/src`. A sibling PR is recommended to mirror these adjustments into the public-skills repo.

## Testing

- [x] Diff-based verification against the production-proven installed plugin (definitive)
- [x] `npm run ci`-aligned gates: lint, typecheck, build, check:pre-commit
- [ ] No new unit tests — msgraph script has no existing Vitest coverage; behaviour is already validated in production

## Checklist

- [x] Code follows project standards
- [x] CI gates green locally
- [x] No merge conflicts with `main`
- [x] Plan and analysis preserved under `docs/superpowers/tasks/2026-06-18-msgraph-skill-sync-incorporate-global-adjustments/`