### PR TITLE
fix(proxy): show a single Opus (prefer 4.8) in connect desktop

### DIFF
--- a/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/plan.md
+++ b/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/plan.md
@@ -1,0 +1,61 @@
+# Plan — proxy connect desktop: single Opus (prefer 4.8)
+
+## Clarification assumptions
+
+- **Plain reading adopted (not asked — trivially reversible):** expose **exactly
+  one** opus model in the Claude Desktop list, chosen by priority
+  `claude-opus-4-8 → claude-opus-4-7 → claude-opus-4-6`. When 4.8 is absent from the
+  gateway, the single highest-priority available opus is shown (not several). If the
+  user actually wants "4.8 only, else all remaining opus", that's a one-line change.
+
+## Goal
+
+`codemie proxy connect desktop` currently lists Opus 4.6 **and** 4.7. After this
+change it lists a single Opus — 4.8 when the CodeMie gateway serves it, otherwise
+the next-best available opus — while sonnet/haiku entries are unchanged.
+
+## Design (confirmed with advisor)
+
+Keep `selectPreferredClaudeModels()` generic (resolve-each). Add `claude-opus-4-8`
+at the head of the opus group in `PREFERRED_CLAUDE_MODELS`, then collapse to one
+opus at a dedicated, tested seam — a new exported `selectDesktopClaudeModels()` that
+the connector calls instead of `selectPreferredClaudeModels()`.
+
+Rationale: the generic resolver's unit tests mock catalogs without 4-8, so adding
+4-8 to the default preferred list leaves them green; only the connector-level tests
+change. Baking "one opus" into the generic resolver would needlessly break its
+contract test.
+
+## Tasks
+
+### Task 1 — Collapse to a single opus via `selectDesktopClaudeModels`
+- **Test-first: yes** — new `describe('selectDesktopClaudeModels')`:
+  - 4.8 present (exact) → opus list is exactly `[claude-opus-4-8]`; 4-7/4-6 absent.
+  - 4.8 absent, 4-7 + 4-6 present → single opus `claude-opus-4-7`.
+  - only 4-6 present → single opus `claude-opus-4-6` (or its dated variant).
+  - 4.8 present only as dated `claude-opus-4-8-YYYYMMDD` → that dated id, still one.
+  - sonnet + haiku preserved around the single opus, order preserved.
+- Add `claude-opus-4-8` to `PREFERRED_CLAUDE_MODELS` ahead of `4-7`/`4-6`.
+- Implement `selectDesktopClaudeModels(available, preferred?)`: call
+  `selectPreferredClaudeModels`, then keep only the first `^claude-opus-` id.
+- Update the `PREFERRED_CLAUDE_MODELS` doc comment to note one-opus collapse + order.
+
+### Task 2 — Route the connector through the new seam
+- **Test-first: yes** — update the two `writeDesktopConfig` expectations
+  (desktop.test.ts:280-285, 298-303) to drop the second opus line, leaving:
+  `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5-20251001`.
+- In `writeDesktopConfig()`, swap `selectPreferredClaudeModels(discoveredModels)`
+  for `selectDesktopClaudeModels(discoveredModels)`.
+
+## Verification
+
+- `npm test` for the desktop connector spec (RED→GREEN per task).
+- `npm run lint` + `npm run typecheck` on the touched file.
+- Manual (handed to user — needs live gateway/SSO/Desktop): run
+  `codemie proxy connect desktop`, confirm one Opus appears (4.8 when the gateway
+  serves it). A fallback opus instead of 4.8 means the gateway lacks 4.8, not a bug.
+
+## Out of scope
+
+- `setup.ts` / `parsers.ts` opus references — profile-default model tiers, unrelated
+  to the Desktop curated list.

--- a/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/qa-report.md
+++ b/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/qa-report.md
@@ -1,0 +1,33 @@
+# QA Report — proxy connect desktop: single Opus (prefer 4.8)
+
+Branch: `fix/proxy-desktop-opus-4.8`
+
+## Gates
+
+| Gate | Command | Result |
+|---|---|---|
+| Unit tests (affected) | `vitest run …/desktop.test.ts` | PASS — 44/44 (5 new `selectDesktopClaudeModels` cases) |
+| Lint | `eslint desktop.ts desktop.test.ts` | PASS — no issues |
+| Typecheck | `tsc --noEmit` | PASS — no errors |
+| Build | `npm run build` | PASS — `dist/` reflects the change |
+
+## Live end-to-end check (non-destructive)
+
+Ran real gateway discovery + new selection against the running proxy
+(`preview-kimi`, http://127.0.0.1:4001). No Claude Desktop config was mutated.
+
+- Gateway serves: `claude-sonnet-4-6`, `claude-opus-4-5-20251101`,
+  `claude-opus-4-6-20260205`, `claude-opus-4-7`, **`claude-opus-4-8`**,
+  `claude-haiku-4-5-20251001` (+ older sonnet ids).
+- `selectDesktopClaudeModels` →
+  `["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]`.
+- **Opus entries exposed to Desktop: exactly 1 — `claude-opus-4-8`.**
+
+Confirms the original symptom (Opus 4.6 **and** 4.7 shown) is resolved: a single
+Opus 4.8 is now offered. When a gateway lacks 4.8, the same logic falls back to the
+next-best available opus (proven by unit tests).
+
+## Notes
+
+- `.codemie/codemie-cli.config.json` is a pre-existing local profile change, unrelated
+  to this task and intentionally not staged.

--- a/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/technical-analysis.md
+++ b/docs/superpowers/tasks/2026-06-26-proxy-desktop-opus-4.8/technical-analysis.md
@@ -1,0 +1,55 @@
+# Technical Analysis — proxy connect desktop: Opus model selection
+
+## Task
+
+`codemie proxy connect desktop` currently exposes **Opus 4.6 and Opus 4.7** in the
+Claude Desktop model list. Change this so a single **Opus 4.8** is exposed when the
+CodeMie gateway serves it, otherwise fall back to other opus models. Verify it works.
+
+## Codebase Findings
+
+- **Owner file:** `src/cli/commands/proxy/connectors/desktop.ts` (added in #390 —
+  "provision managed MCP servers into Claude Desktop").
+- **Curated list** — `PREFERRED_CLAUDE_MODELS` (desktop.ts:49-54):
+  ```
+  claude-sonnet-4-6
+  claude-opus-4-7
+  claude-opus-4-6
+  claude-haiku-4-5
+  ```
+  This is the source of the two opus entries the user sees. Both 4-7 and 4-6 are
+  listed, so when the gateway serves both, both appear in Desktop.
+- **Discovery** — `fetchClaudeModels()` (desktop.ts:67-138) hits the local proxy
+  `/v1/llm_models?include_all=true`, filters to `claude-*`, prefers non-`-vertex`.
+- **Resolution** — `selectPreferredClaudeModels()` (desktop.ts:149-189) maps each
+  preferred name to an available id: exact → dated `<name>-YYYYMMDD` (latest) →
+  `<name>-vertex`. Entries with no match are dropped silently. **Preserves the
+  preferred order** and currently emits one entry per matched preferred name (so
+  two opus entries when both resolve).
+- **Call site** — `writeDesktopConfig()` (desktop.ts:~428-440): fetch → select →
+  map to `InferenceModelEntry[]` → written to Desktop config as `inferenceModels`.
+- **Canonical id** — `claude-opus-4-8` is the correct id (env model map;
+  commit 41e225b set default opus to `claude-opus-4-8`; the active CLI profile uses
+  `"opusModel": "claude-opus-4-8"`).
+
+## Required Behavior Change
+
+Expose **at most one** opus model, choosing the highest-priority one the gateway
+actually serves, in priority order `4-8 → 4-7 → 4-6`. The exact/dated/vertex
+fallback machinery should still apply to each opus candidate.
+
+## Risk Indicators
+
+- Surface is small: one file plus its unit test. Low blast radius.
+- Existing tests assert two opus entries (desktop.test.ts:169-176, 277-305) — they
+  encode the OLD behavior and must be updated to the new one-opus contract.
+- `selectPreferredClaudeModels` is a generic, exported, unit-tested helper. Baking
+  "only one opus" into it would make a generic resolver assert opus-specific rules
+  (smell). Prefer keeping it generic and collapsing opus at a dedicated, tested seam.
+- No network call needed at test time — discovery is mockable (tests already do).
+
+## Verification
+
+- Unit: `npm test` on the desktop connector spec.
+- Manual: run `codemie proxy connect desktop` against the gateway and confirm the
+  Desktop model picker shows a single Opus (4.8 when available).

--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
@@ -16,6 +16,7 @@ import {
   getManagedMcpStatePath,
   mapCanonicalToDesktop,
   reconcileManagedMcpServers,
+  selectDesktopClaudeModels,
   selectPreferredClaudeModels,
   writeDesktopConfig,
 } from '../desktop.js';
@@ -200,6 +201,54 @@ describe('selectPreferredClaudeModels', () => {
   });
 });
 
+describe('selectDesktopClaudeModels', () => {
+  it('exposes only Opus 4.8 when the gateway serves it', () => {
+    const result = selectDesktopClaudeModels([
+      'claude-sonnet-4-6',
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6-20260205',
+      'claude-haiku-4-5-20251001',
+    ]);
+    expect(result).toEqual([
+      'claude-sonnet-4-6',
+      'claude-opus-4-8',
+      'claude-haiku-4-5-20251001',
+    ]);
+  });
+
+  it('falls back to the highest available opus when 4.8 is absent', () => {
+    const result = selectDesktopClaudeModels([
+      'claude-sonnet-4-6',
+      'claude-opus-4-7',
+      'claude-opus-4-6-20260205',
+      'claude-haiku-4-5-20251001',
+    ]);
+    expect(result).toEqual([
+      'claude-sonnet-4-6',
+      'claude-opus-4-7',
+      'claude-haiku-4-5-20251001',
+    ]);
+  });
+
+  it('uses the next opus down when only 4.6 is available', () => {
+    expect(selectDesktopClaudeModels(['claude-opus-4-6-20260205']))
+      .toEqual(['claude-opus-4-6-20260205']);
+  });
+
+  it('keeps a single dated Opus 4.8 over older canonical opus ids', () => {
+    expect(selectDesktopClaudeModels([
+      'claude-opus-4-8-20260601',
+      'claude-opus-4-7',
+    ])).toEqual(['claude-opus-4-8-20260601']);
+  });
+
+  it('returns no opus entry when the gateway serves none', () => {
+    expect(selectDesktopClaudeModels(['claude-sonnet-4-6', 'claude-haiku-4-5-20251001']))
+      .toEqual(['claude-sonnet-4-6', 'claude-haiku-4-5-20251001']);
+  });
+});
+
 describe('writeDesktopConfig', () => {
   let baseDir: string;
   let libDir: string;
@@ -274,13 +323,12 @@ describe('writeDesktopConfig', () => {
     expect(config.inferenceGatewayBaseUrl).toBe('http://localhost:4001');
   });
 
-  it('populates inferenceModels with the curated preferred Claude set', async () => {
+  it('populates inferenceModels with the curated preferred Claude set (single opus)', async () => {
     const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir, [], statePath);
     const config = JSON.parse(await readFile(written, 'utf-8'));
     expect(JSON.parse(config.inferenceModels)).toEqual([
       { name: 'claude-sonnet-4-6' },
       { name: 'claude-opus-4-7' },
-      { name: 'claude-opus-4-6-20260205' },
       { name: 'claude-haiku-4-5-20251001' },
     ]);
   });
@@ -298,7 +346,6 @@ describe('writeDesktopConfig', () => {
     expect(JSON.parse(config.inferenceModels)).toEqual([
       { name: 'claude-sonnet-4-6' },
       { name: 'claude-opus-4-7' },
-      { name: 'claude-opus-4-6-20260205' },
       { name: 'claude-haiku-4-5-20251001' },
     ]);
   });

--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -45,9 +45,14 @@ interface CodeMieLlmModel {
  * an exact ID or as `<entry>-<YYYYMMDD>` (the dated variant). The actual
  * resolved ID is what gets written to the Desktop config so the gateway
  * receives a model name it has registered.
+ *
+ * The opus entries are listed in descending preference (`4-8 → 4-7 → 4-6`):
+ * {@link selectDesktopClaudeModels} collapses them to the single highest-priority
+ * opus the gateway actually serves, so Desktop never shows more than one Opus.
  */
 export const PREFERRED_CLAUDE_MODELS = [
   'claude-sonnet-4-6',
+  'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-haiku-4-5',
@@ -186,6 +191,30 @@ export function selectPreferredClaudeModels(
     })
   );
   return resolved;
+}
+
+/**
+ * Build the exact model set Claude Desktop should be offered.
+ *
+ * Resolves the curated preferred list via {@link selectPreferredClaudeModels},
+ * then collapses the opus family to a single entry: the first (highest-priority)
+ * opus that resolved. With opus ids ordered `4-8 → 4-7 → 4-6` in
+ * {@link PREFERRED_CLAUDE_MODELS}, this exposes Opus 4.8 when the gateway serves
+ * it and otherwise falls back to the next-best available opus. Non-opus models
+ * are passed through untouched and order is preserved.
+ */
+export function selectDesktopClaudeModels(
+  available: string[],
+  preferred: readonly string[] = PREFERRED_CLAUDE_MODELS
+): string[] {
+  const resolved = selectPreferredClaudeModels(available, preferred);
+  let opusKept = false;
+  return resolved.filter((id) => {
+    if (!/^claude-opus-/i.test(id)) return true;
+    if (opusKept) return false;
+    opusKept = true;
+    return true;
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -424,14 +453,15 @@ export async function writeDesktopConfig(
   }
 
   // Discover available Claude models from the gateway and curate down to the
-  // preferred set so the user doesn't have to type them manually in the GUI.
+  // preferred set (a single opus, preferring 4.8) so the user doesn't have to
+  // type them manually in the GUI.
   const discoveredModels = await fetchClaudeModels(proxyUrl, gatewayKey);
   if (discoveredModels.length === 0) {
     throw new ConfigurationError(
       `Local proxy did not expose any Claude models from ${new URL('/v1/llm_models?include_all=true', proxyUrl).toString()}.`
     );
   }
-  const resolvedModels = selectPreferredClaudeModels(discoveredModels);
+  const resolvedModels = selectDesktopClaudeModels(discoveredModels);
   if (resolvedModels.length === 0) {
     throw new ConfigurationError(
       'Local proxy discovered Claude models, but none matched the preferred CodeMie desktop set.'


### PR DESCRIPTION
## Summary

`codemie proxy connect desktop` currently offers **two** Opus models (4.6 **and** 4.7) in the Claude Desktop model list. This change makes it expose **exactly one** Opus — Opus 4.8 when the CodeMie gateway serves it, otherwise the next-best available opus — while sonnet/haiku entries are unchanged.

## Changes

- Add `claude-opus-4-8` at the head of the opus group in `PREFERRED_CLAUDE_MODELS` (ordered `4-8 → 4-7 → 4-6`).
- New exported `selectDesktopClaudeModels()`: resolves the curated preferred set via `selectPreferredClaudeModels()`, then collapses the opus family to the single highest-priority resolved opus. Non-opus models pass through untouched; order preserved.
- Route `writeDesktopConfig()` through the new seam instead of `selectPreferredClaudeModels()`.
- The generic resolver keeps its resolve-each contract (its tests stay green); only connector-level behavior changes.

## Testing

- Unit: `desktop.test.ts` — 44/44 pass, including 5 new `selectDesktopClaudeModels` cases (4.8 exact, 4.8 dated, fallback to 4-7, fallback to 4-6, sonnet/haiku order preserved).
- `npm run lint`, `npm run typecheck`, `npm run build` — all pass.
- Live (non-destructive) gateway check: gateway serving 4.8 → Desktop offered exactly `["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]`.

## Out of scope

- `setup.ts` / `parsers.ts` opus references (profile-default tiers, unrelated to the Desktop curated list).
- A local `.codemie/codemie-cli.config.json` profile change was intentionally excluded.