### PR TITLE
fix(agents): route gpt-5.6-sol models to Responses API

### DIFF
--- a/src/agents/plugins/__tests__/opencode-gpt55-routing.test.ts
+++ b/src/agents/plugins/__tests__/opencode-gpt55-routing.test.ts
@@ -121,3 +121,46 @@ describe('GPT-5.5 / GPT-5.4 → Responses API routing', () => {
     expect(OPENCODE_MODEL_CONFIGS['gpt-5.5-2026-04-24']!.limit.context).toBe(1050000);
   });
 });
+
+describe('GPT-5.6 → Responses API routing', () => {
+  let convertApiModelToOpenCodeConfig: typeof import('../opencode/opencode-dynamic-models.js').convertApiModelToOpenCodeConfig;
+  let OPENCODE_MODEL_CONFIGS: typeof import('../opencode/opencode-model-configs.js').OPENCODE_MODEL_CONFIGS;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ convertApiModelToOpenCodeConfig } = await import('../opencode/opencode-dynamic-models.js'));
+    ({ OPENCODE_MODEL_CONFIGS } = await import('../opencode/opencode-model-configs.js'));
+  });
+
+  // ── Dynamic path (live catalogue) ──────────────────────────────────────────
+
+  it('routes gpt-5.6-sol-2026-07-09 to Responses API via dynamic model conversion', () => {
+    const config = convertApiModelToOpenCodeConfig(makeLlmModel('gpt-5.6-sol-2026-07-09'));
+    expect(config.use_responses_api).toBe(true);
+  });
+
+  it('routes gpt-5-6-sol-2026-07-09 (hyphenated variant) to Responses API via dynamic conversion', () => {
+    const config = convertApiModelToOpenCodeConfig(makeLlmModel('gpt-5-6-sol-2026-07-09'));
+    expect(config.use_responses_api).toBe(true);
+  });
+
+  it('dynamic gpt-5.6-sol-2026-07-09 reports context limit of 1050000', () => {
+    const config = convertApiModelToOpenCodeConfig(makeLlmModel('gpt-5.6-sol-2026-07-09'));
+    expect(config.limit.context).toBe(1050000);
+  });
+
+  // ── Static fallback path (OPENCODE_MODEL_CONFIGS) ──────────────────────────
+
+  it('static config has gpt-5.6-sol-2026-07-09 with use_responses_api: true', () => {
+    expect(OPENCODE_MODEL_CONFIGS['gpt-5.6-sol-2026-07-09']).toBeDefined();
+    expect(OPENCODE_MODEL_CONFIGS['gpt-5.6-sol-2026-07-09']!.use_responses_api).toBe(true);
+  });
+
+  it('static config gpt-5.6-sol-2026-07-09 supports tool_call', () => {
+    expect(OPENCODE_MODEL_CONFIGS['gpt-5.6-sol-2026-07-09']!.tool_call).toBe(true);
+  });
+
+  it('static config gpt-5.6-sol-2026-07-09 reports context limit of 1050000', () => {
+    expect(OPENCODE_MODEL_CONFIGS['gpt-5.6-sol-2026-07-09']!.limit.context).toBe(1050000);
+  });
+});

--- a/src/agents/plugins/opencode/opencode-dynamic-models.ts
+++ b/src/agents/plugins/opencode/opencode-dynamic-models.ts
@@ -28,7 +28,7 @@ import { logger } from '../../../utils/logger.js';
 //
 // Naming conventions observed in CodeMie deployments:
 //   Responses API  →  gpt-5-2-*, gpt-5.2-*, gpt-5.x-codex-*, gpt-5-x-codex-*,
-//                     gpt-5.4-*, gpt-5-4-*, gpt-5.5-*, gpt-5-5-*
+//                     gpt-5.4-*, gpt-5-4-*, gpt-5.5-*, gpt-5-5-*, gpt-5.6-*, gpt-5-6-*
 //   Chat Completions → gpt-4*, gpt-5-<year>-*, o1/o3/o4*, gemini-*, claude-*, …
 //
 // Update this list whenever new Responses-API-only models are deployed.
@@ -44,6 +44,8 @@ const RESPONSES_API_MODEL_PATTERNS: RegExp[] = [
   /^gpt-5-4-/,        // hyphenated variant of gpt-5.4-*
   /^gpt-5\.5-/,       // gpt-5.5-2026-04-24 — same Azure restriction as gpt-5.4
   /^gpt-5-5-/,        // hyphenated variant of gpt-5.5-*
+  /^gpt-5\.6-/,       // gpt-5.6-sol-2026-07-09 — same Azure restriction (tools + reasoning_effort)
+  /^gpt-5-6-/,        // hyphenated variant of gpt-5.6-*
 ];
 
 function isResponsesApiModel(id: string): boolean {
@@ -75,6 +77,7 @@ function detectLimits(id: string, family: string): { context: number; output: nu
   if (id.startsWith('gpt-4.1')) return { context: 1048576, output: 32768 };
   if (id.startsWith('gpt-4o')) return { context: 128000, output: 16384 };
   if (id.startsWith('gpt-5.5') || id.startsWith('gpt-5-5')) return { context: 1050000, output: 128000 }; // Azure-published window for gpt-5.5
+  if (id.startsWith('gpt-5.6') || id.startsWith('gpt-5-6')) return { context: 1050000, output: 128000 }; // Azure-published window for gpt-5.6
   if (id.startsWith('gpt-5')) return { context: 400000, output: 128000 };
   if (/^o[134]-/.test(id) || id === 'o1') return { context: 200000, output: 100000 };
   if (id.startsWith('qwen') || id.startsWith('moonshotai') || id.startsWith('kimi')) return { context: 262144, output: 131072 };

--- a/src/agents/plugins/opencode/opencode-model-configs.ts
+++ b/src/agents/plugins/opencode/opencode-model-configs.ts
@@ -258,6 +258,36 @@ export const OPENCODE_MODEL_CONFIGS: Record<string, OpenCodeModelConfig> = {
     }
   },
 
+  'gpt-5.6-sol-2026-07-09': {
+    id: 'gpt-5.6-sol-2026-07-09',
+    name: 'GPT-5.6 Sol (Jul 2026)',
+    displayName: 'GPT-5.6 Sol (Jul 2026)',
+    family: 'gpt-5',
+    tool_call: true,
+    reasoning: true,
+    attachment: true,
+    temperature: false,
+    structured_output: true,
+    use_responses_api: true,
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text']
+    },
+    knowledge: '2025-08-31',
+    release_date: '2026-07-09',
+    last_updated: '2026-07-09',
+    open_weights: false,
+    cost: {
+      input: 3.75,
+      output: 15,
+      cache_read: 0.375
+    },
+    limit: {
+      context: 1050000,
+      output: 128000
+    }
+  },
+
   // ── Claude Models ──────────────────────────────────────────────────
   'claude-4-5-sonnet': {
     id: 'claude-4-5-sonnet',


### PR DESCRIPTION
## Summary
`codemie-opencode` routed `gpt-5.6-sol-2026-07-09` as a Chat Completions model, so requests carried function tools + `reasoning_effort` to `/v1/chat/completions` — which Azure rejects for the GPT-5.6 family (`litellm.BadRequestError ... Please use /v1/responses instead`). The model was simply missing from the Responses-API allow-list. This adds gpt-5.6 to the routing so it uses the OpenAI Responses API, mirroring the prior gpt-5.4/5.5 fix (`8407373`).

## Changes
- Add `/^gpt-5\.6-/` and `/^gpt-5-6-/` to `RESPONSES_API_MODEL_PATTERNS` in `opencode-dynamic-models.ts` (dynamic / live-catalogue path).
- Add a `detectLimits` branch for gpt-5.6 (1,050,000 context / 128,000 output).
- Add a static `OPENCODE_MODEL_CONFIGS['gpt-5.6-sol-2026-07-09']` entry with `use_responses_api: true` in `opencode-model-configs.ts` (static-fallback path).
- Extend `opencode-gpt55-routing.test.ts` with gpt-5.6 dynamic + static routing/limit assertions.

## Impact
Before: switching to `gpt-5.6-sol-2026-07-09` fails with an Azure BadRequest. After: it routes through the `openai` CUSTOM_LOADER to `/v1/responses` and works, consistent with gpt-5.4/5.5.

## Testing
- [x] Tests added/updated — 6 new gpt-5.6 cases; `npx vitest run src/agents/plugins/__tests__/opencode-gpt55-routing.test.ts` → 19/19 passing.
- [x] Manual testing done — Responses-API routing for gpt-5.6 confirmed working against the CodeMie proxy (via the equivalent `openai`-provider config).

## Checklist
- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [ ] No merge conflicts with `main`
