### PR TITLE
chore(agents): bump Claude Code supported version to 2.1.218

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -34,17 +34,17 @@ let statuslineManagedThisSession = false;
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-export const CLAUDE_SUPPORTED_VERSION = '2.1.205';
+export const CLAUDE_SUPPORTED_VERSION = '2.1.218';
 
 /**
  * Minimum supported Claude Code version
  * Versions below this are known to be incompatible and will be blocked from starting
  * Rule: always 10 patch versions below CLAUDE_SUPPORTED_VERSION
- * e.g. supported = 2.1.205 → minimum = 2.1.195
+ * e.g. supported = 2.1.218 → minimum = 2.1.208
  *
  * **UPDATE THIS WHEN BUMPING CLAUDE VERSION**
  */
-const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.195';
+const CLAUDE_MINIMUM_SUPPORTED_VERSION = '2.1.208';
 
 /**
  * Claude Code installer URLs


### PR DESCRIPTION
## Summary
Bumps the supported Claude Code version from 2.1.205 to 2.1.218 and updates the minimum supported version from 2.1.195 to 2.1.208 (always 10 patch versions below the supported version, per the established rule).

## Changes
- `CLAUDE_SUPPORTED_VERSION`: `2.1.205` → `2.1.218`
- `CLAUDE_MINIMUM_SUPPORTED_VERSION`: `2.1.195` → `2.1.208`

## Testing
- [ ] Tests added/updated
- [ ] Manual testing done

## Checklist
- [x] Code follows project standards
- [x] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`