### PR TITLE
fix(ci): probe common Node.js paths on Windows when PATH lookup fails

### DIFF
--- a/install/windows/install.ps1
+++ b/install/windows/install.ps1
@@ -126,6 +126,26 @@ $PrefixDir = Join-Path $InstallRoot 'npm-prefix'
 $NpmPath = Get-CommandPath 'npm.cmd'
 $NodePath = Get-CommandPath 'node.exe'
 $GitPath = Get-CommandPath 'git.exe'
+
+# Fallback: probe common Node.js install locations when PATH lookup fails.
+# GUI apps (e.g. Connect wizard) may not inherit the user's shell PATH.
+if (-not $NodePath) {
+  $probes = @(
+    "$env:ProgramFiles\nodejs\node.exe",
+    "${env:ProgramFiles(x86)}\nodejs\node.exe",
+    "$env:LOCALAPPDATA\Programs\nodejs\node.exe"
+  )
+  foreach ($probe in $probes) {
+    if (Test-Path $probe) {
+      $NodePath = $probe
+      if (-not $NpmPath) {
+        $NpmPath = Join-Path (Split-Path $probe) 'npm.cmd'
+      }
+      break
+    }
+  }
+}
+
 $NodeMajor = Get-NodeMajor $NodePath
 
 Write-Host 'CodeMie installer diagnostics'


### PR DESCRIPTION
## Summary

- **`install/windows/install.ps1`**: Add fallback path probing for Node.js when `Get-CommandPath` returns empty. GUI apps like the Connect wizard may not inherit the user's shell PATH, so `node.exe` at `C:\Program Files\nodejs\` is invisible to the installer even though it's installed.

## Problem

Users who install Node.js via the company portal (installs to `C:\Program Files\nodejs\`) see "Check Node.js & npm failed — Node.js not found" in the Connect wizard. Root cause: the Electron app spawns processes that don't inherit user-level PATH entries.

## Fix

After the initial `Get-CommandPath 'node.exe'` fails, the script now probes:
- `%ProgramFiles%\nodejs\node.exe`
- `%ProgramFiles(x86)%\nodejs\node.exe`
- `%LOCALAPPDATA%\Programs\nodejs\node.exe`

This mirrors the pattern already used by `isGitInstalled` in the native Swift wizard.

## Test plan

- [ ] Run `install.ps1` on a Windows machine where Node.js is installed via company portal and not in PATH
- [ ] Verify installer detects Node.js via fallback probe and completes successfully
- [ ] Verify `codemie doctor` passes after install

Ref: INC0000773156