### PR TITLE
chore(agents): bump Claude Code supported version to 2.1.199

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -30,17 +30,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_SUPPORTED_VERSION = '2.1.178';
+const CLAUDE_SUPPORTED_VERSION = '2.1.199';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.178 → minimum = 2.1.168
+ * e.g. supported = 2.1.199 → minimum = 2.1.189
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.168';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.189';
 
 /**
  * Claude Code installer URLs

--- a/src/cli/commands/analytics/aggregator.ts
+++ b/src/cli/commands/analytics/aggregator.ts
@@ -789,7 +789,7 @@ export class AnalyticsAggregator {
       }
       for (const prompt of prompts) {
         const raw = prompt?.text;
-        if (!raw) {
+        if (typeof raw !== 'string' || !raw) {
           continue;
         }
         const cleaned = raw


### PR DESCRIPTION
## Summary
Bumps the Claude Code supported version ceiling to 2.1.199 and raises the minimum supported version to 2.1.189 (10 patch versions below max, per project rule). Also fixes a report generation crash caused by non-string prompt text values in the analytics aggregator.

## Changes
- `chore(agents)`: raise `CLAUDE_SUPPORTED_VERSION` to `2.1.199` and `CLAUDE_MINIMUM_SUPPORTED_VERSION` to `2.1.189`
- `fix(analytics)`: add `typeof raw !== 'string'` guard before processing prompt text in `AnalyticsAggregator` to prevent runtime errors when `prompt.text` is not a string

## Testing
- [ ] Tests added/updated
- [ ] Manual testing done

## Checklist
- [ ] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [ ] No merge conflicts with `main`