### PR TITLE
feat(agents): add DeepSeek V4 Flash (DeepSeek-V4-Flash-2026-04-23) to opencode model configs

### DIFF
--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -538,6 +538,31 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
       context: 1048576,
       output: 65536
     }
+  },
+
+  // ── DeepSeek Models (via DIAL) ────────────────────────────────────
+  'DeepSeek-V4-Flash-2026-04-23': {
+    id: 'DeepSeek-V4-Flash-2026-04-23',
+    name: 'DeepSeek V4 Flash',
+    displayName: 'DeepSeek V4 Flash',
+    family: 'deepseek',
+    tool_call: true,
+    reasoning: false,
+    attachment: false,
+    temperature: true,
+    modalities: { input: ['text'], output: ['text'] },
+    knowledge: '2025-07-01',
+    release_date: '2026-04-23',
+    last_updated: '2026-07-17',
+    open_weights: true,
+    cost: {
+      input: 0,   // TODO: per million tokens (USD) — confirm before merge
+      output: 0   // TODO: per million tokens (USD) — confirm before merge
+    },
+    limit: {
+      context: 65536,  // TODO: confirm from model card
+      output: 65536
+    }
   }
 };
 

--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -556,12 +556,12 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
     last_updated: '2026-07-17',
     open_weights: true,
     cost: {
-      input: 0,   // TODO: per million tokens (USD) — confirm before merge
-      output: 0   // TODO: per million tokens (USD) — confirm before merge
+      input: 0.14,
+      output: 0.28
     },
     limit: {
-      context: 65536,  // TODO: confirm from model card
-      output: 65536
+      context: 1048576,
+      output: 393216
     }
   }
 };


### PR DESCRIPTION
## Summary

- Added `DeepSeek-V4-Flash-2026-04-23` to `opencode-model-configs.ts` with correct metadata (family, tool_call, modalities, cost, context limits)
- Filled confirmed pricing: $0.14/M input, $0.28/M output
- Context window: 1M tokens, output: 384K tokens

## Related

- Jira: [EPMCDME-13146](https://jiraeu.epam.com/browse/EPMCDME-13146)
- Companion MR in codemie repo: adds DIAL and LiteLLM config entries for the same model