### PR TITLE
fix(skills): pass interactive flag to runSkillsCli in add command

### DIFF
--- a/src/cli/commands/skills/add.ts
+++ b/src/cli/commands/skills/add.ts
@@ -83,6 +83,7 @@ export function createAddCommand(): Command {
         const result = await runSkillsCli(args, {
           cwd,
           timeoutMs: ADD_GIT_TIMEOUT_MS,
+          interactive,
           env: {
             GIT_TERMINAL_PROMPT: '0',
             GCM_INTERACTIVE: 'never',
@@ -105,6 +106,10 @@ export function createAddCommand(): Command {
             agent_selection_mode: effectiveSelectionMode,
           });
           return;
+        }
+
+        if (!interactive && result.stderr) {
+          process.stderr.write(result.stderr);
         }
 
         const errorCode = classifySkillError({ result });


### PR DESCRIPTION
## Summary

When `-y`/`--yes` is supplied, the `skills add` action computed `interactive=false` but did not forward it to `runSkillsCli`, which defaulted to `interactive=true`. In interactive mode the close handler calls `process.stderr.write` on the buffered stderr. When the parent process has a piped stderr (e.g. integration test `spawnSync`), this raises EPIPE — an uncaught write error that causes Node to exit with code `1` instead of propagating the real upstream exit code.

## Changes
- Pass `interactive` to `runSkillsCli` in `skills add` so non-interactive runs (`-y`) use piped stdio and avoid the EPIPE
- Explicitly forward `result.stderr` to `process.stderr` in non-interactive failure paths so egress-blocked and other markers remain visible to the caller

## Testing
- [x] Integration test `classifies CODEMIE_SKILL_EGRESS_BLOCKED stderr as egress_blocked exit code` now passes (was `expected 1 to be 7`)
- [x] Existing test `propagates non-zero exit code from upstream spawn` continues to pass

## Checklist
- [x] Code follows project standards
- [x] No merge conflicts with `main`