### PR TITLE
fix(proxy): handle Keycloak HTML redirect in model discovery and health check (EPMCDME-13540)

### DIFF
--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/code-review-final.json
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/code-review-final.json
@@ -1,0 +1,7 @@
+{
+  "decision": "approve",
+  "rationale": "All changes narrowly implement the approved spec. The two Content-Type guards in desktop.ts and health-check.ts match spec Fix 1 and Fix 2 verbatim, including error messages and return shapes. All five specified test cases are present. Existing mock objects were updated to include headers (required correctness fix). No public contract, type signature, or exported API was added, removed, or changed.",
+  "follow_ups": [],
+  "confidence": "high",
+  "risk_flags": []
+}

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/code-review.diff
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/code-review.diff
@@ -1,0 +1,236 @@
+diff --git a/src/cli/commands/proxy/__tests__/health-check.test.ts b/src/cli/commands/proxy/__tests__/health-check.test.ts
+index 92ad99a..4a8c230 100644
+--- a/src/cli/commands/proxy/__tests__/health-check.test.ts
++++ b/src/cli/commands/proxy/__tests__/health-check.test.ts
+@@ -7,6 +7,7 @@ vi.mock('@/utils/logger.js', () => ({
+ 
+ const HEALTH = (url: unknown): boolean => String(url).endsWith('/health');
+ const MODELS = (url: unknown): boolean => String(url).includes('/v1/llm_models');
++const mkHeaders = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
+ 
+ describe('checkProxyHealth', () => {
+   let originalFetch: typeof globalThis.fetch;
+@@ -59,7 +60,7 @@ describe('checkProxyHealth', () => {
+   it('deep: healthy when /health and /v1/llm_models both succeed, with Bearer auth', async () => {
+     const fetchSpy = vi.fn(async (url: unknown) => {
+       if (HEALTH(url)) return { ok: true, status: 200 };
+-      if (MODELS(url)) return { ok: true, status: 200, json: async () => [] };
++      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('application/json'), json: async () => [] };
+       throw new Error(`unexpected url ${String(url)}`);
+     });
+     globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+@@ -132,4 +133,31 @@ describe('checkProxyHealth', () => {
+     expect(fetchSpy).toHaveBeenCalledTimes(1);
+     expect(MODELS(fetchSpy.mock.calls[0][0])).toBe(false);
+   });
++
++  it('deep: unauthorized when /v1/llm_models returns 200 with HTML content-type (Keycloak redirect)', async () => {
++    globalThis.fetch = vi.fn(async (url: unknown) => {
++      if (HEALTH(url)) return { ok: true, status: 200 };
++      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('text/html; charset=utf-8') };
++      throw new Error(`unexpected url ${String(url)}`);
++    }) as unknown as typeof globalThis.fetch;
++
++    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
++
++    expect(result.healthy).toBe(false);
++    expect(result.level).toBe('deep');
++    expect(result.code).toBe('unauthorized');
++    expect(result.reason).toContain('SSO session expired');
++  });
++
++  it('deep: healthy when /v1/llm_models returns 200 with application/json (regression)', async () => {
++    globalThis.fetch = vi.fn(async (url: unknown) => {
++      if (HEALTH(url)) return { ok: true, status: 200 };
++      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('application/json'), json: async () => [] };
++      throw new Error(`unexpected url ${String(url)}`);
++    }) as unknown as typeof globalThis.fetch;
++
++    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
++
++    expect(result).toEqual({ healthy: true, level: 'deep', code: 'ok' });
++  });
+ });
+diff --git a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+index db4ab3b..f78f15b 100644
+--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
++++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+@@ -75,9 +75,12 @@ describe('fetchClaudeModels', () => {
+   beforeEach(() => { originalFetch = globalThis.fetch; });
+   afterEach(() => { globalThis.fetch = originalFetch; });
+ 
++  const mkHeaders = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
++
+   it('returns Claude family ids and excludes vertex / non-claude entries', async () => {
+     globalThis.fetch = vi.fn().mockResolvedValue({
+       ok: true,
++      headers: mkHeaders('application/json'),
+       json: async () => [
+         { base_name: 'claude-sonnet-4-5-20250929' },
+         { base_name: 'claude-4-5-sonnet' },
+@@ -89,7 +92,7 @@ describe('fetchClaudeModels', () => {
+         { base_name: 'claude-opus-4-6-vertex' },
+         { base_name: 'gpt-5.5-2026-04-24' },
+       ],
+-    }) as any;
++    }) as unknown as typeof globalThis.fetch;
+ 
+     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
+     expect(models).toEqual([
+@@ -104,8 +107,8 @@ describe('fetchClaudeModels', () => {
+   });
+ 
+   it('sends Authorization Bearer header with the gateway key', async () => {
+-    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) });
+-    globalThis.fetch = fetchSpy as any;
++    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, headers: mkHeaders('application/json'), json: async () => ({ data: [] }) });
++    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+ 
+     await fetchClaudeModels('http://127.0.0.1:4001', 'my-key');
+     const [, init] = fetchSpy.mock.calls[0];
+@@ -127,12 +130,13 @@ describe('fetchClaudeModels', () => {
+   it('returns vertex Claude ids when the catalog is vertex-only', async () => {
+     globalThis.fetch = vi.fn().mockResolvedValue({
+       ok: true,
++      headers: mkHeaders('application/json'),
+       json: async () => [
+         { base_name: 'gemini-2.5-flash' },
+         { base_name: 'claude-sonnet-4-5-vertex' },
+         { base_name: 'claude-sonnet-4-6-vertex' },
+       ],
+-    }) as any;
++    }) as unknown as typeof globalThis.fetch;
+ 
+     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
+     expect(models).toEqual([
+@@ -144,16 +148,50 @@ describe('fetchClaudeModels', () => {
+   it('prefers non-vertex Claude ids when both canonical and vertex entries exist', async () => {
+     globalThis.fetch = vi.fn().mockResolvedValue({
+       ok: true,
++      headers: mkHeaders('application/json'),
+       json: async () => [
+         { base_name: 'claude-sonnet-4-6' },
+         { base_name: 'claude-sonnet-4-6-vertex' },
+         { base_name: 'claude-opus-4-6-vertex' },
+       ],
+-    }) as any;
++    }) as unknown as typeof globalThis.fetch;
+ 
+     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
+     expect(models).toEqual(['claude-sonnet-4-6']);
+   });
++
++  it('throws ConfigurationError with re-auth message when response is HTML (Keycloak redirect)', async () => {
++    globalThis.fetch = vi.fn().mockResolvedValue({
++      ok: true,
++      headers: mkHeaders('text/html; charset=utf-8'),
++      json: async () => { throw new SyntaxError("Unexpected token '<'"); },
++    }) as unknown as typeof globalThis.fetch;
++
++    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
++      .rejects.toThrow('SSO session may have expired');
++  });
++
++  it('throws ConfigurationError when response content-type is plain text (not JSON)', async () => {
++    globalThis.fetch = vi.fn().mockResolvedValue({
++      ok: true,
++      headers: mkHeaders('text/plain; charset=utf-8'),
++      json: async () => { throw new SyntaxError('not json'); },
++    }) as unknown as typeof globalThis.fetch;
++
++    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
++      .rejects.toThrow('SSO session may have expired');
++  });
++
++  it('returns models when content-type is application/json (regression)', async () => {
++    globalThis.fetch = vi.fn().mockResolvedValue({
++      ok: true,
++      headers: mkHeaders('application/json; charset=utf-8'),
++      json: async () => ({ data: [{ id: 'claude-sonnet-4-6' }] }),
++    }) as unknown as typeof globalThis.fetch;
++
++    const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
++    expect(models).toContain('claude-sonnet-4-6');
++  });
+ });
+ 
+ describe('selectPreferredClaudeModels', () => {
+@@ -266,8 +304,9 @@ describe('writeDesktopConfig', () => {
+     // Default: stub fetch to return our model list so writeDesktopConfig can populate inferenceModels.
+     globalThis.fetch = vi.fn().mockResolvedValue({
+       ok: true,
++      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
+       json: async () => MODEL_LIST_RESPONSE,
+-    }) as any;
++    }) as unknown as typeof globalThis.fetch;
+   });
+ 
+   afterEach(() => { globalThis.fetch = originalFetch; });
+@@ -351,7 +390,11 @@ describe('writeDesktopConfig', () => {
+   });
+ 
+   it('fails fast when discovery returns nothing', async () => {
+-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] }) as any;
++    globalThis.fetch = vi.fn().mockResolvedValue({
++      ok: true,
++      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
++      json: async () => [],
++    }) as unknown as typeof globalThis.fetch;
+     await expect(writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir, [], statePath))
+       .rejects.toThrow('Local proxy did not expose any Claude models');
+   });
+@@ -359,13 +402,14 @@ describe('writeDesktopConfig', () => {
+   it('succeeds with a vertex-only model catalog like a Vertex-only tenant', async () => {
+     globalThis.fetch = vi.fn().mockResolvedValue({
+       ok: true,
++      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
+       json: async () => [
+         { base_name: 'gemini-2.5-flash', deployment_name: 'gemini-2.5-flash' },
+         { base_name: 'gemini-2.5-pro', deployment_name: 'gemini-2.5-pro' },
+         { base_name: 'claude-sonnet-4-5-vertex', deployment_name: 'claude-sonnet-4-5-vertex' },
+         { base_name: 'claude-sonnet-4-6-vertex', deployment_name: 'claude-sonnet-4-6-vertex' },
+       ],
+-    }) as any;
++    }) as unknown as typeof globalThis.fetch;
+ 
+     const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir);
+     const config = JSON.parse(await readFile(written, 'utf-8'));
+diff --git a/src/cli/commands/proxy/connectors/desktop.ts b/src/cli/commands/proxy/connectors/desktop.ts
+index ee7c800..d4bf5ac 100644
+--- a/src/cli/commands/proxy/connectors/desktop.ts
++++ b/src/cli/commands/proxy/connectors/desktop.ts
+@@ -101,6 +101,14 @@ export async function fetchClaudeModels(proxyUrl: string, gatewayKey: string): P
+           : `Local proxy model discovery failed at ${endpoint}: ${response.status} ${response.statusText}`
+       );
+     }
++    const contentType = response.headers.get('content-type') ?? '';
++    if (!contentType.includes('application/json')) {
++      throw new ConfigurationError(
++        `Local proxy model discovery received an unexpected response (${contentType || 'no content-type'}) from ${endpoint}. ` +
++        `Your SSO session may have expired — run \`codemie proxy stop && codemie profile login\` ` +
++        `to re-authenticate, then run \`codemie proxy connect desktop\` again.`
++      );
++    }
+     const json = await response.json() as ModelsListResponse | CodeMieLlmModel[];
+     const ids = Array.isArray(json)
+       ? json
+diff --git a/src/cli/commands/proxy/health-check.ts b/src/cli/commands/proxy/health-check.ts
+index af35d8c..f0dc016 100644
+--- a/src/cli/commands/proxy/health-check.ts
++++ b/src/cli/commands/proxy/health-check.ts
+@@ -102,6 +102,15 @@ export async function checkProxyHealth(
+         reason: `Upstream model discovery returned ${res.status}`,
+       };
+     }
++    const contentType = res.headers.get('content-type') ?? '';
++    if (!contentType.includes('application/json')) {
++      return {
++        healthy: false,
++        level: 'deep',
++        code: 'unauthorized',
++        reason: 'SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.',
++      };
++    }
+     return { healthy: true, level: 'deep', code: 'ok' };
+   } catch (error) {
+     logger.debug('[proxy-health] Deep check failed', error);

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/complexity-assessment.json
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/complexity-assessment.json
@@ -1,0 +1,34 @@
+{
+  "schema": 1,
+  "task": "Fix proxy connect desktop crash on Keycloak HTML response — add Content-Type/redirect guard in fetchClaudeModels, fix false-healthy deep-check in health-check.ts, surface actionable re-auth error, add regression tests",
+  "generated": "2026-07-23T00:00:00Z",
+  "dimensions": {
+    "component_scope":      { "score": 3, "label": "M" },
+    "requirements_clarity": { "score": 2, "label": "S" },
+    "technical_risk":       { "score": 3, "label": "M" },
+    "file_change_estimate": { "score": 3, "label": "M" },
+    "dependencies":         { "score": 1, "label": "XS" },
+    "affected_layers":      { "score": 3, "label": "M" }
+  },
+  "total": 15,
+  "size": "M",
+  "routing": "brainstorming",
+  "key_reasoning": [
+    {
+      "dimension": "component_scope",
+      "reason": "Three components across two layers: fetchClaudeModels() in desktop.ts (primary crash site), checkProxyHealth() deep-check in health-check.ts (secondary false-healthy fix), and ConfigurationError in the utility layer for new four-way error classification. Coordination needed but established patterns cover the pattern."
+    },
+    {
+      "dimension": "technical_risk",
+      "reason": "Base risk is low — Content-Type/redirect guard is a well-known Node.js fetch pattern and fetchManagedMcpServers provides a reference. Bumped from S to M by the auth red flag: fix involves detecting and classifying Keycloak/SSO session failures, which touches the authentication failure path. The non-trivial design decision is plumbing authServerUrl/authRealm from profile config into the error message path, which has no existing implementation."
+    },
+    {
+      "dimension": "file_change_estimate",
+      "reason": "Five files modified: desktop.ts and health-check.ts (source fixes), errors.ts or equivalent (new error message path), desktop.test.ts and health-check.test.ts (regression tests for four error scenarios). All modifications, no new files. Spans src/cli/commands/proxy/connectors/, src/cli/commands/proxy/, and src/utils/ — three directories."
+    }
+  ],
+  "red_flags_applied": [
+    "Technical Risk bumped from S (2) to M (3): fix involves detecting and classifying Keycloak/SSO authentication failures — affects authentication flow red flag triggered"
+  ],
+  "split_recommendation": null
+}

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/decisions.jsonl
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/decisions.jsonl
@@ -1,0 +1,3 @@
+{"gate_id":"spec.approved","decision":"approve","decided_by":"user","decided_at":"2026-07-23T00:00:00Z","note":"User approved spec with proceed"}
+{"gate_id":"plan.approved","decision":"approve","decided_by":"user","decided_at":"2026-07-23T00:00:00Z","note":"User approved plan with proceed"}
+{"gate_id":"code-review.final","decision":"approve","decided_by":"user","decided_at":"2026-07-23T00:00:00Z"}

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/plan.md
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/plan.md
@@ -1,0 +1,401 @@
+# Proxy Keycloak HTML Response Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `codemie proxy connect desktop` from crashing with a SyntaxError when the upstream model-discovery endpoint returns a Keycloak HTML page instead of JSON, and fix the same false-healthy bug in the proxy deep health-check.
+
+**Architecture:** Add a Content-Type guard in `fetchClaudeModels()` (desktop.ts) and `checkProxyHealth()` (health-check.ts) — both check `!contentType.includes('application/json')` after `response.ok` passes, and surface a `ConfigurationError` / `code: 'unauthorized'` result with actionable re-auth instructions.
+
+**Tech Stack:** TypeScript, Node.js built-in `fetch`, Vitest 4.1.5 (`globalThis.fetch = vi.fn()` mock pattern), `ConfigurationError` from `@/utils/errors.js`.
+
+## Global Constraints
+
+- ES modules with `.js` extensions on all imports.
+- No `any` — use `as unknown as typeof globalThis.fetch` for fetch mocks.
+- `ConfigurationError` is the only user-facing error class; always throw it (never raw `Error`) for user-facing failures.
+- Tests only on explicit request — but this plan is an explicit request, so all test steps are in scope.
+- `globalThis.fetch = vi.fn()` is the established mock pattern; no import mocking needed.
+- Run commands from the repo root (`/mnt/c/Users/AleksandrBudanov/Projects/codemie-dev/codemie-code`).
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `src/cli/commands/proxy/connectors/desktop.ts` | Add Content-Type guard at line 104 (before `response.json()`); update existing test mocks |
+| `src/cli/commands/proxy/health-check.ts` | Add Content-Type guard at line 105 (before `return { healthy: true }`) |
+| `src/cli/commands/proxy/connectors/__tests__/desktop.test.ts` | Add 3 new `fetchClaudeModels` tests; update 5 existing mock objects to include `headers` |
+| `src/cli/commands/proxy/__tests__/health-check.test.ts` | Add 2 new deep-check tests; update 1 existing mock object to include `headers` |
+
+---
+
+### Task 1: `fetchClaudeModels` Content-Type guard
+
+**Files:**
+- Modify: `src/cli/commands/proxy/connectors/desktop.ts:103-104`
+- Modify: `src/cli/commands/proxy/connectors/__tests__/desktop.test.ts` (fetchClaudeModels describe block)
+
+**Test-first: yes — HTML 200 mock → `rejects.toThrow('SSO session may have expired')` (Step 1–2 write and run RED before guard is added in Step 3)**
+
+**Interfaces:**
+- Consumes: `ConfigurationError` from `@/utils/errors.js` (already imported at line 6)
+- Produces: `fetchClaudeModels()` now throws `ConfigurationError` (not `SyntaxError`) when the proxy returns a non-JSON 200 response
+
+- [ ] **Step 1: Write 3 failing tests in `desktop.test.ts`**
+
+Add a `headers` helper at the top of the `fetchClaudeModels` describe block (line 73, after the `afterEach`) and append 3 new `it` blocks before the closing `});` at line 157.
+
+The `headers` helper:
+```typescript
+const headers = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
+```
+
+New test 1 — HTML 200 throws with re-auth message:
+```typescript
+it('throws ConfigurationError with re-auth message when response is HTML (Keycloak redirect)', async () => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: headers('text/html; charset=utf-8'),
+    json: async () => { throw new SyntaxError("Unexpected token '<'"); },
+  }) as unknown as typeof globalThis.fetch;
+
+  await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+    .rejects.toThrow('SSO session may have expired');
+});
+```
+
+New test 2 — plain-text 200 also triggers the guard:
+```typescript
+it('throws ConfigurationError when response content-type is plain text (not JSON)', async () => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: headers('text/plain; charset=utf-8'),
+    json: async () => { throw new SyntaxError('not json'); },
+  }) as unknown as typeof globalThis.fetch;
+
+  await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+    .rejects.toThrow('SSO session may have expired');
+});
+```
+
+New test 3 — JSON 200 with explicit content-type still works (regression):
+```typescript
+it('returns models when content-type is application/json (regression)', async () => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: headers('application/json; charset=utf-8'),
+    json: async () => ({ data: [{ id: 'claude-sonnet-4-6' }] }),
+  }) as unknown as typeof globalThis.fetch;
+
+  const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
+  expect(models).toContain('claude-sonnet-4-6');
+});
+```
+
+- [ ] **Step 2: Run the new tests to confirm RED**
+
+```bash
+npx vitest run --project unit src/cli/commands/proxy/connectors/__tests__/desktop.test.ts --reporter verbose 2>&1 | grep -E "✓|✗|FAIL|PASS|Error|expected"
+```
+
+Expected: tests 1 and 2 fail because without the guard, the SyntaxError is caught by the outer catch and rethrown as "Local proxy model discovery could not reach" — not the expected "SSO session may have expired". Test 3 may pass (no guard yet) or fail with TypeError if run after tests 1/2 — either confirms tests are sensitive to the guard.
+
+- [ ] **Step 3: Add the Content-Type guard to `desktop.ts`**
+
+In `src/cli/commands/proxy/connectors/desktop.ts`, after the closing `}` of the `if (!response.ok)` block (line 103) and before `const json = await response.json()` (line 104), insert:
+
+```typescript
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      throw new ConfigurationError(
+        `Local proxy model discovery received an unexpected response (${contentType || 'no content-type'}) from ${endpoint}. ` +
+        `Your SSO session may have expired — run \`codemie proxy stop && codemie profile login\` ` +
+        `to re-authenticate, then run \`codemie proxy connect desktop\` again.`
+      );
+    }
+```
+
+The file around the insertion point looks like this after the edit:
+```typescript
+    if (!response.ok) {
+      // ... (lines 88–102 unchanged)
+      throw new ConfigurationError(...);
+    }
+    // INSERT HERE ↓
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      throw new ConfigurationError(
+        `Local proxy model discovery received an unexpected response (${contentType || 'no content-type'}) from ${endpoint}. ` +
+        `Your SSO session may have expired — run \`codemie proxy stop && codemie profile login\` ` +
+        `to re-authenticate, then run \`codemie proxy connect desktop\` again.`
+      );
+    }
+    const json = await response.json() as ModelsListResponse | CodeMieLlmModel[];
+```
+
+- [ ] **Step 4: Update existing `fetchClaudeModels` mocks in `desktop.test.ts` to include headers**
+
+Without this step, the existing 5 tests in the `fetchClaudeModels` describe block will fail with `TypeError: Cannot read properties of undefined (reading 'get')` because their mock responses have no `headers` property.
+
+Update each `mockResolvedValue(...)` in the `fetchClaudeModels` describe block to include `headers: headers('application/json')`:
+
+**Line 79–92** (returns Claude family ids):
+```typescript
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  headers: headers('application/json'),
+  json: async () => [
+    { base_name: 'claude-sonnet-4-5-20250929' },
+    // ... rest unchanged
+  ],
+}) as unknown as typeof globalThis.fetch;
+```
+
+**Line 107** (sends Authorization header):
+```typescript
+const fetchSpy = vi.fn().mockResolvedValue({
+  ok: true,
+  headers: headers('application/json'),
+  json: async () => ({ data: [] }),
+});
+```
+
+**Line 116** (throws when fetch fails) — no change needed; this mock uses `mockRejectedValue`, which throws before headers are accessed.
+
+**Line 122** (throws when response is not ok):
+```typescript
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: false,
+  headers: headers('application/json'),
+  json: async () => ({}),
+}) as unknown as typeof globalThis.fetch;
+```
+
+Wait — `!response.ok` fires before the content-type guard, so `headers` is not accessed for this case. No change strictly needed, but add it for consistency to make the mock realistic.
+
+**Line 128–136** (vertex-only catalog):
+```typescript
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  headers: headers('application/json'),
+  json: async () => [...],
+}) as unknown as typeof globalThis.fetch;
+```
+
+**Line 144–152** (prefers non-vertex):
+```typescript
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  headers: headers('application/json'),
+  json: async () => [...],
+}) as unknown as typeof globalThis.fetch;
+```
+
+- [ ] **Step 5: Run all `fetchClaudeModels` tests to confirm GREEN**
+
+```bash
+npx vitest run --project unit src/cli/commands/proxy/connectors/__tests__/desktop.test.ts --reporter verbose 2>&1 | grep -E "✓|✗|FAIL|PASS|fetchClaudeModels"
+```
+
+Expected output:
+```
+✓ fetchClaudeModels > returns Claude family ids and excludes vertex / non-claude entries
+✓ fetchClaudeModels > sends Authorization Bearer header with the gateway key
+✓ fetchClaudeModels > throws when fetch fails
+✓ fetchClaudeModels > throws when response is not ok
+✓ fetchClaudeModels > returns vertex Claude ids when the catalog is vertex-only
+✓ fetchClaudeModels > prefers non-vertex Claude ids when both canonical and vertex entries exist
+✓ fetchClaudeModels > throws ConfigurationError with re-auth message when response is HTML (Keycloak redirect)
+✓ fetchClaudeModels > throws ConfigurationError when response content-type is plain text (not JSON)
+✓ fetchClaudeModels > returns models when content-type is application/json (regression)
+```
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add src/cli/commands/proxy/connectors/desktop.ts \
+        src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+git commit -m "fix(proxy): guard fetchClaudeModels against non-JSON 200 (Keycloak HTML redirect)
+
+EPMCDME-13540: after response.ok passes, check Content-Type before
+calling response.json(). A 302->200 Keycloak redirect produces ok=true
+with text/html body; response.json() threw SyntaxError. Now throws
+ConfigurationError with actionable re-auth message instead."
+```
+
+---
+
+### Task 2: `checkProxyHealth` deep-check Content-Type guard
+
+**Files:**
+- Modify: `src/cli/commands/proxy/health-check.ts:104-105`
+- Modify: `src/cli/commands/proxy/__tests__/health-check.test.ts` (deep describe tests)
+
+**Test-first: yes — HTML 200 deep-check mock → `result.code === 'unauthorized'` (Steps 7–8 write and run RED before guard is added in Step 9)**
+
+**Interfaces:**
+- Consumes: `ProxyHealthResult` with `code: 'unauthorized'` (type already defined at line 15–19)
+- Produces: `checkProxyHealth({ deep: true })` returns `{ healthy: false, code: 'unauthorized' }` when the models endpoint returns a non-JSON 200
+
+- [ ] **Step 7: Write 2 tests in `health-check.test.ts`**
+
+Add a `headers` helper at the top of the describe block (after `const MODELS = ...` at line 9) and 2 new `it` blocks before the final `});`.
+
+The `headers` helper:
+```typescript
+const headers = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
+```
+
+New test 4 — HTML 200 deep check returns unauthorized:
+```typescript
+it('deep: unauthorized when /v1/llm_models returns 200 with HTML content-type (Keycloak redirect)', async () => {
+  globalThis.fetch = vi.fn(async (url: unknown) => {
+    if (HEALTH(url)) return { ok: true, status: 200 };
+    if (MODELS(url)) return {
+      ok: true,
+      status: 200,
+      headers: headers('text/html; charset=utf-8'),
+    };
+    throw new Error(`unexpected url ${String(url)}`);
+  }) as unknown as typeof globalThis.fetch;
+
+  const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+  expect(result.healthy).toBe(false);
+  expect(result.level).toBe('deep');
+  expect(result.code).toBe('unauthorized');
+  expect(result.reason).toContain('SSO session expired');
+});
+```
+
+New test 5 — JSON 200 deep check still healthy (regression):
+```typescript
+it('deep: healthy when /v1/llm_models returns 200 with application/json (regression)', async () => {
+  globalThis.fetch = vi.fn(async (url: unknown) => {
+    if (HEALTH(url)) return { ok: true, status: 200 };
+    if (MODELS(url)) return {
+      ok: true,
+      status: 200,
+      headers: headers('application/json'),
+      json: async () => [],
+    };
+    throw new Error(`unexpected url ${String(url)}`);
+  }) as unknown as typeof globalThis.fetch;
+
+  const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+  expect(result).toEqual({ healthy: true, level: 'deep', code: 'ok' });
+});
+```
+
+- [ ] **Step 8: Run the new tests to confirm RED**
+
+```bash
+npx vitest run --project unit src/cli/commands/proxy/__tests__/health-check.test.ts --reporter verbose 2>&1 | grep -E "✓|✗|FAIL|PASS|Error|expected"
+```
+
+Expected: test 4 fails — currently the code hits `return { healthy: true, level: 'deep', code: 'ok' }` for any `res.ok === true` response, so the result is `healthy: true` instead of `healthy: false`.
+
+- [ ] **Step 9: Add the Content-Type guard to `health-check.ts`**
+
+In `src/cli/commands/proxy/health-check.ts`, after the closing `}` of the `if (!res.ok)` block (line 103) and before `return { healthy: true, level: 'deep', code: 'ok' }` (line 105), insert:
+
+```typescript
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'unauthorized',
+        reason: 'SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.',
+      };
+    }
+```
+
+The file around the insertion point looks like this after the edit:
+```typescript
+    if (!res.ok) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'upstream-error',
+        reason: `Upstream model discovery returned ${res.status}`,
+      };
+    }
+    // INSERT HERE ↓
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'unauthorized',
+        reason: 'SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.',
+      };
+    }
+    return { healthy: true, level: 'deep', code: 'ok' };
+```
+
+- [ ] **Step 10: Update the existing deep-healthy mock in `health-check.test.ts` to include headers**
+
+The existing test at line 59 (`deep: healthy when /health and /v1/llm_models both succeed`) returns `{ ok: true, status: 200, json: async () => [] }` for the models endpoint — no `headers`. After the guard is added, `res.headers.get(...)` will throw TypeError on this mock.
+
+Update the MODELS branch of that test's fetchSpy:
+```typescript
+if (MODELS(url)) return {
+  ok: true,
+  status: 200,
+  headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
+  json: async () => [],
+};
+```
+
+- [ ] **Step 11: Run all `health-check.test.ts` tests to confirm GREEN**
+
+```bash
+npx vitest run --project unit src/cli/commands/proxy/__tests__/health-check.test.ts --reporter verbose 2>&1 | grep -E "✓|✗|FAIL|PASS|checkProxyHealth"
+```
+
+Expected output:
+```
+✓ checkProxyHealth > shallow: returns healthy when /health responds 200
+✓ checkProxyHealth > shallow: dead-socket when the /health fetch rejects (proxy not listening)
+✓ checkProxyHealth > shallow: dead-socket when /health returns a non-2xx status
+✓ checkProxyHealth > deep: healthy when /health and /v1/llm_models both succeed, with Bearer auth
+✓ checkProxyHealth > deep: unauthorized when /v1/llm_models returns 401
+✓ checkProxyHealth > deep: unauthorized when /v1/llm_models returns 403
+✓ checkProxyHealth > deep: upstream-error when /v1/llm_models returns a 5xx
+✓ checkProxyHealth > deep: upstream-error when the models fetch throws
+✓ checkProxyHealth > does not perform the deep call when deep is not requested
+✓ checkProxyHealth > deep: unauthorized when /v1/llm_models returns 200 with HTML content-type (Keycloak redirect)
+✓ checkProxyHealth > deep: healthy when /v1/llm_models returns 200 with application/json (regression)
+```
+
+- [ ] **Step 12: Run the full unit suite to check for regressions**
+
+```bash
+npx vitest run --project unit --reporter verbose 2>&1 | tail -20
+```
+
+Expected: all tests pass, no failures.
+
+- [ ] **Step 13: Run typecheck to confirm no type errors**
+
+```bash
+npm run typecheck 2>&1 | tail -20
+```
+
+Expected: exit 0, no errors.
+
+- [ ] **Step 14: Commit Task 2**
+
+```bash
+git add src/cli/commands/proxy/health-check.ts \
+        src/cli/commands/proxy/__tests__/health-check.test.ts
+git commit -m "fix(proxy): guard checkProxyHealth deep-check against non-JSON 200
+
+EPMCDME-13540: same Keycloak HTML redirect that crashes fetchClaudeModels
+also causes checkProxyHealth to return healthy:true falsely. Guard
+added after res.ok passes: non-JSON content-type returns
+{healthy:false, code:'unauthorized'} with re-auth guidance."
+```

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/spec.md
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/spec.md
@@ -1,0 +1,92 @@
+# Spec: Proxy Keycloak HTML Response Fix
+
+**Ticket:** EPMCDME-13540  
+**Slug:** epmcdme-13540-proxy-keycloak-html-fix
+
+## Problem
+
+`codemie proxy connect desktop` crashes with an unhandled `SyntaxError` when the upstream model discovery endpoint returns a Keycloak HTML page instead of JSON. This happens because Node.js `fetch()` silently follows the 302 redirect to the Keycloak login page, producing a `200 OK` response with `text/html` content. `response.ok` is `true`, so the existing status check passes, and `response.json()` throws on the HTML body.
+
+A secondary issue: `checkProxyHealth()` deep-check has the same false-healthy bug — an HTML 200 causes it to return `{ healthy: true }`, masking the auth failure.
+
+## Root Cause
+
+- `fetchClaudeModels()` in `desktop.ts` calls `response.json()` without verifying `Content-Type`.
+- `checkProxyHealth()` in `health-check.ts` returns `{ healthy: true }` without verifying `Content-Type`.
+- Both trust `response.ok` as a sufficient success signal, which is wrong when redirects are followed.
+
+## Design
+
+### Fix 1 — `fetchClaudeModels()` guard (`desktop.ts`)
+
+After the `response.ok` check and before `response.json()`, add a Content-Type guard:
+
+```typescript
+const contentType = response.headers.get('content-type') ?? '';
+if (!contentType.includes('application/json')) {
+  throw new ConfigurationError(
+    `Local proxy model discovery received an unexpected response (${contentType || 'no content-type'}) from ${endpoint}. ` +
+    `Your SSO session may have expired — run \`codemie proxy stop && codemie profile login\` ` +
+    `to re-authenticate, then run \`codemie proxy connect desktop\` again.`
+  );
+}
+```
+
+The guard uses `!includes('application/json')` (not `includes('text/html')`) to catch Keycloak HTML, plain-text error pages, and any other non-JSON 200 that would crash `response.json()`.
+
+The existing catch block re-throws `ConfigurationError` unchanged, so the error surfaces via `printProxyError` as `✗ <message>`.
+
+### Fix 2 — `checkProxyHealth()` deep-check guard (`health-check.ts`)
+
+After the `!res.ok` check and before `return { healthy: true }`, add:
+
+```typescript
+const contentType = res.headers.get('content-type') ?? '';
+if (!contentType.includes('application/json')) {
+  return {
+    healthy: false,
+    level: 'deep',
+    code: 'unauthorized',
+    reason: 'SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.',
+  };
+}
+```
+
+This prevents a false-healthy result when the proxy is running but the upstream session is dead.
+
+### Error taxonomy
+
+| Scenario | Detection | Outcome |
+|---|---|---|
+| Proxy unavailable | `fetch()` throws (ECONNREFUSED) | Already handled |
+| SSO session expired / redirect | `response.ok` + non-JSON content-type | **New** — `ConfigurationError` / `code: 'unauthorized'` |
+| Backend error | `!response.ok` (4xx/5xx) | Already handled |
+| Unexpected content type | `response.ok` + non-JSON, non-HTML | Same new guard catches it |
+
+## Test Cases
+
+### `desktop.test.ts`
+
+1. HTML 200 from `/v1/llm_models` → `fetchClaudeModels` throws `ConfigurationError` containing the re-auth message
+2. JSON 200 from `/v1/llm_models` → returns model list (regression)
+3. Plain-text 200 → `fetchClaudeModels` throws `ConfigurationError` (broadened guard coverage)
+
+### `health-check.test.ts`
+
+4. HTML 200 from deep-check endpoint → `checkProxyHealth` returns `{ healthy: false, code: 'unauthorized' }`
+5. JSON 200 from deep-check endpoint → `checkProxyHealth` returns `{ healthy: true }` (regression)
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/cli/commands/proxy/connectors/desktop.ts` | Add Content-Type guard in `fetchClaudeModels()` |
+| `src/cli/commands/proxy/health-check.ts` | Add Content-Type guard in `checkProxyHealth()` deep path |
+| `src/cli/commands/proxy/connectors/desktop.test.ts` | Add tests 1–3 |
+| `src/cli/commands/proxy/health-check.test.ts` | Add tests 4–5 |
+
+## Out of Scope
+
+- Proactive token refresh or automatic re-login
+- Changes to `sso.auth.ts` expiry logic (local `expiresAt` check is a separate concern)
+- Changes to `sso.proxy.ts` (does not follow redirects; not affected)

--- a/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/technical-analysis.md
+++ b/docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/technical-analysis.md
@@ -1,0 +1,135 @@
+# Technical Research
+
+**Task**: proxy connect desktop sso keycloak fetchClaudeModels model-discovery
+**Generated**: 2026-07-23T00:00:00Z
+**Research path**: codegraph
+
+---
+
+## 1. Original Context
+
+codemie proxy connect desktop fails when local proxy model discovery receives Keycloak HTML instead of JSON. The CLI command `codemie proxy connect desktop` calls `fetchClaudeModels()` which hits `http://127.0.0.1:4001/v1/llm_models?include_all=true`. When the upstream Keycloak session has expired, the upstream returns a 302 redirect to the Keycloak login page. Node.js `fetch()` follows the redirect and lands on a 200 HTML page. `response.ok` is true so the code calls `response.json()` which throws `SyntaxError: Unexpected token '<', "<!-- Keycl"... is not valid JSON`. Acceptance criteria: (1) no crash on HTML/non-JSON response from model discovery endpoint, (2) detect Keycloak/OAuth HTML and surface actionable re-authentication message, (3) distinguish between: local proxy unavailable, auth/session issue, invalid non-JSON response, model discovery backend failure, (4) regression test coverage for non-JSON responses from /v1/llm_models?include_all=true.
+
+---
+
+## 2. Codebase Findings
+
+### Existing Implementations
+
+- `src/cli/commands/proxy/connectors/desktop.ts` — primary crash site; contains `fetchClaudeModels()`, `writeDesktopConfig()`, `selectDesktopClaudeModels()`, and MCP reconciliation; all model-discovery logic lives here
+- `src/cli/commands/proxy/index.ts` — `createProxyCommand()`: registers the `proxy connect desktop` action, calls `writeDesktopConfig`, handles rollback on error via `printProxyError`
+- `src/cli/commands/proxy/health-check.ts` — `checkProxyHealth()`: shallow (`/health`) and deep (`/v1/llm_models`) health checks; currently detects 401/403 but not HTML/redirect responses — secondary fix required here
+- `src/cli/commands/proxy/connectors/managed-mcp-remote.ts` — `fetchManagedMcpServers()`: safe null-on-failure fetch pattern; uses explicit status check and manual `JSON.parse` — the established reference pattern for safe HTTP handling in this codebase
+- `src/utils/errors.ts` — `ConfigurationError` and `CodeMieError` base classes; `formatErrorForUser` renders errors to the console
+- `src/utils/logger.ts` — structured logging; `sanitizeLogArgs()` wraps all log arguments
+- `src/providers/plugins/sso/` — SSO auth, proxy daemon, session sync plugins; `authServerUrl` and `authRealm` fields stored in profile config
+
+### Architecture and Layers Affected
+
+- **CLI layer** (`src/cli/`): user-facing command parsing, orchestration, and error formatting — `proxy connect desktop` action registration and `printProxyError` handler in `index.ts`
+- **Connector layer** (`src/cli/commands/proxy/connectors/`): desktop config write and model fetch in `desktop.ts`; `fetchClaudeModels()` is the primary change surface; `health-check.ts` requires a secondary coordinated fix
+- **Provider/SSO layer** (`src/providers/plugins/sso/`): holds Keycloak profile fields (`authServerUrl`, `authRealm`) that can be used to construct actionable re-auth messages
+- **Utility layer** (`src/utils/`): `ConfigurationError` is the correct error class to throw for the new error cases
+
+### Integration Points
+
+- Node.js built-in `fetch` called directly in `fetchClaudeModels()` with no redirect policy override, no Content-Type guard, and no timeout — the integration point where the bug manifests
+- Local proxy daemon on `DEFAULT_DAEMON_PORT = 4001` (hardcoded in `src/cli/commands/proxy/index.ts`)
+- Keycloak/SSO server referenced via `authServerUrl` / `authRealm` from profile config in `src/env/types.ts`
+- `managed-mcp-remote.ts` uses a different HTTP stack (`HTTPClient.getRaw`) with explicit null-on-failure — an internal reference for safe fetch patterns
+
+### Patterns and Conventions
+
+- **Error handling pattern**: errors thrown as `ConfigurationError` (or subclasses); caught by `printProxyError` in `index.ts` which prints `error.message` and calls `process.exit(1)` — new error cases must follow this pattern
+- **Response.ok guard before response.json()**: this is the broken pattern in `fetchClaudeModels()`; it does not account for 302→200 HTML responses where `response.ok` is `true` but body is HTML
+- **Safe null-on-failure pattern** in `fetchManagedMcpServers`: entire fetch body wrapped in try/catch; returns `null` on any failure — the reference pattern to follow or adapt
+- **Test mock pattern**: `globalThis.fetch = vi.fn()` for stubbing fetch in unit tests; no import mocking needed
+- `sanitizeLogArgs()` wraps all structured log arguments in logger calls
+
+---
+
+## 3. Documentation Findings
+
+### Guides and Architecture Docs
+
+- `/mnt/c/Users/AleksandrBudanov/Projects/codemie-dev/codemie-code/.ai-run/guides/integration/external-integrations.md` — covers SSO/provider patterns but contains no guidance on Keycloak HTML redirect detection or Content-Type validation
+- `/mnt/c/Users/AleksandrBudanov/Projects/codemie-dev/codemie-code/.ai-run/guides/integration/exposed-api.md` — CLI surface and proxy endpoints documented here
+
+### Architectural Decisions
+
+- No ADRs or recorded decisions found specifically for model-discovery error handling or Keycloak redirect handling.
+- The choice to use `response.ok` as the sole guard before `response.json()` is an implicit convention not documented anywhere; it pre-dates Keycloak redirect scenarios.
+
+### Derived Conventions
+
+- All user-surfaced error messages go through `ConfigurationError.message` → `printProxyError` → `process.exit(1)`; new error cases must integrate into this flow
+- When a fetch can return non-JSON or may fail gracefully, the `fetchManagedMcpServers` null-on-failure pattern is the established safe alternative
+- Re-auth messages should include the Keycloak realm info from profile config (`authServerUrl`, `authRealm`) to be actionable
+
+---
+
+## 4. Testing Landscape
+
+### Existing Coverage
+
+- `src/cli/commands/proxy/connectors/__tests__/desktop.test.ts` — unit tests for `fetchClaudeModels`, `writeDesktopConfig`, model selection, and MCP reconciliation; covers `{ ok: false }` responses and empty arrays but **missing**: test for HTML/non-JSON 200 response (the Keycloak redirect scenario)
+- `src/cli/commands/proxy/__tests__/health-check.test.ts` — unit tests for `checkProxyHealth`; covers 401/403/500/throw cases but **missing**: HTML redirect detection path
+- `src/cli/commands/proxy/__tests__/watcher.test.ts` — proxy watcher tests; not directly relevant to this task
+- `tests/integration/sso-claude-plugin.test.ts` — integration SSO tests; scope unclear for this specific failure mode
+
+### Testing Framework and Patterns
+
+- Vitest `^4.1.5`, three configured projects: `unit` (covers `src/**/*.test.ts`), `cli` (covers `tests/integration/**`), `agent` (real network)
+- Fetch stubbing via `globalThis.fetch = vi.fn()` — no special import mocking needed; tests can return `{ ok: true, json: () => Promise.reject(new SyntaxError(...)), text: () => Promise.resolve('<html>...') }` to simulate the Keycloak scenario
+- Existing tests in `desktop.test.ts` demonstrate the mock shape needed for new cases
+
+### Coverage Gaps
+
+- No test for `fetchClaudeModels()` receiving a 200 HTML response (Keycloak redirect scenario) — the exact failure path from the bug report
+- No test for `checkProxyHealth()` deep-check returning a false-healthy signal on 200 HTML response
+- No test distinguishing between: proxy unavailable (connection refused), auth/session expired (HTML), non-JSON response (other content type), backend failure (non-2xx JSON error)
+- No test asserting that `ConfigurationError` message content includes re-auth guidance when Keycloak HTML is detected
+
+---
+
+## 5. Configuration and Environment
+
+### Environment Variables
+
+- No env var overrides found for the model discovery endpoint (`http://127.0.0.1:4001/v1/llm_models`)
+- `authServerUrl` and `authRealm` — Keycloak/SSO fields in profile config (`src/env/types.ts`); accessible for constructing actionable re-auth messages
+
+### Configuration Files
+
+- `DEFAULT_DAEMON_PORT = 4001` — hardcoded constant in `src/cli/commands/proxy/index.ts`; governs the local proxy address
+- `PREFERRED_CLAUDE_MODELS` — curated model list in `desktop.ts`; no impact on this fix
+- Profile config in `src/env/types.ts` — holds `authServerUrl`/`authRealm` for Keycloak context
+
+### Feature Flags and Deployment Concerns
+
+- No feature flags found for model discovery or SSO redirect handling.
+- No deployment manifests reference the model discovery endpoint directly.
+- Secrets management: Keycloak credentials are managed through the profile config; no vault references found in scope.
+
+---
+
+## 6. Risk Indicators
+
+- **Primary crash confirmed in `desktop.ts`**: `fetchClaudeModels()` calls `response.json()` unconditionally when `response.ok` is true. Node.js `fetch` follows redirects by default; a 302→200 Keycloak HTML page satisfies `response.ok === true`, so the existing `if (!response.ok)` guard never fires. Fix requires: (a) `redirect: 'manual'` fetch option OR (b) Content-Type check before calling `response.json()`.
+- **Secondary vulnerability in `health-check.ts`**: `checkProxyHealth()` deep-check on `/v1/llm_models` branches only on `401`/`403`/non-ok status. Same 302→200 HTML scenario causes it to return `{ healthy: true, level: 'deep', code: 'ok' }` — a false-healthy signal. This must be fixed in the same changeset to avoid misleading health reports.
+- **No Content-Type inspection anywhere in the HTTP fetch chain for model discovery**: unlike `managed-mcp-remote.ts` which uses a different HTTP stack, `fetchClaudeModels` uses raw `fetch` with no response validation beyond `response.ok`.
+- **No `redirect: 'manual'` or `redirect: 'error'` option set**: the fix should explicitly set one of these on the `fetch` call to intercept the redirect before it resolves to an HTML page, or validate `Content-Type: application/json` after following the redirect.
+- **No test for non-JSON 200 responses**: `desktop.test.ts` and `health-check.test.ts` both lack the test case required by acceptance criterion (4). This is the largest test coverage gap.
+- **Error message quality risk**: current `SyntaxError` from `response.json()` is unhandled and propagates as an unformatted crash. Acceptance criterion (2) requires Keycloak-specific detection — the fix must inspect response body text for HTML/OAuth patterns before surfacing the re-auth message.
+- **`authServerUrl`/`authRealm` availability in error path**: constructing an actionable re-auth message requires reading from profile config inside `fetchClaudeModels` or passing it in from the call site in `index.ts`. This plumbing does not currently exist and must be designed carefully.
+- **`managed-mcp-remote.ts` uses a different HTTP abstraction (`HTTPClient.getRaw`)**: the safe pattern there is not directly portable to `fetchClaudeModels` which uses raw `fetch`. The fix must adapt the pattern rather than copy it verbatim.
+
+---
+
+## 7. Summary for Complexity Assessment
+
+This task touches three files across two architectural layers: the Connector layer (`desktop.ts` and `health-check.ts`) and the Utility/Error layer (`errors.ts` or equivalent for new error message constants). The primary change is surgical — adding a Content-Type guard or `redirect: 'manual'` option in `fetchClaudeModels()` and a parallel fix in `checkProxyHealth()`'s deep-check path — but acceptance criterion (2) adds meaningful scope: detecting Keycloak/OAuth HTML specifically and surfacing a re-auth message requires reading profile config (`authServerUrl`, `authRealm`) inside or adjacent to the error path, which currently has no plumbing for it.
+
+The task follows established patterns (throw `ConfigurationError`, catch in `printProxyError`, mock `globalThis.fetch` in tests) so there is no architectural novelty. However, the four-way error discrimination required by acceptance criterion (3) — proxy unavailable vs. auth/session expired vs. invalid non-JSON vs. backend failure — means the implementation must introduce distinct error classification logic rather than a single catch-all. This is moderately complex: the failure modes require inspecting HTTP status codes, response body content-type headers, and response body text (HTML fingerprint detection), each in the right order.
+
+Test coverage for the affected area is present but has exactly the gap this task must close. `desktop.test.ts` already demonstrates the `globalThis.fetch = vi.fn()` mock pattern; new test cases for the four error scenarios are straightforward to add. The key risk is the `health-check.ts` secondary fix — it is easy to miss since it is not the primary crash site but is exercised by the same Keycloak redirect path. Failing to fix it would leave a false-healthy signal in place. Overall complexity is low-to-medium: well-scoped, established patterns, clear test targets, one non-trivial design decision around surfacing Keycloak profile context in the error message path.

--- a/src/cli/commands/proxy/__tests__/health-check.test.ts
+++ b/src/cli/commands/proxy/__tests__/health-check.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/utils/logger.js', () => ({
 
 const HEALTH = (url: unknown): boolean => String(url).endsWith('/health');
 const MODELS = (url: unknown): boolean => String(url).includes('/v1/llm_models');
+const mkHeaders = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
 
 describe('checkProxyHealth', () => {
   let originalFetch: typeof globalThis.fetch;
@@ -59,7 +60,7 @@ describe('checkProxyHealth', () => {
   it('deep: healthy when /health and /v1/llm_models both succeed, with Bearer auth', async () => {
     const fetchSpy = vi.fn(async (url: unknown) => {
       if (HEALTH(url)) return { ok: true, status: 200 };
-      if (MODELS(url)) return { ok: true, status: 200, json: async () => [] };
+      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('application/json'), json: async () => [] };
       throw new Error(`unexpected url ${String(url)}`);
     });
     globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
@@ -131,5 +132,32 @@ describe('checkProxyHealth', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(MODELS(fetchSpy.mock.calls[0][0])).toBe(false);
+  });
+
+  it('deep: unauthorized when /v1/llm_models returns 200 with HTML content-type (Keycloak redirect)', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('text/html; charset=utf-8') };
+      throw new Error(`unexpected url ${String(url)}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result.healthy).toBe(false);
+    expect(result.level).toBe('deep');
+    expect(result.code).toBe('unauthorized');
+    expect(result.reason).toContain('SSO session expired');
+  });
+
+  it('deep: healthy when /v1/llm_models returns 200 with application/json (regression)', async () => {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (HEALTH(url)) return { ok: true, status: 200 };
+      if (MODELS(url)) return { ok: true, status: 200, headers: mkHeaders('application/json'), json: async () => [] };
+      throw new Error(`unexpected url ${String(url)}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await checkProxyHealth({ port: 4001, gatewayKey: 'k', deep: true });
+
+    expect(result).toEqual({ healthy: true, level: 'deep', code: 'ok' });
   });
 });

--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
@@ -75,9 +75,12 @@ describe('fetchClaudeModels', () => {
   beforeEach(() => { originalFetch = globalThis.fetch; });
   afterEach(() => { globalThis.fetch = originalFetch; });
 
+  const mkHeaders = (ct: string) => ({ get: (h: string) => h === 'content-type' ? ct : null });
+
   it('returns Claude family ids and excludes vertex / non-claude entries', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: mkHeaders('application/json'),
       json: async () => [
         { base_name: 'claude-sonnet-4-5-20250929' },
         { base_name: 'claude-4-5-sonnet' },
@@ -89,7 +92,7 @@ describe('fetchClaudeModels', () => {
         { base_name: 'claude-opus-4-6-vertex' },
         { base_name: 'gpt-5.5-2026-04-24' },
       ],
-    }) as any;
+    }) as unknown as typeof globalThis.fetch;
 
     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
     expect(models).toEqual([
@@ -104,8 +107,8 @@ describe('fetchClaudeModels', () => {
   });
 
   it('sends Authorization Bearer header with the gateway key', async () => {
-    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) });
-    globalThis.fetch = fetchSpy as any;
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, headers: mkHeaders('application/json'), json: async () => ({ data: [] }) });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
 
     await fetchClaudeModels('http://127.0.0.1:4001', 'my-key');
     const [, init] = fetchSpy.mock.calls[0];
@@ -127,12 +130,13 @@ describe('fetchClaudeModels', () => {
   it('returns vertex Claude ids when the catalog is vertex-only', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: mkHeaders('application/json'),
       json: async () => [
         { base_name: 'gemini-2.5-flash' },
         { base_name: 'claude-sonnet-4-5-vertex' },
         { base_name: 'claude-sonnet-4-6-vertex' },
       ],
-    }) as any;
+    }) as unknown as typeof globalThis.fetch;
 
     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
     expect(models).toEqual([
@@ -144,15 +148,49 @@ describe('fetchClaudeModels', () => {
   it('prefers non-vertex Claude ids when both canonical and vertex entries exist', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: mkHeaders('application/json'),
       json: async () => [
         { base_name: 'claude-sonnet-4-6' },
         { base_name: 'claude-sonnet-4-6-vertex' },
         { base_name: 'claude-opus-4-6-vertex' },
       ],
-    }) as any;
+    }) as unknown as typeof globalThis.fetch;
 
     const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
     expect(models).toEqual(['claude-sonnet-4-6']);
+  });
+
+  it('throws ConfigurationError with re-auth message when response is HTML (Keycloak redirect)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: mkHeaders('text/html; charset=utf-8'),
+      json: async () => { throw new SyntaxError("Unexpected token '<'"); },
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+      .rejects.toThrow('SSO session may have expired');
+  });
+
+  it('throws ConfigurationError when response content-type is plain text (not JSON)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: mkHeaders('text/plain; charset=utf-8'),
+      json: async () => { throw new SyntaxError('not json'); },
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy'))
+      .rejects.toThrow('SSO session may have expired');
+  });
+
+  it('returns models when content-type is application/json (regression)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: mkHeaders('application/json; charset=utf-8'),
+      json: async () => ({ data: [{ id: 'claude-sonnet-4-6' }] }),
+    }) as unknown as typeof globalThis.fetch;
+
+    const models = await fetchClaudeModels('http://127.0.0.1:4001', 'codemie-proxy');
+    expect(models).toContain('claude-sonnet-4-6');
   });
 });
 
@@ -266,8 +304,9 @@ describe('writeDesktopConfig', () => {
     // Default: stub fetch to return our model list so writeDesktopConfig can populate inferenceModels.
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
       json: async () => MODEL_LIST_RESPONSE,
-    }) as any;
+    }) as unknown as typeof globalThis.fetch;
   });
 
   afterEach(() => { globalThis.fetch = originalFetch; });
@@ -351,7 +390,11 @@ describe('writeDesktopConfig', () => {
   });
 
   it('fails fast when discovery returns nothing', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] }) as any;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
+      json: async () => [],
+    }) as unknown as typeof globalThis.fetch;
     await expect(writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir, [], statePath))
       .rejects.toThrow('Local proxy did not expose any Claude models');
   });
@@ -359,13 +402,14 @@ describe('writeDesktopConfig', () => {
   it('succeeds with a vertex-only model catalog like a Vertex-only tenant', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: { get: (h: string) => h === 'content-type' ? 'application/json' : null },
       json: async () => [
         { base_name: 'gemini-2.5-flash', deployment_name: 'gemini-2.5-flash' },
         { base_name: 'gemini-2.5-pro', deployment_name: 'gemini-2.5-pro' },
         { base_name: 'claude-sonnet-4-5-vertex', deployment_name: 'claude-sonnet-4-5-vertex' },
         { base_name: 'claude-sonnet-4-6-vertex', deployment_name: 'claude-sonnet-4-6-vertex' },
       ],
-    }) as any;
+    }) as unknown as typeof globalThis.fetch;
 
     const written = await writeDesktopConfig('http://127.0.0.1:4001', 'codemie-proxy', baseDir);
     const config = JSON.parse(await readFile(written, 'utf-8'));

--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -101,6 +101,14 @@ export async function fetchClaudeModels(proxyUrl: string, gatewayKey: string): P
           : `Local proxy model discovery failed at ${endpoint}: ${response.status} ${response.statusText}`
       );
     }
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      throw new ConfigurationError(
+        `Local proxy model discovery received an unexpected response (${contentType || 'no content-type'}) from ${endpoint}. ` +
+        `Your SSO session may have expired — run \`codemie proxy stop && codemie profile login\` ` +
+        `to re-authenticate, then run \`codemie proxy connect desktop\` again.`
+      );
+    }
     const json = await response.json() as ModelsListResponse | CodeMieLlmModel[];
     const ids = Array.isArray(json)
       ? json

--- a/src/cli/commands/proxy/health-check.ts
+++ b/src/cli/commands/proxy/health-check.ts
@@ -102,6 +102,15 @@ export async function checkProxyHealth(
         reason: `Upstream model discovery returned ${res.status}`,
       };
     }
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      return {
+        healthy: false,
+        level: 'deep',
+        code: 'unauthorized',
+        reason: 'SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.',
+      };
+    }
     return { healthy: true, level: 'deep', code: 'ok' };
   } catch (error) {
     logger.debug('[proxy-health] Deep check failed', error);


### PR DESCRIPTION
## Summary

- **`desktop.ts`**: add Content-Type guard in `fetchClaudeModels()` — after `response.ok` passes, check `!contentType.includes('application/json')` before calling `response.json()`. A 302→200 Keycloak redirect produces `ok: true` with a `text/html` body; without the guard `response.json()` threw an unhandled `SyntaxError`.
- **`health-check.ts`**: same guard in `checkProxyHealth()` deep path — an HTML 200 previously returned `{ healthy: true }` (false positive); it now returns `{ healthy: false, code: 'unauthorized' }` with re-auth guidance.
- Both surfaces now show an actionable message: _"Your SSO session may have expired — run `codemie proxy stop && codemie profile login` to re-authenticate."_
- 5 new Vitest tests (3 in `desktop.test.ts`, 2 in `health-check.test.ts`) covering HTML 200, plain-text 200, and JSON regression cases.

## Fix confirmed locally (Windows, codemie 0.9.0)

With the fix branch built and `npm link`'d, and the Keycloak session expired (confirmed via `curl` returning HTML from `/v1/llm_models`):

**Before the fix** — raw crash:
```
✗ Local proxy model discovery could not reach http://127.0.0.1:4001/v1/llm_models?include_all=true.
  Reason: Unexpected token '<', "<!-- Keycl"... is not valid JSON
```

**After the fix** — both surfaces report correctly:
```
Existing proxy is unhealthy (SSO session expired — run `codemie proxy stop && codemie profile login` to re-authenticate.). Restarting...
Starting proxy...
Using profile: epm-cdme
✓ Proxy started
✗ Local proxy model discovery received an unexpected response (text/html;charset=utf-8)
  from http://127.0.0.1:4001/v1/llm_models?include_all=true.
  Your SSO session may have expired — run `codemie proxy stop && codemie profile login`
  to re-authenticate, then run `codemie proxy connect desktop` again.
```

The health check catch fired first, restarted the proxy, then the model discovery guard fired with the correct content-type and re-auth message — exactly the expected behaviour.

## SDLC artifacts

`docs/superpowers/tasks/2026-07-23-epmcdme-13540-proxy-keycloak-html-fix/`

## Test plan

- [ ] `npx vitest run --project unit src/cli/commands/proxy/connectors/__tests__/desktop.test.ts`
- [ ] `npx vitest run --project unit src/cli/commands/proxy/__tests__/health-check.test.ts`
- [ ] `npm run typecheck`
- [ ] Manual: expire Keycloak session → `codemie proxy connect desktop` → confirm actionable error, no SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)