### PR TITLE
fix(analytics): correctly attribute sessions to wrapper agent names

### DIFF
--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/code-review.diff
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/code-review.diff
@@ -1,0 +1,254 @@
+diff --git a/src/agents/core/session/types.ts b/src/agents/core/session/types.ts
+index 3d4f28f..b3acc5c 100644
+--- a/src/agents/core/session/types.ts
++++ b/src/agents/core/session/types.ts
+@@ -112,7 +112,7 @@ export interface RuntimeCheckpoint {
+  */
+ export interface Session {
+   sessionId: string; // CodeMie session ID (UUID)
+-  agentName: string; // 'claude', 'gemini'
++  agentName: string; // 'codemie-claude', 'codemie-gemini', etc. (wrapper name, not short plugin name)
+   provider: string; // 'ai-run-sso', etc.
+   project?: string; // SSO project name (optional, only for ai-run-sso provider)
+   startTime: number; // Unix timestamp (ms)
+diff --git a/src/cli/commands/__tests__/hook-agent-name.test.ts b/src/cli/commands/__tests__/hook-agent-name.test.ts
+new file mode 100644
+index 0000000..7b4e38d
+--- /dev/null
++++ b/src/cli/commands/__tests__/hook-agent-name.test.ts
+@@ -0,0 +1,18 @@
++import { describe, it, expect } from 'vitest';
++import { toWrapperAgentName } from '../hook.js';
++
++describe('toWrapperAgentName', () => {
++  it('prefixes short plugin names with codemie-', () => {
++    expect(toWrapperAgentName('claude')).toBe('codemie-claude');
++    expect(toWrapperAgentName('codex')).toBe('codemie-codex');
++    expect(toWrapperAgentName('gemini')).toBe('codemie-gemini');
++    expect(toWrapperAgentName('kimi')).toBe('codemie-kimi');
++    expect(toWrapperAgentName('opencode')).toBe('codemie-opencode');
++  });
++
++  it('passes through names that already start with codemie', () => {
++    expect(toWrapperAgentName('codemie-code')).toBe('codemie-code');
++    expect(toWrapperAgentName('codemie-claude')).toBe('codemie-claude');
++    expect(toWrapperAgentName('codemie-cli')).toBe('codemie-cli');
++  });
++});
+diff --git a/src/cli/commands/analytics/__tests__/data-loader.test.ts b/src/cli/commands/analytics/__tests__/data-loader.test.ts
+index f93c62b..8c43732 100644
+--- a/src/cli/commands/analytics/__tests__/data-loader.test.ts
++++ b/src/cli/commands/analytics/__tests__/data-loader.test.ts
+@@ -219,3 +219,71 @@ describe('MetricsDataLoader.loadSessions — completed_ prefixed sessions', () =
+     expect(sessions[0].agentSessionFile).toBeUndefined();
+   });
+ });
++
++describe('MetricsDataLoader.loadSessions — wrapper agent name filter', () => {
++  let dir: string;
++
++  beforeEach(() => {
++    dir = mkdtempSync(join(tmpdir(), 'data-loader-agent-test-'));
++  });
++
++  afterEach(() => {
++    rmSync(dir, { recursive: true, force: true });
++  });
++
++  function writeAgentSession(id: string, agentName: string): void {
++    writeFileSync(
++      join(dir, `completed_${id}.json`),
++      JSON.stringify({
++        startTime: 1000,
++        endTime: 2000,
++        status: 'completed',
++        agentName,
++        provider: 'anthropic',
++        workingDirectory: '/tmp/project',
++      })
++    );
++  }
++
++  it('short filter "claude" matches wrapper-named session "codemie-claude" (broad)', () => {
++    writeAgentSession('aaaa-0001', 'codemie-claude');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'claude' });
++    expect(sessions).toHaveLength(1);
++  });
++
++  it('short filter "gemini" matches wrapper-named session "codemie-gemini" (broad)', () => {
++    writeAgentSession('aaaa-0002', 'codemie-gemini');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'gemini' });
++    expect(sessions).toHaveLength(1);
++  });
++
++  it('exact wrapper filter "codemie-claude" matches wrapper session "codemie-claude" (narrow)', () => {
++    writeAgentSession('aaaa-0003', 'codemie-claude');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
++    expect(sessions).toHaveLength(1);
++  });
++
++  it('short filter "claude" also matches native short-name session "claude" (backward compat)', () => {
++    writeAgentSession('aaaa-0004', 'claude');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'claude' });
++    expect(sessions).toHaveLength(1);
++  });
++
++  it('exact wrapper filter "codemie-claude" does NOT match native session "claude" (prevents native leak)', () => {
++    writeAgentSession('aaaa-0005', 'claude');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
++    expect(sessions).toHaveLength(0);
++  });
++
++  it('exact wrapper filter "codemie-gemini" does NOT match "codemie-claude" session (cross-agent)', () => {
++    writeAgentSession('aaaa-0006', 'codemie-claude');
++    const loader = new MetricsDataLoader(dir);
++    const sessions = loader.loadSessions({ agentName: 'codemie-gemini' });
++    expect(sessions).toHaveLength(0);
++  });
++});
+diff --git a/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts b/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+index 262081d..3c36763 100644
+--- a/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
++++ b/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+@@ -1,6 +1,7 @@
+ import { describe, it, expect } from 'vitest';
+ import { agentMatchesAnalyticsFilter, isCodexFamilyAgent } from '../codex-agent.js';
+ 
++
+ describe('isCodexFamilyAgent', () => {
+   it('matches native codex and codemie-codex wrapper', () => {
+     expect(isCodexFamilyAgent('codex')).toBe(true);
+@@ -21,3 +22,43 @@ describe('agentMatchesAnalyticsFilter', () => {
+     expect(agentMatchesAnalyticsFilter('codex', 'codemie-codex')).toBe(false);
+   });
+ });
++
++describe('agentMatchesAnalyticsFilter — new agents', () => {
++  it.each([
++    // Short-name filter: broad — matches both short and codemie- prefixed sessions
++    ['claude',          'claude'],
++    ['codemie-claude',  'claude'],
++    ['gemini',          'gemini'],
++    ['codemie-gemini',  'gemini'],
++    ['kimi',            'kimi'],
++    ['codemie-kimi',    'kimi'],
++    ['opencode',        'opencode'],
++    ['codemie-opencode','opencode'],
++  ] as [string, string][])('"%s" session + "%s" filter → match (short broad)', (session, filter) => {
++    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
++  });
++
++  it.each([
++    // Exact wrapper filter: narrow — only the exact codemie- name
++    ['codemie-claude',   'codemie-claude'],
++    ['codemie-gemini',   'codemie-gemini'],
++    ['codemie-kimi',     'codemie-kimi'],
++    ['codemie-opencode', 'codemie-opencode'],
++    ['codemie-cli',      'codemie-cli'],
++    // Legacy underscore normalised to hyphen form
++    ['codemie-cli',      'codemie_cli'],
++    ['codemie_cli',      'codemie-cli'],
++    ['codemie_cli',      'codemie_cli'],
++  ] as [string, string][])('"%s" session + "%s" filter → match (exact wrapper)', (session, filter) => {
++    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
++  });
++
++  it('exact codemie-claude filter does NOT match short-name claude session', () => {
++    expect(agentMatchesAnalyticsFilter('claude', 'codemie-claude')).toBe(false);
++  });
++
++  it('does not cross-match different agents', () => {
++    expect(agentMatchesAnalyticsFilter('codemie-claude', 'codemie-gemini')).toBe(false);
++    expect(agentMatchesAnalyticsFilter('claude', 'gemini')).toBe(false);
++  });
++});
+diff --git a/src/cli/commands/analytics/cost/codex-agent.ts b/src/cli/commands/analytics/cost/codex-agent.ts
+index ae26186..cca4660 100644
+--- a/src/cli/commands/analytics/cost/codex-agent.ts
++++ b/src/cli/commands/analytics/cost/codex-agent.ts
+@@ -1,5 +1,5 @@
+ /**
+- * Agent-name helpers for Codex-family analytics (native `codex` and `codemie-codex` wrapper).
++ * Agent-name helpers for analytics — family matching and CLI filter resolution.
+  */
+ 
+ /** True when analytics should use Codex rollout parsers/readers for this agent name. */
+@@ -11,15 +11,37 @@ export function isCodexFamilyAgent(agentName: string | undefined): boolean {
+   return a === 'codex' || a === 'codemie-codex' || a.includes('codex');
+ }
+ 
+-/** Match session agent against a CLI --agent filter (codex matches the whole family). */
++/** Internal: normalise legacy codemie_xxx → codemie-xxx (underscore form). */
++function normalizeAgentId(name: string): string {
++  return name.toLowerCase().replace(/^codemie_/, 'codemie-');
++}
++
++/**
++ * Match session agent against a CLI --agent filter.
++ *
++ * Rules:
++ * - `codex` filter: broad family match (legacy behaviour via isCodexFamilyAgent).
++ * - `codemie-xxx` filter: exact wrapper match only (narrow).
++ * - short-name filter (no prefix): matches both the short name AND `codemie-<short>`.
++ * - Legacy `codemie_xxx` (underscore) in either position is normalised to `codemie-xxx`.
++ */
+ export function agentMatchesAnalyticsFilter(sessionAgent: string, filterAgent: string): boolean {
+-  const filter = filterAgent.toLowerCase();
+-  const session = sessionAgent.toLowerCase();
++  const filter = normalizeAgentId(filterAgent);
++  const session = normalizeAgentId(sessionAgent);
++
++  // Legacy broad match: --agent codex matches all codex family variants
+   if (filter === 'codex') {
+     return isCodexFamilyAgent(session);
+   }
+-  if (filter === 'codemie-codex') {
+-    return session === 'codemie-codex';
++
++  // Exact wrapper match: --agent codemie-xxx matches only codemie-xxx sessions.
++  // native-loader synthesises sessions with agentName 'claude'/'codex' for bare
++  // non-wrapper runs; keeping wrapper filters narrow prevents those from leaking in.
++  if (filter.startsWith('codemie-')) {
++    return session === filter;
+   }
+-  return session === filter;
++
++  // Short-name broad match: --agent claude matches 'claude' AND 'codemie-claude'.
++  // Ensures backward compat after sessions switch to wrapper name storage.
++  return session === filter || session === `codemie-${filter}`;
+ }
+diff --git a/src/cli/commands/hook.ts b/src/cli/commands/hook.ts
+index baadcff..b951ca6 100644
+--- a/src/cli/commands/hook.ts
++++ b/src/cli/commands/hook.ts
+@@ -646,6 +646,16 @@ async function routeHookEvent(event: BaseHookEvent, rawInput: string, sessionId:
+   }
+ }
+ 
++/**
++ * Derive the wrapper agent name for session file storage.
++ * CODEMIE_AGENT carries the short plugin name (e.g. 'claude') so that
++ * AgentRegistry.getAgent() lookups and the backend API payload are unaffected.
++ * Only the persisted session JSON uses the wrapper name.
++ */
++export function toWrapperAgentName(name: string): string {
++  return name.startsWith('codemie') ? name : `codemie-${name}`;
++}
++
+ /**
+  * Helper: Create and save session record
+  * Uses correlation information from hook event
+@@ -737,7 +747,7 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string,
+     // Create session record with correlation already matched
+     const session = {
+       sessionId,
+-      agentName,
++      agentName: toWrapperAgentName(agentName),
+       provider,
+       ...(project && { project }),
+       startTime: Date.now(),

--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/complexity-assessment.json
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/complexity-assessment.json
@@ -1,0 +1,30 @@
+{
+  "schema": 1,
+  "task": "Fix codemie analytics to correctly attribute sessions to wrapper agent names (codemie-claude, codemie-codex, etc.) by changing CODEMIE_AGENT env var derivation in BaseAgentAdapter.ts and extending agentMatchesAnalyticsFilter in codex-agent.ts to handle all 7 agent types bidirectionally.",
+  "generated": "2026-07-16T00:00:00Z",
+  "dimensions": {
+    "component_scope":      { "score": 4, "label": "L" },
+    "requirements_clarity": { "score": 3, "label": "M" },
+    "technical_risk":       { "score": 4, "label": "L" },
+    "file_change_estimate": { "score": 3, "label": "M" },
+    "dependencies":         { "score": 2, "label": "S" },
+    "affected_layers":      { "score": 3, "label": "M" }
+  },
+  "total": 19,
+  "size": "M",
+  "routing": "brainstorming",
+  "key_reasoning": [
+    {
+      "dimension": "component_scope",
+      "reason": "BaseAgentAdapter.ts is the shared base class for all 7 agent plugins — a core shared utility change. The CODEMIE_AGENT env var flows cross-cuttingly through BaseAgentAdapter, hook.ts (createSessionRecord, AgentRegistry.getAgent call sites), codex-agent.ts (analytics filter), and session types.ts. Red flag applied: touches core shared utilities and affects multiple agents."
+    },
+    {
+      "dimension": "technical_risk",
+      "reason": "AgentRegistry.getAgent(CODEMIE_AGENT) is called at multiple points in hook.ts (performIncrementalSync line 318, normalizeEventName line 534, sendSessionStartMetrics line 831). A naive change to the env var will silently break session processing because the registry key is the short name (claude), not the wrapper name. The fix requires deriving wrapper name separately at the CODEMIE_AGENT assignment site while keeping metadata.name unchanged for registry lookups. Additionally, the backend API receives agentName via sendSessionStartMetrics/sendSessionEndMetrics — changing the value changes API payloads and may break server-side dashboards. The codemie_cli legacy underscore variant has no obvious codebase source, requiring special-case handling."
+    }
+  ],
+  "red_flags_applied": [
+    "Component Scope bumped from M (3) to L (4): BaseAgentAdapter.ts is a core shared utility and the change affects all 7 agent types flowing through it"
+  ],
+  "split_recommendation": null
+}

--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/complexity-assessment.md
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/complexity-assessment.md
@@ -1,0 +1,32 @@
+# Complexity Assessment
+
+**Task**: Fix codemie analytics to correctly attribute sessions to wrapper agent names  
+**Total**: 19 / 36 — **Size: M**  
+**Routing**: `superpowers:brainstorming`  
+**Generated**: 2026-07-16
+
+## Dimension Scores
+
+| Dimension | Score | Label | Key Reason |
+|---|---|---|---|
+| Component Scope | 4 | L | `BaseAgentAdapter` is the shared base class for all 7 agents — core shared utility; red flag applied |
+| Requirements Clarity | 3 | M | Core requirements clear; gaps remain (registry aliasing approach undecided, backend API coordination unconfirmed, `codemie_cli` underscore variant has no codebase source) |
+| Technical Risk | 4 | L | `AgentRegistry.getAgent(CODEMIE_AGENT)` is called at 3 sites in `hook.ts`; a naive env var change silently breaks session processing; backend API payload impact may require server coordination |
+| File Change Estimate | 3 | M | 5–7 files across 3+ directories (`BaseAgentAdapter.ts`, `codex-agent.ts`, `types.ts`, possibly `hook.ts`, plus test updates) |
+| Dependencies | 2 | S | No new packages; minor env var derivation change only |
+| Affected Layers | 3 | M | Agent-Plugin layer + Analytics/Service layer + Session-Types; no DB schema, no external integration |
+
+## Red Flags Applied
+
+- Component Scope bumped from M (3) to L (4): `BaseAgentAdapter.ts` is a core shared utility and the change affects all 7 agent types flowing through it.
+
+## Key Risks
+
+1. **`AgentRegistry.getAgent(CODEMIE_AGENT)` dependency** — naive env var change silently breaks session processing at 3 call sites in `hook.ts`. Fix: derive wrapper name separately at the `CODEMIE_AGENT` assignment site while keeping `metadata.name` unchanged.
+2. **Backend API payload change** — `sendSessionStartMetrics`/`sendSessionEndMetrics` pass `agentName` to the CodeMie API; changing the value changes API payloads. May require coordination with the server-side team.
+3. **Backward compatibility** — existing session files on disk use short names. The analytics filter must treat `claude` and `codemie-claude` as the same family bidirectionally.
+4. **`codemie_cli` legacy underscore variant** — no obvious codebase source; requires explicit special-case handling in the filter function.
+
+## Split Recommendation
+
+None — proceed as a single task.

--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/plan.md
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/plan.md
@@ -1,0 +1,482 @@
+# EPMCDME-10379: Fix analytics agent attribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `codemie analytics` attribute sessions to their wrapper agent name (`codemie-claude`, etc.) instead of the short plugin name (`claude`).
+
+**Architecture:** Two independent changes applied in order. Task 1 refactors the analytics filter to handle all seven canonical agent names (short and wrapper form). Task 2 patches the single line in `hook.ts` that stores the session's `agentName` field, and exports a helper to make that change unit-testable. Task 3 adds integration-level fixtures confirming the full read path works end-to-end.
+
+**Tech Stack:** TypeScript, Node.js ≥ 20, Vitest
+
+## Global Constraints
+
+- ES modules only; all imports must include `.js` extension.
+- `@/` alias maps to `/src`; use it for cross-package imports.
+- Conventional Commits with allowed scope list (`analytics`, `cli`). Subject ≤ 100 chars.
+- Ticket reference `EPMCDME-10379` goes in the commit body footer, not the subject.
+- Run `npm run typecheck` and `npx vitest run --project unit <test-file>` after every task.
+- Never use `--no-verify`.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/cli/commands/analytics/cost/codex-agent.ts` | Modify | Add internal `normalizeAgentId`; refactor `agentMatchesAnalyticsFilter` |
+| `src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts` | Modify | Extend with all-agent parametrised tests |
+| `src/cli/commands/hook.ts` | Modify | Export `toWrapperAgentName`; use it in `createSessionRecord` |
+| `src/cli/commands/__tests__/hook-agent-name.test.ts` | Create | Unit tests for `toWrapperAgentName` |
+| `src/agents/core/session/types.ts` | Modify | Update `Session.agentName` comment |
+| `src/cli/commands/analytics/__tests__/data-loader.test.ts` | Modify | Add wrapper-name filter fixture tests |
+
+---
+
+## Task 1: Extend analytics filter for all wrapper agent names
+
+**Files:**
+- Modify: `src/cli/commands/analytics/cost/codex-agent.ts`
+- Modify: `src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts`
+
+**Interfaces:**
+- Produces: `agentMatchesAnalyticsFilter(sessionAgent, filterAgent)` with updated semantics
+  (short filter is broad, exact `codemie-` filter is narrow, legacy underscore normalised).
+  `isCodexFamilyAgent` signature and behaviour unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts` and append below the existing `describe` blocks:
+
+```ts
+describe('agentMatchesAnalyticsFilter — new agents', () => {
+  it.each([
+    // Short-name filter: broad — matches both short and codemie- prefixed sessions
+    ['claude',          'claude'],
+    ['codemie-claude',  'claude'],
+    ['gemini',          'gemini'],
+    ['codemie-gemini',  'gemini'],
+    ['kimi',            'kimi'],
+    ['codemie-kimi',    'kimi'],
+    ['opencode',        'opencode'],
+    ['codemie-opencode','opencode'],
+  ] as [string, string][])('"%s" session + "%s" filter → match (short broad)', (session, filter) => {
+    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
+  });
+
+  it.each([
+    // Exact wrapper filter: narrow — only the exact codemie- name
+    ['codemie-claude',   'codemie-claude'],
+    ['codemie-gemini',   'codemie-gemini'],
+    ['codemie-kimi',     'codemie-kimi'],
+    ['codemie-opencode', 'codemie-opencode'],
+    ['codemie-cli',      'codemie-cli'],
+    // Legacy underscore normalised to hyphen form
+    ['codemie-cli',      'codemie_cli'],
+    ['codemie_cli',      'codemie-cli'],
+    ['codemie_cli',      'codemie_cli'],
+  ] as [string, string][])('"%s" session + "%s" filter → match (exact wrapper)', (session, filter) => {
+    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
+  });
+
+  it('exact codemie-claude filter does NOT match short-name claude session', () => {
+    expect(agentMatchesAnalyticsFilter('claude', 'codemie-claude')).toBe(false);
+  });
+
+  it('does not cross-match different agents', () => {
+    expect(agentMatchesAnalyticsFilter('codemie-claude', 'codemie-gemini')).toBe(false);
+    expect(agentMatchesAnalyticsFilter('claude', 'gemini')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run --project unit src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+```
+
+Expected: Several FAIL lines. The new `it.each` groups fail because the current
+implementation uses exact-match for non-codex agents and doesn't handle `codemie_cli`.
+
+- [ ] **Step 3: Implement the changes in `codex-agent.ts`**
+
+Replace the entire file content:
+
+```ts
+/**
+ * Agent-name helpers for analytics — family matching and CLI filter resolution.
+ */
+
+/** True when analytics should use Codex rollout parsers/readers for this agent name. */
+export function isCodexFamilyAgent(agentName: string | undefined): boolean {
+  const a = (agentName ?? '').toLowerCase();
+  if (!a) {
+    return false;
+  }
+  return a === 'codex' || a === 'codemie-codex' || a.includes('codex');
+}
+
+/** Internal: normalise legacy codemie_xxx → codemie-xxx (underscore form). */
+function normalizeAgentId(name: string): string {
+  return name.toLowerCase().replace(/^codemie_/, 'codemie-');
+}
+
+/**
+ * Match session agent against a CLI --agent filter.
+ *
+ * Rules:
+ * - `codex` filter: broad family match (legacy behaviour via isCodexFamilyAgent).
+ * - `codemie-xxx` filter: exact wrapper match only (narrow).
+ * - short-name filter (no prefix): matches both the short name AND `codemie-<short>`.
+ * - Legacy `codemie_xxx` (underscore) in either position is normalised to `codemie-xxx`.
+ */
+export function agentMatchesAnalyticsFilter(sessionAgent: string, filterAgent: string): boolean {
+  const filter = normalizeAgentId(filterAgent);
+  const session = normalizeAgentId(sessionAgent);
+
+  // Legacy broad match: --agent codex matches all codex family variants
+  if (filter === 'codex') {
+    return isCodexFamilyAgent(session);
+  }
+
+  // Exact wrapper match: --agent codemie-xxx matches only codemie-xxx sessions.
+  // Keeps wrapper filters narrow so native-loader synthesised sessions (agentName
+  // 'claude'/'codex') don't leak into codemie-wrapper-specific reports.
+  if (filter.startsWith('codemie-')) {
+    return session === filter;
+  }
+
+  // Short-name broad match: --agent claude matches 'claude' AND 'codemie-claude'.
+  // Backward compat: scripts using --agent claude still see post-fix sessions stored
+  // under the new wrapper name.
+  return session === filter || session === `codemie-${filter}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run --project unit src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+```
+
+Expected: All tests PASS, including the pre-existing `isCodexFamilyAgent` and
+`agentMatchesAnalyticsFilter` describe blocks and all new parametrised cases.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/commands/analytics/cost/codex-agent.ts \
+        src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+git commit -m "$(cat <<'EOF'
+fix(analytics): extend agentMatchesAnalyticsFilter for all wrapper agent names
+
+Short-name filters (e.g. --agent claude) now match both the short form and the
+codemie- prefixed wrapper form. Legacy codemie_xxx underscore names are normalised
+to codemie-xxx. Exact wrapper filters (--agent codemie-claude) remain narrow so
+native-loader synthesised sessions do not leak in.
+
+EPMCDME-10379
+EOF
+)"
+```
+
+---
+
+## Task 2: Store wrapper name in session file + export helper for testing
+
+**Files:**
+- Modify: `src/cli/commands/hook.ts`
+- Create: `src/cli/commands/__tests__/hook-agent-name.test.ts`
+- Modify: `src/agents/core/session/types.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `export function toWrapperAgentName(name: string): string` from `hook.ts`.
+  Sessions written by `createSessionRecord` will have `agentName: 'codemie-claude'` etc.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/cli/commands/__tests__/hook-agent-name.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toWrapperAgentName } from '../hook.js';
+
+describe('toWrapperAgentName', () => {
+  it('prefixes short plugin names with codemie-', () => {
+    expect(toWrapperAgentName('claude')).toBe('codemie-claude');
+    expect(toWrapperAgentName('codex')).toBe('codemie-codex');
+    expect(toWrapperAgentName('gemini')).toBe('codemie-gemini');
+    expect(toWrapperAgentName('kimi')).toBe('codemie-kimi');
+    expect(toWrapperAgentName('opencode')).toBe('codemie-opencode');
+  });
+
+  it('passes through names that already start with codemie', () => {
+    expect(toWrapperAgentName('codemie-code')).toBe('codemie-code');
+    expect(toWrapperAgentName('codemie-claude')).toBe('codemie-claude');
+    expect(toWrapperAgentName('codemie-cli')).toBe('codemie-cli');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run --project unit src/cli/commands/__tests__/hook-agent-name.test.ts
+```
+
+Expected: FAIL — `toWrapperAgentName` is not exported from `hook.ts`.
+
+- [ ] **Step 3: Add `toWrapperAgentName` to `hook.ts` and apply it**
+
+Find the block that reads `CODEMIE_AGENT` in `createSessionRecord` (around line 660).
+Add the helper immediately before the `createSessionRecord` function definition, and
+update the session object literal inside the function.
+
+Add after the existing imports/constants near the top of `hook.ts` (before
+`createSessionRecord`), around line 650:
+
+```ts
+/**
+ * Derive the wrapper agent name for session file storage.
+ * CODEMIE_AGENT carries the short plugin name (e.g. 'claude') so that
+ * AgentRegistry.getAgent() lookups and the backend API payload are unaffected.
+ * Only the persisted session JSON uses the wrapper name.
+ */
+export function toWrapperAgentName(name: string): string {
+  return name.startsWith('codemie') ? name : `codemie-${name}`;
+}
+```
+
+Then inside `createSessionRecord`, locate the session object literal (around line 738):
+
+```ts
+    // Create session record with correlation already matched
+    const session = {
+      sessionId,
+      agentName,
+```
+
+Change `agentName` to `agentName: toWrapperAgentName(agentName)`:
+
+```ts
+    // Create session record with correlation already matched
+    const session = {
+      sessionId,
+      agentName: toWrapperAgentName(agentName),
+```
+
+Do NOT change any other use of `agentName` in this file — registry lookups, logger
+calls, and metric senders must keep the short name.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run --project unit src/cli/commands/__tests__/hook-agent-name.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Update `Session.agentName` comment in `types.ts`**
+
+Open `src/agents/core/session/types.ts` and find line 115:
+
+```ts
+  agentName: string; // 'claude', 'gemini'
+```
+
+Change to:
+
+```ts
+  agentName: string; // 'codemie-claude', 'codemie-gemini', etc. (wrapper name, not short plugin name)
+```
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/commands/hook.ts \
+        src/cli/commands/__tests__/hook-agent-name.test.ts \
+        src/agents/core/session/types.ts
+git commit -m "$(cat <<'EOF'
+fix(cli): store wrapper agent name in session file
+
+createSessionRecord now writes agentName as 'codemie-claude' etc. instead of
+the short plugin name 'claude'. CODEMIE_AGENT env var is unchanged so
+AgentRegistry lookups and the backend metrics API payload are unaffected.
+
+EPMCDME-10379
+EOF
+)"
+```
+
+---
+
+## Task 3: Data-loader integration tests for wrapper-name filter
+
+**Files:**
+- Modify: `src/cli/commands/analytics/__tests__/data-loader.test.ts`
+
+**Interfaces:**
+- Consumes: `agentMatchesAnalyticsFilter` changes from Task 1 (already in place).
+- Produces: regression coverage confirming the full path from session file read through
+  `matchesFilter` works for wrapper-named sessions.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `src/cli/commands/analytics/__tests__/data-loader.test.ts`.
+
+At the top, confirm the imports include `writeFileSync`, `mkdtempSync`, `rmSync`,
+`join`, `tmpdir`, and `MetricsDataLoader`. They are already present in the existing
+test file.
+
+Append a new `describe` block at the end of the file:
+
+```ts
+describe('MetricsDataLoader.loadSessions — wrapper agent name filter', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'data-loader-wrapper-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeSession(id: string, agentName: string): void {
+    writeFileSync(
+      join(dir, `${id}.json`),
+      JSON.stringify({
+        startTime: 1000,
+        status: 'active',
+        agentName,
+        provider: 'anthropic',
+        workingDirectory: '/tmp/project',
+      })
+    );
+  }
+
+  it('includes codemie-claude session when filtering by short name claude', () => {
+    writeSession('s1', 'codemie-claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'claude' });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].startEvent?.agentName).toBe('codemie-claude');
+  });
+
+  it('includes pre-fix claude session when filtering by short name claude', () => {
+    writeSession('s2', 'claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'claude' });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].startEvent?.agentName).toBe('claude');
+  });
+
+  it('returns codemie-claude session when filtering by exact wrapper codemie-claude', () => {
+    writeSession('s3', 'codemie-claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('excludes pre-fix claude session when filtering by exact wrapper codemie-claude', () => {
+    writeSession('s4', 'claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('includes codemie-gemini session when filtering by short name gemini', () => {
+    writeSession('s5', 'codemie-gemini');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'gemini' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('matches codemie_cli (underscore) session when filtering by codemie-cli (hyphen)', () => {
+    writeSession('s6', 'codemie_cli');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-cli' });
+    expect(sessions).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+npx vitest run --project unit src/cli/commands/analytics/__tests__/data-loader.test.ts
+```
+
+Expected: All tests PASS. The new tests pass immediately because Task 1 already
+implemented the filter logic they exercise. No production code change is needed here.
+
+- [ ] **Step 3: Run the full unit suite to confirm no regressions**
+
+```bash
+npm run test:unit
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/analytics/__tests__/data-loader.test.ts
+git commit -m "$(cat <<'EOF'
+test(analytics): add wrapper-name filter fixture tests for data-loader
+
+Verifies that codemie-claude sessions are included by --agent claude (short broad),
+excluded by --agent codemie-claude if stored as the pre-fix short name, and that
+legacy codemie_cli (underscore) sessions are matched by codemie-cli (hyphen) filter.
+
+EPMCDME-10379
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Covered by |
+|---|---|
+| Session file stores `codemie-claude` etc. | Task 2: `toWrapperAgentName` in `createSessionRecord` |
+| Analytics filter handles all 7 agent types | Task 1: `normalizeAgentId` + `agentMatchesAnalyticsFilter` |
+| Legacy `codemie_cli` underscore handled | Task 1: `normalizeAgentId` strips underscore form |
+| `codemie-cli` exact match works | Task 1: exact wrapper path |
+| Backward compat: `--agent claude` still works | Task 1: short-name broad path |
+| Existing codex narrow behaviour preserved | Task 1: codex family path unchanged |
+| `Session.agentName` comment updated | Task 2 Step 5 |
+| Tests for each new agent type | Tasks 1 + 3 |
+| No changes to `CODEMIE_AGENT`, registry, or backend API | Task 2: only session object field changed |
+
+**Placeholder scan:** No TBDs or incomplete steps found.
+
+**Type consistency:** `toWrapperAgentName` defined and exported in Task 2 Step 3; consumed in the same step; tested in Step 1. No cross-task type mismatches.

--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/spec.md
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/spec.md
@@ -1,0 +1,163 @@
+# Spec: Fix codemie analytics agent attribution
+
+**Ticket**: EPMCDME-10379  
+**Branch**: EPMCDME-10379_fix-analytics-agent-attribution  
+**Date**: 2026-07-16
+
+---
+
+## Problem
+
+`codemie analytics` does not show usage data for new CLI agents (`codemie-claude`,
+`codemie-codex`, `codemie-gemini`, `codemie-kimi`, `codemie-opencode`). Their sessions
+merge silently into rows named `claude`, `codex`, etc. and are invisible as distinct
+entities.
+
+**Root cause**: `BaseAgentAdapter.run()` sets `CODEMIE_AGENT: this.metadata.name`, which
+is the short plugin name (`claude`, `codex`, …). This env var is inherited by lifecycle
+hooks that write `~/.codemie/sessions/<uuid>.json`, so `agentName` in every session file
+is the short name instead of the wrapper name (`codemie-claude`, …).
+
+---
+
+## Approach
+
+**Approach A — derive wrapper name at session write time only.**
+
+`CODEMIE_AGENT` stays as the short name throughout the process. Three call sites in
+`hook.ts` pass it to `AgentRegistry.getAgent()`, and the backend API receives it via
+`sendSessionStartMetrics`/`sendSessionEndMetrics` — both are left untouched. Only the
+session file's `agentName` field is changed to the wrapper name.
+
+---
+
+## Changes
+
+### 1. `src/cli/commands/hook.ts`
+
+Add a module-level helper:
+
+```ts
+function toWrapperAgentName(name: string): string {
+  return name.startsWith('codemie') ? name : `codemie-${name}`;
+}
+```
+
+In `createSessionRecord()`, after reading `agentName` from `CODEMIE_AGENT`, use
+`toWrapperAgentName(agentName)` for the Session object's `agentName` field only:
+
+```ts
+const session = {
+  sessionId,
+  agentName: toWrapperAgentName(agentName),  // was: agentName
+  provider,
+  ...
+};
+```
+
+The re-entry branch (lines 708–734) loads an existing live session from disk — its
+`agentName` was already set at creation and is not updated. The transcript marker call
+(`appendTranscriptMarker(path, sessionId, agentName)`) keeps the short name since it is
+used only for log markers, not for analytics.
+
+Registry lookups, logger init, `sendSessionStartMetrics`, and `sendSessionEndMetrics`
+all continue to use the short `agentName` from `CODEMIE_AGENT` unchanged.
+
+### 2. `src/cli/commands/analytics/cost/codex-agent.ts`
+
+Refactor `agentMatchesAnalyticsFilter` using an internal normaliser:
+
+```ts
+/** Internal: normalise legacy codemie_xxx to codemie-xxx. */
+function normalizeAgentId(name: string): string {
+  return name.toLowerCase().replace(/^codemie_/, 'codemie-');
+}
+
+export function agentMatchesAnalyticsFilter(sessionAgent: string, filterAgent: string): boolean {
+  const filter = normalizeAgentId(filterAgent);
+  const session = normalizeAgentId(sessionAgent);
+
+  // Legacy broad match: --agent codex matches all codex family variants
+  if (filter === 'codex') {
+    return isCodexFamilyAgent(session);
+  }
+
+  // Exact wrapper match: --agent codemie-xxx matches only codemie-xxx sessions.
+  // native-loader synthesises sessions with agentName 'claude'/'codex' for bare
+  // non-wrapper runs; keeping wrapper filters narrow prevents those from leaking in.
+  if (filter.startsWith('codemie-')) {
+    return session === filter;
+  }
+
+  // Short-name broad match: --agent claude matches 'claude' AND 'codemie-claude'.
+  // Ensures backward compat after sessions switch to wrapper name storage.
+  return session === filter || session === `codemie-${filter}`;
+}
+```
+
+`isCodexFamilyAgent` is unchanged.
+
+**Filter matching table**:
+
+| Session `agentName` | Filter | Matches | Reason |
+|---|---|---|---|
+| `claude` (pre-fix) | `claude` | ✓ | short broad |
+| `codemie-claude` (new) | `claude` | ✓ | short broad |
+| `claude` (pre-fix) | `codemie-claude` | ✗ | exact wrapper, narrow |
+| `codemie-claude` (new) | `codemie-claude` | ✓ | exact wrapper |
+| `codemie-codex` | `codex` | ✓ | codex family path |
+| `codex` | `codemie-codex` | ✗ | exact wrapper, narrow (existing) |
+| `codemie-gemini` | `gemini` | ✓ | short broad |
+| `codemie-kimi` | `kimi` | ✓ | short broad |
+| `codemie-opencode` | `opencode` | ✓ | short broad |
+| `codemie-cli` | `codemie-cli` | ✓ | exact wrapper |
+| `codemie_cli` | `codemie-cli` | ✓ | underscore normalised |
+| `codemie_cli` | `codemie_cli` | ✓ | underscore normalised |
+| `codemie-claude` | `codemie-gemini` | ✗ | different agent |
+
+### 3. `src/agents/core/session/types.ts`
+
+Update the `Session.agentName` comment from `// 'claude', 'gemini'` to
+`// 'codemie-claude', 'codemie-gemini', etc.`
+
+---
+
+## Tests
+
+### `src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts`
+
+Extend with:
+
+- `agentMatchesAnalyticsFilter` parametrised tests covering: short-name broad matches
+  for all new agents, exact wrapper matches, legacy underscore normalisation, existing
+  codex narrow behaviour preserved, cross-agent non-match assertions.
+
+### `src/cli/commands/analytics/__tests__/data-loader.test.ts`
+
+Add one fixture test: write a session file with `agentName: 'codemie-claude'`, call
+`matchesFilter` with `agentName: 'claude'` — assert the session is included. Add the
+inverse (session `claude`, filter `codemie-claude`).
+
+---
+
+## Acceptance Criteria
+
+- `codemie analytics` displays rows for all 7 CLI agent types: `codemie-cli`,
+  `codemie-claude`, `codemie-codex`, `codemie-gemini`, `codemie-kimi`,
+  `codemie-opencode`, `codemie_cli` (legacy underscore via bidirectional filter).
+- New sessions written by wrapper agents carry the wrapper name in
+  `~/.codemie/sessions/<uuid>.json`.
+- `--agent claude` and `--agent codemie-claude` both match new and pre-fix sessions.
+- Existing `codemie-cli` behaviour is unchanged.
+- No changes to `CODEMIE_AGENT`, `AgentRegistry`, or the backend API payload.
+- All new tests pass; existing tests remain green.
+
+---
+
+## Out of Scope
+
+- Retroactive migration of existing session files on disk (not needed; the filter
+  handles both old and new names bidirectionally).
+- Backend (`codemie` repo) changes — tracked separately in MR !3762.
+- `NATIVE_AGENTS` extension in `native-loader.ts` — pre-existing limitation, separate
+  ticket.

--- a/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/technical-analysis.md
+++ b/docs/superpowers/tasks/2026-07-16-epmcdme-10379-fix-analytics-agent-attribution/technical-analysis.md
@@ -1,0 +1,204 @@
+# Technical Research
+
+**Task**: analytics agentName session cli agents
+**Generated**: 2026-07-16T00:00:00Z
+**Research path**: filesystem
+
+---
+
+## 1. Original Context
+
+Fix codemie analytics command to support all agents. The `codemie analytics` CLI command does not show usage data for new CLI agents: `codemie-claude`, `codemie-codex`, `codemie-gemini`, `codemie-kimi`, `codemie-opencode`. Root cause (confirmed): When a new agent runs, the session file written to `~/.codemie/sessions/<uuid>.json` records `agentName: claude` (the underlying process name) instead of `agentName: codemie-claude` (the wrapper name). The CodeMie wrapper identity is lost at session write time. The session write path must record the wrapper agent name, not the inner process name. Key files: `src/cli/commands/analytics/data-loader.ts` reads agentName from session files; need to find where session metadata is written (search for agentName assignments and session file write logic, likely in a session hook or session manager). Acceptance criteria: codemie analytics displays usage statistics for all 7 CLI agent types: codemie-cli, codemie-claude, codemie-codex, codemie-gemini, codemie-kimi, codemie-opencode, codemie_cli (legacy underscore variant). New agent sessions are correctly attributed by agent name. Existing codemie-cli behaviour is unchanged. Tests cover each new agent type appearing in analytics output.
+
+---
+
+## 2. Codebase Findings
+
+### Existing Implementations
+
+**Session write path — the root cause location:**
+
+- `src/agents/core/BaseAgentAdapter.ts` line 511: `CODEMIE_AGENT: this.metadata.name`
+  - This is where `CODEMIE_AGENT` is set in the subprocess environment. `this.metadata.name` is the plugin's short name (`claude`, `codex`, `gemini`, `kimi`, `opencode`), NOT the wrapper name (`codemie-claude`, etc.).
+  - This env var is inherited by all lifecycle hooks that subsequently write the session file.
+
+- `src/cli/commands/hook.ts` function `createSessionRecord()` (line 657–785):
+  - Called from `handleSessionStart()` during the `SessionStart` lifecycle hook.
+  - Reads `agentName = getConfigValue('CODEMIE_AGENT', config)` (line 660).
+  - Writes a `Session` object to `~/.codemie/sessions/<uuid>.json` with `agentName` taken directly from `CODEMIE_AGENT`.
+  - This is the primary write path for CodeMie-tracked sessions.
+
+- `src/agents/core/session/ensure-session.ts` function `ensureSessionFile()` (line 11–77):
+  - Secondary write path used by `codemie-code` (the OpenCode-based built-in) as a fallback when no session file exists at the end of a run.
+  - Reads `agentName = env.CODEMIE_AGENT || defaultAgentName` (line 26).
+  - The `defaultAgentName` parameter is passed as `BUILTIN_AGENT_NAME` (`'codemie-code'`) from the codemie-code plugin.
+
+- `src/agents/core/session/SessionStore.ts`:
+  - `saveSession()` writes the Session JSON to `~/.codemie/sessions/<sessionId>.json`.
+  - No agentName transformation occurs here; it writes whatever the Session object carries.
+
+**Session read / analytics path:**
+
+- `src/cli/commands/analytics/data-loader.ts` `MetricsDataLoader.loadSession()` (line 190–261):
+  - Reads `sessionMetadata.agentName` directly from the JSON file (line 205).
+  - Constructs a `SessionStartEvent` using that raw value — no normalization or remapping is applied.
+
+- `src/cli/commands/analytics/aggregator.ts` line 407:
+  - `agentName: startEvent.agentName` — value passes through unmodified to `SessionAnalytics`.
+
+- `src/cli/commands/analytics/data-loader.ts` `matchesFilter()` (line 286–332):
+  - Agent filter calls `agentMatchesAnalyticsFilter(startEvent.agentName, filter.agentName)` (line 302).
+
+- `src/cli/commands/analytics/cost/codex-agent.ts`:
+  - `agentMatchesAnalyticsFilter()` — currently only handles `codex`/`codemie-codex` family matching explicitly; all other agents use exact-match (`session === filter`).
+  - `isCodexFamilyAgent()` — codex-only family check.
+
+**Agent plugin name constants (what CODEMIE_AGENT is set to today):**
+
+| CLI wrapper invoked | `metadata.name` set in plugin | `CODEMIE_AGENT` written to session file |
+|---|---|---|
+| `codemie-claude` | `claude` (claude.plugin.ts line 63) | `claude` |
+| `codemie-codex` | `codex` (codex.plugin.ts line 106) | `codex` |
+| `codemie-gemini` | `gemini` (gemini.plugin.ts line 29) | `gemini` |
+| `codemie-kimi` | `kimi` (kimi.plugin.ts line 34) | `kimi` |
+| `codemie-opencode` | `opencode` (opencode.plugin.ts line 18) | `opencode` |
+| `codemie-code` (built-in) | `codemie-code` (codemie-code.plugin.ts line 182) | `codemie-code` |
+
+The `BUILTIN_AGENT_NAME = 'codemie-code'` is the only agent whose stored name already matches its wrapper name because it was designed as a standalone entity, not a wrapper around an inner process.
+
+**Native session discovery (separate path):**
+
+- `src/cli/commands/analytics/native-loader.ts`:
+  - `NATIVE_AGENTS = ['claude', 'codex']` — only two native agents are scanned.
+  - `synthesizeRawSession()` and `synthesizeCodexRawSession()` use the `agentName` from the `SessionDescriptor`, which comes from the adapter's `discoverSessions()`. These are untracked (non-CodeMie-wrapper) sessions; their agentName will be `claude` or `codex` naturally.
+
+### Architecture and Layers Affected
+
+**Layers touched by this fix:**
+
+1. **Agent Plugin layer** (`src/agents/core/BaseAgentAdapter.ts`): The single line setting `CODEMIE_AGENT: this.metadata.name` is the source of truth for what gets stored. To preserve the wrapper identity, this value must be the wrapper name (e.g., `codemie-claude`) rather than the inner plugin name (`claude`).
+
+2. **CLI Hook layer** (`src/cli/commands/hook.ts`): `createSessionRecord()` reads `CODEMIE_AGENT` and stores it. No changes needed here if the env var is corrected upstream, but the type comment on `Session.agentName` (currently annotated `// 'claude', 'gemini'`) would need updating.
+
+3. **Session core types** (`src/agents/core/session/types.ts`): The `Session.agentName` field comment reads `// 'claude', 'gemini'` — misleading but structurally harmless; update the comment.
+
+4. **Analytics filter layer** (`src/cli/commands/analytics/cost/codex-agent.ts`): `agentMatchesAnalyticsFilter()` must be extended to support all seven canonical agent name variants. Currently it only has explicit codex-family logic; other agents use bare exact match, which will break if `codemie-claude` is in the session but the user filters `--agent claude`.
+
+5. **Analytics data-loader** (`src/cli/commands/analytics/data-loader.ts`): No structural changes needed; it reads whatever is in the session file. The fix flows through automatically once the upstream write is corrected.
+
+### Integration Points
+
+- `BaseAgentAdapter.run()` → sets `CODEMIE_AGENT` in env → passed to `spawn()` child process which fires hooks.
+- `hook.ts createSessionRecord()` → reads `CODEMIE_AGENT` → `SessionStore.saveSession()` → `~/.codemie/sessions/<uuid>.json`.
+- `hook.ts sendSessionStartMetrics()` / `sendSessionEndMetrics()` → uses `agentName` from `CODEMIE_AGENT` for API telemetry; changing this value also changes what the backend receives.
+- `AgentRegistry.getAgent(agentName)` in `hook.ts performIncrementalSync()` (line 318) and `normalizeEventName()` (line 534): called with the `CODEMIE_AGENT` value. If `CODEMIE_AGENT` becomes `codemie-claude`, the registry must be able to resolve that name. Currently the registry maps `claude` → `ClaudePlugin`; it does NOT have a `codemie-claude` entry.
+- `src/providers/plugins/sso/proxy/plugins/*.plugin.ts`: several proxy plugins also read `agentName` from the session or env; may propagate the new name to the backend.
+- `src/cli/commands/analytics/native-loader.ts`: `NATIVE_AGENTS` array and the `synthesizeRawSession` calls — these are for bare `claude`/`codex` (non-wrapper) runs; no change needed here.
+- `src/cli/commands/analytics/cost/codex-agent.ts`: the `isCodexFamilyAgent()` function is called from `native-loader.ts` and `cost-enricher.ts` to select the correct parser. If `codemie-codex` sessions are now written as `codemie-codex`, `isCodexFamilyAgent()` must continue to match them (it already does: line 11 `a === 'codemie-codex'`).
+
+### Patterns and Conventions
+
+- **Agent metadata name as canonical identity**: `metadata.name` drives the registry key, the CLI binary name suffix (via `AgentCLI.setupProgram()` line 61–63 `programName = name.startsWith('codemie-') ? name : 'codemie-' + name`), and `CODEMIE_AGENT`. Currently metadata names are short (`claude`, `codex`) while wrapper binaries are long (`codemie-claude`, `codemie-codex`).
+- **`agentMatchesAnalyticsFilter` pattern**: extended family matching already exists for codex. The fix should replicate this pattern for all agents that have both a short native name and a `codemie-` prefixed wrapper name.
+- **Session file format**: plain JSON, written by `SessionStore.saveSession()`, read by `MetricsDataLoader.loadSession()`. Schema is `Session` interface in `src/agents/core/session/types.ts`.
+- **CODEMIE_AGENT env var**: single environment variable that flows from `BaseAgentAdapter.run()` through the entire subprocess tree (hooks, proxy plugins, etc.). Changing it is a cross-cutting concern.
+- **`ensureSessionFile` fallback**: used by `codemie-code` plugin as a last-resort session creator. It also reads `CODEMIE_AGENT`; once the env var is correct, it works automatically.
+
+---
+
+## 3. Documentation Findings
+
+### Guides and Architecture Docs
+
+- `.ai-run/guides/architecture/architecture.md` — covers the 5-layer plugin architecture; confirms the `CLI → Registry → Plugin` flow and the role of `BaseAgentAdapter`.
+- `.ai-run/guides/testing/testing-patterns.md` — Vitest conventions; relevant for writing the required new tests.
+- `.ai-run/guides/standards/code-quality.md` — TypeScript conventions (interfaces, explicit return types, no `any`).
+- No guide specifically documents the session write pipeline or the `CODEMIE_AGENT` env var contract.
+
+### Architectural Decisions
+
+- The `BUILTIN_AGENT_NAME = 'codemie-code'` constant (exported from `src/agents/plugins/codemie-code.plugin.ts`) is the only agent whose stored `agentName` already uses the wrapper name convention. This was intentional because `codemie-code` is a standalone product, not a transparent wrapper around a third-party CLI.
+- The `metadata.name` for `claude`, `codex`, `gemini`, `kimi`, `opencode` was chosen to match the underlying third-party CLI binary name. The short-name convention was a deliberate simplification; the wrapper name was not considered a session-attribution requirement at the time.
+- The `AgentRegistry` uses `metadata.name` as its lookup key. Any approach that changes `CODEMIE_AGENT` without changing `metadata.name` must ensure `AgentRegistry.getAgent(CODEMIE_AGENT)` still resolves to the correct plugin (either by keeping the registry key as the short name, or by registering alias keys).
+
+### Derived Conventions
+
+- The pattern `name.startsWith('codemie-') ? name : 'codemie-' + name` in `AgentCLI.setupProgram()` shows a clear precedent: the CLI binary name IS always `codemie-<name>`. The `metadata.name` is the canonical short name used internally; the wrapper binary is `codemie-<short>`.
+- Tests use `agentName: 'claude'` in all fixtures currently. Any test that constructs session fixtures needs to be updated to also test `codemie-claude` etc.
+
+---
+
+## 4. Testing Landscape
+
+### Existing Coverage
+
+- `src/cli/commands/analytics/__tests__/data-loader.test.ts` — tests `MetricsDataLoader.sessionMatchesFilter()` and `loadSessions()` with `agentName: 'claude'` hardcoded. Does NOT test any `codemie-` prefixed agent names.
+- `src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts` — tests `isCodexFamilyAgent()` and `agentMatchesAnalyticsFilter()` for codex family only.
+- `src/cli/commands/analytics/__tests__/aggregator.test.ts` — tests aggregation; uses fixture data with short agent names.
+- `src/cli/commands/analytics/__tests__/native-loader.test.ts` — tests native session synthesis; agent names are `claude`/`codex`.
+- `src/cli/commands/analytics/sources/__tests__/sessions-source.test.ts` — tests native vs. external session filtering; `agentName: 'claude'` in fixtures.
+- No existing test exercises `codemie-claude`, `codemie-gemini`, `codemie-kimi`, `codemie-opencode` as stored `agentName` values.
+
+### Testing Framework and Patterns
+
+- **Framework**: Vitest (see `package.json`, guide: `.ai-run/guides/testing/testing-patterns.md`).
+- **Dynamic import mocking**: `vi.mock('../../data-loader.js', ...)` — used in `sessions-source.test.ts`.
+- **Filesystem fixtures**: `mkdtempSync`/`writeFileSync`/`rmSync` — used in `data-loader.test.ts` for real session file I/O.
+- **Pure unit tests**: `codex-agent.test.ts` calls functions directly with no mocks.
+- Test utilities are co-located in `__tests__/` subdirectories within the feature module.
+
+### Coverage Gaps
+
+- No test verifies that `agentMatchesAnalyticsFilter('codemie-claude', 'claude')` returns the expected value (currently `false` — whether that should be `true` is a design decision).
+- No test verifies that `agentMatchesAnalyticsFilter('claude', 'codemie-claude')` returns the expected value.
+- No test uses `codemie-gemini`, `codemie-kimi`, `codemie-opencode` as `agentName` in any session fixture.
+- No test verifies that `BaseAgentAdapter` writes the correct wrapper name into `CODEMIE_AGENT` (that code path is integration-level and has no dedicated unit tests in this module).
+- No test covers `agentMatchesAnalyticsFilter` for the legacy `codemie_cli` (underscore) variant.
+
+---
+
+## 5. Configuration and Environment
+
+### Environment Variables
+
+- `CODEMIE_AGENT`: set by `BaseAgentAdapter.run()` (line 511 of `src/agents/core/BaseAgentAdapter.ts`); consumed by `hook.ts` (session creation, metrics sending), `logger.ts`, and proxy plugins. This is the central variable that needs to change.
+- `CODEMIE_SESSION_ID`: the UUID session identifier; unchanged.
+- `CODEMIE_PROVIDER`: provider name (e.g., `ai-run-sso`); unchanged.
+- `CODEMIE_CLIENT_TYPE`: defaults to `this.metadata.ssoConfig?.clientType || 'codemie-cli'`; independent of agentName.
+- `CODEMIE_AGENT` is also read in `hook.ts initializeLoggerContext()` (line 133) and `hook.ts initializeHookContext()` (line 1244) to initialize the logger's agent name for log formatting.
+
+### Configuration Files
+
+- `~/.codemie/sessions/<uuid>.json` — the session metadata file; `agentName` field is the focus of the fix.
+- `~/.codemie/sessions/completed_<uuid>.json` — renamed form of the above after `SessionEnd`.
+- No config file controls the `agentName` mapping; it derives entirely from `metadata.name` at runtime.
+
+### Feature Flags and Deployment Concerns
+
+- No feature flags exist for agent attribution.
+- The analytics command reads session files directly from disk; no API or database migration is involved.
+- Existing session files on disk with old short names (`claude`, `codex`, etc.) will NOT be retroactively updated. The fix only affects new sessions created after the change is deployed. Backward compatibility of the analytics filter is therefore important: `--agent claude` should still match sessions with stored name `claude` (pre-fix) as well as any new short-name sessions.
+- The backend API (`sendSessionStartMetrics`, `sendSessionEndMetrics`) also receives `agentName`; changing the stored name changes what is sent to the server. This is a backend-facing impact that may require coordination.
+
+---
+
+## 6. Risk Indicators
+
+- **`AgentRegistry.getAgent(CODEMIE_AGENT)` dependency**: `hook.ts` calls `AgentRegistry.getAgent(agentName)` at multiple points (`performIncrementalSync` line 318, `normalizeEventName` line 534, `sendSessionStartMetrics` line 831). If `CODEMIE_AGENT` is changed to `codemie-claude`, the registry lookup will return `undefined` because the registry key is `claude`. This would silently break session processing (incremental sync, hook normalization, MCP detection). **Critical path risk.** Any fix must either: (a) keep `metadata.name` as `claude` and derive the wrapper name separately for session storage, or (b) add registry aliases for `codemie-*` names.
+- **Backend API receives `agentName`**: Both `sendSessionStartMetrics` and `sendSessionEndMetrics` pass `agentName` to the CodeMie API. Changing to wrapper names changes the API payload and may break backend analytics queries or dashboards that filter on short names. **Coordination required.**
+- **`isCodexFamilyAgent()` dependency in native-loader and cost-enricher**: The cost enricher uses `isCodexFamilyAgent(agentName)` to select parsers. If sessions written by `codemie-codex` are stored as `codemie-codex`, `isCodexFamilyAgent()` already handles this (it checks `a === 'codemie-codex'`). No regression here.
+- **Backward compatibility of existing session files**: Sessions already on disk use short names. The `--agent` filter must still match those. The safest approach is to make `agentMatchesAnalyticsFilter` treat `claude` and `codemie-claude` as the same family (bidirectional match).
+- **`codemie_cli` legacy underscore variant**: The acceptance criteria requires matching `codemie_cli` (underscore). No existing code handles this normalization. This is an ad-hoc variant that needs explicit handling in the filter function.
+- **No existing tests for wrapper agent names**: All test fixtures use short names. The test surface for the new names is zero, making regression risk high until covered.
+- **`NATIVE_AGENTS` in native-loader is hardcoded to `['claude', 'codex']`**: Only Claude and Codex native sessions are discovered. Gemini, Kimi, and OpenCode native sessions are NOT discovered. This is a pre-existing limitation; the ticket focuses on CodeMie-tracked sessions, but it is worth noting in scope.
+- **`Session.agentName` type comment**: `types.ts` line 115 comments `// 'claude', 'gemini'` — this is documentation debt, not a code bug, but should be updated.
+
+---
+
+## 7. Summary for Complexity Assessment
+
+**Layers touched and file change surface:** The fix spans three distinct layers. The root cause is in the Agent Plugin layer (`src/agents/core/BaseAgentAdapter.ts`, one line: `CODEMIE_AGENT: this.metadata.name`). However, simply changing `this.metadata.name` to include the `codemie-` prefix would break the `AgentRegistry` lookup used in `src/cli/commands/hook.ts` at multiple call sites. The safest implementation path is to introduce a separate wrapper-name field (e.g., derive `codemie-${this.metadata.name}` at the `CODEMIE_AGENT` assignment site, while keeping `metadata.name` unchanged for registry lookups). The second change required is in the Analytics filter layer: `src/cli/commands/analytics/cost/codex-agent.ts` must have its `agentMatchesAnalyticsFilter` function extended to handle all seven canonical agent types bidirectionally (wrapper name ↔ short name). Total estimated file changes: 3–5 source files (`BaseAgentAdapter.ts`, `codex-agent.ts`, `types.ts` comment update, possibly `hook.ts` if the logger/registry call sites need guard updates).
+
+**Technical novelty:** The pattern for family-based agent matching already exists (Codex family). The fix extends this established pattern to all agents. The tricky part is ensuring `AgentRegistry.getAgent()` continues to work after the env var change — this requires either a wrapper-name derivation at the assignment site (preferred) or registry aliasing. The derivation approach (`codemie-${name}` where name is the short plugin name) is straightforward and keeps `metadata.name` as the stable registry key. The `codemie_cli` legacy underscore variant (acceptance criteria item 7) is a special case with no obvious source in the current codebase — it may be a historical alias from before hyphens were standardized.
+
+**Test coverage posture and key risks:** The affected area has moderate test coverage for existing behavior but zero coverage for the new agent name variants. Tests will need to be added for `codex-agent.ts` filter logic (covering all seven agent types), for the data-loader's filter behavior with wrapper names, and possibly for the `BaseAgentAdapter` env var assignment. The most significant risk is the `AgentRegistry.getAgent(CODEMIE_AGENT)` dependency in `hook.ts` — if the implementation naively changes the env var to the wrapper name, session processing will silently degrade (hooks will log a warning and skip processing, causing sessions to appear in analytics with no metrics data). Backend API impact (agentName in metrics API calls) may require server-side coordination and should be confirmed before deploying.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,7 +2325,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.2.tgz",
       "integrity": "sha512-KfjEOT6sCg0vvItagfEtGpmrGoLMGfma4Affb5BGEqPmS2YR3AxW54pABSkhQlzCehTB+0BnLquAe1lGF4J9zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -3695,7 +3694,6 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3793,7 +3791,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4113,7 +4110,6 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -4164,7 +4160,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4940,7 +4935,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5398,7 +5392,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7846,7 +7839,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.9.0.tgz",
       "integrity": "sha512-n2sJRYmM+xfJ0l3OfH8eNnIyv3nQY7L08gZQu3dw6wSdfPtKAk92L83M2NIP5SS8Cl/bsBBG3yKzEOjkx0O+7A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -9337,7 +9329,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9406,7 +9397,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -9482,7 +9472,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -9788,7 +9777,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agents/core/session/agent-name.ts
+++ b/src/agents/core/session/agent-name.ts
@@ -1,0 +1,11 @@
+/**
+ * Derive the wrapper agent name for session file storage.
+ * CODEMIE_AGENT carries the short plugin name (e.g. 'claude') so that
+ * AgentRegistry.getAgent() lookups and the backend API payload are unaffected.
+ * Only the persisted session JSON uses the wrapper name.
+ */
+export function toWrapperAgentName(name: string): string {
+  if (!name) return name;
+  const normalized = name.toLowerCase().replace(/^codemie_/, 'codemie-');
+  return normalized.startsWith('codemie-') ? normalized : `codemie-${normalized}`;
+}

--- a/src/agents/core/session/ensure-session.ts
+++ b/src/agents/core/session/ensure-session.ts
@@ -1,5 +1,11 @@
 import { logger } from '../../../utils/logger.js';
 
+function toWrapperAgentName(name: string): string {
+  if (!name) return name;
+  const normalized = name.toLowerCase().replace(/^codemie_/, 'codemie-');
+  return normalized.startsWith('codemie-') ? normalized : `codemie-${normalized}`;
+}
+
 /**
  * Ensure session metadata file exists for SessionSyncer.
  * Creates a new session file in ~/.codemie/sessions/ if one doesn't already exist.
@@ -23,7 +29,7 @@ export async function ensureSessionFile(
       return;
     }
 
-    const agentName = env.CODEMIE_AGENT || defaultAgentName;
+    const agentName = toWrapperAgentName(env.CODEMIE_AGENT || defaultAgentName);
     const provider = env.CODEMIE_PROVIDER || 'unknown';
     const project = env.CODEMIE_PROJECT;
     const workingDirectory = process.cwd();

--- a/src/agents/core/session/ensure-session.ts
+++ b/src/agents/core/session/ensure-session.ts
@@ -1,10 +1,5 @@
 import { logger } from '../../../utils/logger.js';
-
-function toWrapperAgentName(name: string): string {
-  if (!name) return name;
-  const normalized = name.toLowerCase().replace(/^codemie_/, 'codemie-');
-  return normalized.startsWith('codemie-') ? normalized : `codemie-${normalized}`;
-}
+import { toWrapperAgentName } from './agent-name.js';
 
 /**
  * Ensure session metadata file exists for SessionSyncer.

--- a/src/agents/core/session/types.ts
+++ b/src/agents/core/session/types.ts
@@ -112,7 +112,7 @@ export interface RuntimeCheckpoint {
  */
 export interface Session {
   sessionId: string; // CodeMie session ID (UUID)
-  agentName: string; // 'claude', 'gemini'
+  agentName: string; // 'codemie-claude', 'codemie-gemini', etc. (wrapper name, not short plugin name)
   provider: string; // 'ai-run-sso', etc.
   project?: string; // SSO project name (optional, only for ai-run-sso provider)
   startTime: number; // Unix timestamp (ms)

--- a/src/cli/commands/__tests__/hook-agent-name.test.ts
+++ b/src/cli/commands/__tests__/hook-agent-name.test.ts
@@ -10,9 +10,18 @@ describe('toWrapperAgentName', () => {
     expect(toWrapperAgentName('opencode')).toBe('codemie-opencode');
   });
 
-  it('passes through names that already start with codemie', () => {
+  it('passes through names that already start with codemie-', () => {
     expect(toWrapperAgentName('codemie-code')).toBe('codemie-code');
     expect(toWrapperAgentName('codemie-claude')).toBe('codemie-claude');
     expect(toWrapperAgentName('codemie-cli')).toBe('codemie-cli');
+  });
+
+  it('normalises codemie_ (underscore) to codemie- (hyphen)', () => {
+    expect(toWrapperAgentName('codemie_cli')).toBe('codemie-cli');
+    expect(toWrapperAgentName('codemie_claude')).toBe('codemie-claude');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(toWrapperAgentName('')).toBe('');
   });
 });

--- a/src/cli/commands/__tests__/hook-agent-name.test.ts
+++ b/src/cli/commands/__tests__/hook-agent-name.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { toWrapperAgentName } from '../hook.js';
+
+describe('toWrapperAgentName', () => {
+  it('prefixes short plugin names with codemie-', () => {
+    expect(toWrapperAgentName('claude')).toBe('codemie-claude');
+    expect(toWrapperAgentName('codex')).toBe('codemie-codex');
+    expect(toWrapperAgentName('gemini')).toBe('codemie-gemini');
+    expect(toWrapperAgentName('kimi')).toBe('codemie-kimi');
+    expect(toWrapperAgentName('opencode')).toBe('codemie-opencode');
+  });
+
+  it('passes through names that already start with codemie', () => {
+    expect(toWrapperAgentName('codemie-code')).toBe('codemie-code');
+    expect(toWrapperAgentName('codemie-claude')).toBe('codemie-claude');
+    expect(toWrapperAgentName('codemie-cli')).toBe('codemie-cli');
+  });
+});

--- a/src/cli/commands/analytics/__tests__/data-loader.test.ts
+++ b/src/cli/commands/analytics/__tests__/data-loader.test.ts
@@ -286,4 +286,11 @@ describe('MetricsDataLoader.loadSessions — wrapper agent name filter', () => {
     const sessions = loader.loadSessions({ agentName: 'codemie-gemini' });
     expect(sessions).toHaveLength(0);
   });
+
+  it('hyphen filter "codemie-cli" matches underscore-form session "codemie_cli" (legacy normalisation)', () => {
+    writeAgentSession('aaaa-0007', 'codemie_cli');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-cli' });
+    expect(sessions).toHaveLength(1);
+  });
 });

--- a/src/cli/commands/analytics/__tests__/data-loader.test.ts
+++ b/src/cli/commands/analytics/__tests__/data-loader.test.ts
@@ -219,3 +219,71 @@ describe('MetricsDataLoader.loadSessions — completed_ prefixed sessions', () =
     expect(sessions[0].agentSessionFile).toBeUndefined();
   });
 });
+
+describe('MetricsDataLoader.loadSessions — wrapper agent name filter', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'data-loader-agent-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeAgentSession(id: string, agentName: string): void {
+    writeFileSync(
+      join(dir, `completed_${id}.json`),
+      JSON.stringify({
+        startTime: 1000,
+        endTime: 2000,
+        status: 'completed',
+        agentName,
+        provider: 'anthropic',
+        workingDirectory: '/tmp/project',
+      })
+    );
+  }
+
+  it('short filter "claude" matches wrapper-named session "codemie-claude" (broad)', () => {
+    writeAgentSession('aaaa-0001', 'codemie-claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'claude' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('short filter "gemini" matches wrapper-named session "codemie-gemini" (broad)', () => {
+    writeAgentSession('aaaa-0002', 'codemie-gemini');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'gemini' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('exact wrapper filter "codemie-claude" matches wrapper session "codemie-claude" (narrow)', () => {
+    writeAgentSession('aaaa-0003', 'codemie-claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('short filter "claude" also matches native short-name session "claude" (backward compat)', () => {
+    writeAgentSession('aaaa-0004', 'claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'claude' });
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('exact wrapper filter "codemie-claude" does NOT match native session "claude" (prevents native leak)', () => {
+    writeAgentSession('aaaa-0005', 'claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-claude' });
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('exact wrapper filter "codemie-gemini" does NOT match "codemie-claude" session (cross-agent)', () => {
+    writeAgentSession('aaaa-0006', 'codemie-claude');
+    const loader = new MetricsDataLoader(dir);
+    const sessions = loader.loadSessions({ agentName: 'codemie-gemini' });
+    expect(sessions).toHaveLength(0);
+  });
+});

--- a/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { agentMatchesAnalyticsFilter, isCodexFamilyAgent } from '../codex-agent.js';
 
+
 describe('isCodexFamilyAgent', () => {
   it('matches native codex and codemie-codex wrapper', () => {
     expect(isCodexFamilyAgent('codex')).toBe(true);
@@ -19,5 +20,45 @@ describe('agentMatchesAnalyticsFilter', () => {
   it('filters codemie-codex narrowly', () => {
     expect(agentMatchesAnalyticsFilter('codemie-codex', 'codemie-codex')).toBe(true);
     expect(agentMatchesAnalyticsFilter('codex', 'codemie-codex')).toBe(false);
+  });
+});
+
+describe('agentMatchesAnalyticsFilter — new agents', () => {
+  it.each([
+    // Short-name filter: broad — matches both short and codemie- prefixed sessions
+    ['claude',          'claude'],
+    ['codemie-claude',  'claude'],
+    ['gemini',          'gemini'],
+    ['codemie-gemini',  'gemini'],
+    ['kimi',            'kimi'],
+    ['codemie-kimi',    'kimi'],
+    ['opencode',        'opencode'],
+    ['codemie-opencode','opencode'],
+  ] as [string, string][])('"%s" session + "%s" filter → match (short broad)', (session, filter) => {
+    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
+  });
+
+  it.each([
+    // Exact wrapper filter: narrow — only the exact codemie- name
+    ['codemie-claude',   'codemie-claude'],
+    ['codemie-gemini',   'codemie-gemini'],
+    ['codemie-kimi',     'codemie-kimi'],
+    ['codemie-opencode', 'codemie-opencode'],
+    ['codemie-cli',      'codemie-cli'],
+    // Legacy underscore normalised to hyphen form
+    ['codemie-cli',      'codemie_cli'],
+    ['codemie_cli',      'codemie-cli'],
+    ['codemie_cli',      'codemie_cli'],
+  ] as [string, string][])('"%s" session + "%s" filter → match (exact wrapper)', (session, filter) => {
+    expect(agentMatchesAnalyticsFilter(session, filter)).toBe(true);
+  });
+
+  it('exact codemie-claude filter does NOT match short-name claude session', () => {
+    expect(agentMatchesAnalyticsFilter('claude', 'codemie-claude')).toBe(false);
+  });
+
+  it('does not cross-match different agents', () => {
+    expect(agentMatchesAnalyticsFilter('codemie-claude', 'codemie-gemini')).toBe(false);
+    expect(agentMatchesAnalyticsFilter('claude', 'gemini')).toBe(false);
   });
 });

--- a/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts
@@ -61,4 +61,9 @@ describe('agentMatchesAnalyticsFilter — new agents', () => {
     expect(agentMatchesAnalyticsFilter('codemie-claude', 'codemie-gemini')).toBe(false);
     expect(agentMatchesAnalyticsFilter('claude', 'gemini')).toBe(false);
   });
+
+  it('returns false for undefined session agent (marker/non-session files)', () => {
+    expect(agentMatchesAnalyticsFilter(undefined, 'claude')).toBe(false);
+    expect(agentMatchesAnalyticsFilter(undefined, 'codemie-claude')).toBe(false);
+  });
 });

--- a/src/cli/commands/analytics/cost/codex-agent.ts
+++ b/src/cli/commands/analytics/cost/codex-agent.ts
@@ -1,5 +1,5 @@
 /**
- * Agent-name helpers for Codex-family analytics (native `codex` and `codemie-codex` wrapper).
+ * Agent-name helpers for analytics — family matching and CLI filter resolution.
  */
 
 /** True when analytics should use Codex rollout parsers/readers for this agent name. */
@@ -11,15 +11,37 @@ export function isCodexFamilyAgent(agentName: string | undefined): boolean {
   return a === 'codex' || a === 'codemie-codex' || a.includes('codex');
 }
 
-/** Match session agent against a CLI --agent filter (codex matches the whole family). */
+/** Internal: normalise legacy codemie_xxx → codemie-xxx (underscore form). */
+function normalizeAgentId(name: string): string {
+  return name.toLowerCase().replace(/^codemie_/, 'codemie-');
+}
+
+/**
+ * Match session agent against a CLI --agent filter.
+ *
+ * Rules:
+ * - `codex` filter: broad family match (legacy behaviour via isCodexFamilyAgent).
+ * - `codemie-xxx` filter: exact wrapper match only (narrow).
+ * - short-name filter (no prefix): matches both the short name AND `codemie-<short>`.
+ * - Legacy `codemie_xxx` (underscore) in either position is normalised to `codemie-xxx`.
+ */
 export function agentMatchesAnalyticsFilter(sessionAgent: string, filterAgent: string): boolean {
-  const filter = filterAgent.toLowerCase();
-  const session = sessionAgent.toLowerCase();
+  const filter = normalizeAgentId(filterAgent);
+  const session = normalizeAgentId(sessionAgent);
+
+  // Legacy broad match: --agent codex matches all codex family variants
   if (filter === 'codex') {
     return isCodexFamilyAgent(session);
   }
-  if (filter === 'codemie-codex') {
-    return session === 'codemie-codex';
+
+  // Exact wrapper match: --agent codemie-xxx matches only codemie-xxx sessions.
+  // native-loader synthesises sessions with agentName 'claude'/'codex' for bare
+  // non-wrapper runs; keeping wrapper filters narrow prevents those from leaking in.
+  if (filter.startsWith('codemie-')) {
+    return session === filter;
   }
-  return session === filter;
+
+  // Short-name broad match: --agent claude matches 'claude' AND 'codemie-claude'.
+  // Ensures backward compat after sessions switch to wrapper name storage.
+  return session === filter || session === `codemie-${filter}`;
 }

--- a/src/cli/commands/analytics/cost/codex-agent.ts
+++ b/src/cli/commands/analytics/cost/codex-agent.ts
@@ -25,7 +25,8 @@ function normalizeAgentId(name: string): string {
  * - short-name filter (no prefix): matches both the short name AND `codemie-<short>`.
  * - Legacy `codemie_xxx` (underscore) in either position is normalised to `codemie-xxx`.
  */
-export function agentMatchesAnalyticsFilter(sessionAgent: string, filterAgent: string): boolean {
+export function agentMatchesAnalyticsFilter(sessionAgent: string | undefined, filterAgent: string): boolean {
+  if (!sessionAgent) return false;
   const filter = normalizeAgentId(filterAgent);
   const session = normalizeAgentId(sessionAgent);
 

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -647,6 +647,16 @@ async function routeHookEvent(event: BaseHookEvent, rawInput: string, sessionId:
 }
 
 /**
+ * Derive the wrapper agent name for session file storage.
+ * CODEMIE_AGENT carries the short plugin name (e.g. 'claude') so that
+ * AgentRegistry.getAgent() lookups and the backend API payload are unaffected.
+ * Only the persisted session JSON uses the wrapper name.
+ */
+export function toWrapperAgentName(name: string): string {
+  return name.startsWith('codemie') ? name : `codemie-${name}`;
+}
+
+/**
  * Helper: Create and save session record
  * Uses correlation information from hook event
  *
@@ -737,7 +747,7 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
     // Create session record with correlation already matched
     const session = {
       sessionId,
-      agentName,
+      agentName: toWrapperAgentName(agentName),
       provider,
       ...(project && { project }),
       startTime: Date.now(),

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -653,7 +653,9 @@ async function routeHookEvent(event: BaseHookEvent, rawInput: string, sessionId:
  * Only the persisted session JSON uses the wrapper name.
  */
 export function toWrapperAgentName(name: string): string {
-  return name.startsWith('codemie') ? name : `codemie-${name}`;
+  if (!name) return name;
+  const normalized = name.toLowerCase().replace(/^codemie_/, 'codemie-');
+  return normalized.startsWith('codemie-') ? normalized : `codemie-${normalized}`;
 }
 
 /**
@@ -806,7 +808,7 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
 async function sendSessionStartMetrics(event: SessionStartEvent, sessionId: string, agentSessionId: string, config?: HookProcessingConfig): Promise<void> {
   try {
     // Get required configuration values
-    const agentName = getConfigValue('CODEMIE_AGENT', config);
+    const agentName = getConfigValue('CODEMIE_AGENT', config); // short plugin name intentional — backend API key
     const provider = getConfigValue('CODEMIE_PROVIDER', config);
     const ssoUrl = getConfigValue('CODEMIE_URL', config);
     const syncApiUrl = getConfigValue('CODEMIE_SYNC_API_URL', config);
@@ -1079,7 +1081,7 @@ async function renameSessionFiles(sessionId: string): Promise<void> {
 async function sendSessionEndMetrics(event: SessionEndEvent, sessionId: string, agentSessionId: string, config?: HookProcessingConfig): Promise<void> {
   try {
     // Get required configuration values
-    const agentName = getConfigValue('CODEMIE_AGENT', config);
+    const agentName = getConfigValue('CODEMIE_AGENT', config); // short plugin name intentional — backend API key
     const provider = getConfigValue('CODEMIE_PROVIDER', config);
     const ssoUrl = getConfigValue('CODEMIE_URL', config);
     const apiUrl = getConfigValue('CODEMIE_SYNC_API_URL', config) || getConfigValue('CODEMIE_BASE_URL', config);

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 import { logger } from '@/utils/logger.js';
 import { AgentRegistry } from '@/agents/registry.js';
 import { getSessionPath, getSessionMetricsPath, getSessionConversationPath } from '@/agents/core/session/session-config.js';
+import { toWrapperAgentName } from '@/agents/core/session/agent-name.js';
+export { toWrapperAgentName };
 import type { BaseHookEvent, HookTransformer, MCPConfigSummary, ExtensionsScanSummary } from '@/agents/core/types.js';
 import type { ProcessingContext } from '@/agents/core/session/BaseProcessor.js';
 
@@ -644,18 +646,6 @@ async function routeHookEvent(event: BaseHookEvent, rawInput: string, sessionId:
     );
     throw error;
   }
-}
-
-/**
- * Derive the wrapper agent name for session file storage.
- * CODEMIE_AGENT carries the short plugin name (e.g. 'claude') so that
- * AgentRegistry.getAgent() lookups and the backend API payload are unaffected.
- * Only the persisted session JSON uses the wrapper name.
- */
-export function toWrapperAgentName(name: string): string {
-  if (!name) return name;
-  const normalized = name.toLowerCase().replace(/^codemie_/, 'codemie-');
-  return normalized.startsWith('codemie-') ? normalized : `codemie-${normalized}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes `codemie analytics` showing no data for `codemie-claude`, `codemie-gemini`, `codemie-codex`, `codemie-kimi`, `codemie-opencode` agents.

**Root cause:** Both session write paths stored `CODEMIE_AGENT` (short plugin name, e.g. `claude`) directly in the session JSON instead of the wrapper binary name (`codemie-claude`). Because `codemie analytics --agent codemie-claude` used an exact-match filter, wrapper sessions were invisible.

**Changes:**
- `hook.ts / createSessionRecord` — apply `toWrapperAgentName()` when writing `agentName` to the primary session file. `CODEMIE_AGENT` itself is unchanged so `AgentRegistry.getAgent()` lookups at 3 call-sites continue to work.
- `ensure-session.ts / ensureSessionFile` — second write path (used by opencode plugin) now applies the same wrapper-name transform.
- `toWrapperAgentName` — hardened: guard changed from `startsWith('codemie')` to `startsWith('codemie-')`, `codemie_xxx` underscore form normalised to `codemie-xxx`, empty-string guarded.
- `agentMatchesAnalyticsFilter` — extended; short filter `--agent claude` is broad (matches `claude` and `codemie-claude`), exact wrapper filter `--agent codemie-claude` is narrow (prevents native-loader session leakage).

## Verification

Manual end-to-end on the fix branch. Fire the hook exactly as the wrapper does:

```powershell
$sessionId = "real-test-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())"
$payload = '{"hook_event_name":"SessionStart","session_id":"' + $sessionId + '","transcript_path":"C:/tmp/fake.jsonl","permission_mode":"default","source":"startup"}'
$env:CODEMIE_AGENT = 'claude'
$env:CODEMIE_PROVIDER = 'ai-run-sso'
$env:CODEMIE_SESSION_ID = $sessionId
$payload | node bin/codemie.js hook
```

Session file confirmed written with `"agentName": "codemie-claude"` (was `"claude"` before this fix).

Filter checks (all three verified):

| Command | Expected | Result |
|---|---|---|
| `analytics cost --agent claude --last 1d` | session found | verified |
| `analytics cost --agent codemie-claude --last 1d` | session found | verified |
| `analytics cost --agent codemie-gemini --last 1d` | not found | verified |

## Test plan

- [ ] `npx vitest run --project unit src/cli/commands/analytics/cost/__tests__/codex-agent.test.ts src/cli/commands/__tests__/hook-agent-name.test.ts src/cli/commands/analytics/__tests__/data-loader.test.ts` — 45 tests pass
- [ ] `npx vitest run --project unit` — full unit suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
