### PR TITLE
fix(assistants): load registered assistants from top-level config in setup flow

### DIFF
--- a/src/cli/commands/assistants/setup/index.ts
+++ b/src/cli/commands/assistants/setup/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import type { Assistant, AssistantBase } from 'codemie-sdk';
 import { logger } from '@/utils/logger.js';
-import { ConfigLoader } from '@/utils/config.js';
+import { ConfigLoader, loadRegisteredAssistants } from '@/utils/config.js';
 import { StorageScope } from '@/env/types.js';
 import type { CodemieAssistant } from '@/env/types.js';
 import { MESSAGES, ACTIONS } from '@/cli/commands/assistants/constants.js';
@@ -66,7 +66,7 @@ async function setupAssistants(options: SetupCommandOptions, hostAgent?: TargetA
 
   const config = await ConfigLoader.load(workingDir, { name: profileName });
   const client = await getAuthenticatedClient(config);
-  const registeredAssistants = config.codemieAssistants || [];
+  const registeredAssistants = await loadRegisteredAssistants();
   config.codemieAssistants = registeredAssistants;
 
   const { selectedIds, action } = await promptAssistantSelection(config, options, client);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1452,7 +1452,12 @@ export async function loadRegisteredAssistants(): Promise<CodemieAssistant[]> {
       ConfigLoader.loadAssistantsByScope(StorageScope.GLOBAL, workingDir).catch(() => [] as CodemieAssistant[]),
       ConfigLoader.loadAssistantsByScope(StorageScope.LOCAL, workingDir).catch(() => [] as CodemieAssistant[]),
     ]);
-    return [...globalAssistants, ...localAssistants];
+    const seen = new Set<string>();
+    return [...localAssistants, ...globalAssistants].filter(a => {
+      if (seen.has(a.id)) return false;
+      seen.add(a.id);
+      return true;
+    });
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

- `ConfigLoader.load()` only merges profile-level data; after migration `004`, `codemieAssistants` lives at the top-level `MultiProviderConfig`, not in profiles
- `config.codemieAssistants || []` always resolved to `[]`, so the **Registered** tab in the CLI assistant selection panel always showed 0 assistants
- Replace the profile-based read with `loadRegisteredAssistants()`, which correctly loads from both global and local top-level config with file verification

## Test plan

- [x] Register an assistant as a skill via `codemie assistants setup`
- [x] Re-open the CLI assistant selection panel
- [x] Verify the **Registered** tab shows the previously registered assistant
- [x] Verify other tabs (Project, Marketplace) are unaffected
- [x] Verify behaviour with both global and local storage scopes

Fixes [EPMCDME-13372](https://jiraeu.epam.com/browse/EPMCDME-13372)