### PR TITLE
fix(proxy): vscode byok - use chat completions for GPT-5.5 and GPT-5.6

### DIFF
--- a/docs/ARCHITECTURE-PROXY.md
+++ b/docs/ARCHITECTURE-PROXY.md
@@ -716,6 +716,13 @@ The command reuses a healthy daemon when its profile, project, provider, target 
 
 The connector merges one managed model into VS Code's `chatLanguageModels.json` and preserves unrelated models plus an existing `${input:chat.lm.secret.*}` reference as `apiKey`. If no valid reference exists, it omits `apiKey` rather than generating a placeholder and directs the user to open `Chat: Manage Language Models`, right-click **CodeMie Profile Model**, and choose **Update API Key**. VS Code then stores the local `codemie-proxy` key in secret storage; CodeMie SSO credentials never enter VS Code configuration.
 
+GPT-5.5 and GPT-5.6 are routed through Chat Completions with `thinking: false` and no
+reasoning-effort metadata. This is an explicit compatibility tradeoff: the current
+CodeMie/LiteLLM Chat route rejects requests that combine tools with reasoning, while the
+Responses route can lose `previous_response_id` state across load-balanced follow-up requests.
+The models must remain non-reasoning in the VS Code catalog until one of those upstream
+limitations is resolved.
+
 ```mermaid
 sequenceDiagram
     participant VS as VS Code Agent

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -140,6 +140,14 @@ unrelated providers, models, settings, and unknown provider properties. It rejec
 or a non-array root without overwriting the file. Re-running the command with another profile
 replaces the previous CodeMie-managed model without changing unrelated entries.
 
+GPT-5.5 and GPT-5.6 are deliberate exceptions: the connector routes them through Chat Completions
+but publishes `thinking: false` and omits reasoning-effort metadata. The current CodeMie/LiteLLM
+route rejects Chat Completions requests that combine tool calling with reasoning. Responses API
+reasoning is not used as a fallback because load-balanced follow-up requests can fail when the
+referenced `previous_response_id` is unavailable. Keep thinking disabled for these models until
+the upstream Chat route accepts tools with reasoning or the Responses route provides reliable
+response-state continuity.
+
 Check the daemon context with `codemie proxy status`. Automated VS Code BYOK configuration
 and routing coverage runs as part of `npm run test:all`.
 
@@ -155,6 +163,7 @@ and routing coverage runs as part of `npm run test:all`.
 | Configuration is rejected | `chatLanguageModels.json` is malformed or not an array | Repair the file; the connector leaves invalid content unchanged |
 | VS Code still uses old settings | Model configuration was not reloaded | Reload VS Code |
 | Active profile changed but model did not | VS Code configuration still contains the previous profile model | Re-run `codemie proxy connect vscode` |
+| GPT-5.5 or GPT-5.6 fails when thinking is enabled | Current Chat route rejects tools combined with reasoning | Keep thinking disabled; the managed catalog intentionally omits reasoning controls |
 | Inline suggestions still use Copilot | Expected limitation | BYOK covers chat/agent workflows, not inline completion |
 
 ### Claude Desktop 3P

--- a/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
@@ -17,11 +17,11 @@ const EXPECTED_MODEL_IDS = [
   'gpt-5-2025-08-07',
   'gpt-5-mini-2025-08-07',
   'gpt-5-nano-2025-08-07',
-  'gpt-5-1-codex-2025-11-13',
   'gpt-5-2-2025-12-11',
   'gpt-5.4-2026-03-05',
   'gpt-5.5-2026-04-24',
   'gpt-5.6-luna-2026-07-09',
+  'gpt-5.6-sol-2026-07-09',
   'gpt-5.6-terra-2026-07-09',
   'gemini-3-flash',
   'gemini-3.1-pro',
@@ -135,14 +135,27 @@ describe('writeVsCodeLanguageModelsConfigAtPath', () => {
     }
   });
 
-  it('does not advertise the rejected none effort for GPT-5.1 Codex', async () => {
+  it('disables thinking for GPT-5.5 and GPT-5.6 Chat Completions models', async () => {
     await writeVsCodeLanguageModelsConfigAtPath(configPath, 'http://127.0.0.1:4001');
 
     const providers = await readProviders();
     const models = providers[0].models as Array<Record<string, unknown>>;
-    const codex = models.find(model => model.id === 'gpt-5-1-codex-2025-11-13');
+    const affectedIds = [
+      'gpt-5.5-2026-04-24',
+      'gpt-5.6-luna-2026-07-09',
+      'gpt-5.6-sol-2026-07-09',
+      'gpt-5.6-terra-2026-07-09',
+    ];
 
-    expect(codex?.supportsReasoningEffort).toEqual(['low', 'medium', 'high']);
+    for (const id of affectedIds) {
+      const model = models.find(candidate => candidate.id === id);
+      expect(model).toMatchObject({
+        apiType: 'chat-completions',
+        thinking: false,
+      });
+      expect(model).not.toHaveProperty('supportsReasoningEffort');
+      expect(model).not.toHaveProperty('reasoningEffortFormat');
+    }
   });
 
   it('forces bearer authentication for Messages models only', async () => {
@@ -178,7 +191,7 @@ describe('writeVsCodeLanguageModelsConfigAtPath', () => {
         apiKey: secretReference,
         customProperty: 'preserved',
         settings: {
-          'gpt-5.5-2026-04-24': { reasoningEffort: 'high' },
+          'gpt-5.4-2026-03-05': { reasoningEffort: 'high' },
           'custom-setting': { enabled: true },
         },
         models: [
@@ -210,7 +223,7 @@ describe('writeVsCodeLanguageModelsConfigAtPath', () => {
       apiKey: secretReference,
       customProperty: 'preserved',
       settings: {
-        'gpt-5.5-2026-04-24': { reasoningEffort: 'high' },
+        'gpt-5.4-2026-03-05': { reasoningEffort: 'high' },
         'custom-setting': { enabled: true },
       },
     });

--- a/src/cli/commands/proxy/connectors/vscode-models.ts
+++ b/src/cli/commands/proxy/connectors/vscode-models.ts
@@ -27,10 +27,8 @@ export interface VsCodeModelDefinition {
 }
 
 const GPT_5_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
-const GPT_5_1_EFFORTS = ['low', 'medium', 'high'] as const;
 const GPT_5_2_EFFORTS = ['none', 'low', 'medium', 'high'] as const;
 const GPT_5_XHIGH_EFFORTS = ['none', 'low', 'medium', 'high', 'xhigh'] as const;
-const GPT_5_6_EFFORTS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 const GEMINI_FLASH_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
 const GEMINI_PRO_EFFORTS = ['low', 'medium', 'high'] as const;
 const CLAUDE_EFFORTS = ['low', 'medium', 'high'] as const;
@@ -97,16 +95,6 @@ export const VS_CODE_SUPPORTED_MODELS: readonly VsCodeModelDefinition[] = [
     maxOutputTokens: 128000,
   },
   {
-    id: 'gpt-5-1-codex-2025-11-13',
-    apiType: 'responses',
-    vision: true,
-    thinking: true,
-    supportsReasoningEffort: GPT_5_1_EFFORTS,
-    reasoningEffortFormat: 'responses',
-    maxInputTokens: 272000,
-    maxOutputTokens: 128000,
-  },
-  {
     id: 'gpt-5-2-2025-12-11',
     apiType: 'chat-completions',
     vision: true,
@@ -126,36 +114,39 @@ export const VS_CODE_SUPPORTED_MODELS: readonly VsCodeModelDefinition[] = [
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
+  // GPT-5.5/5.6 use Chat Completions to avoid Responses API follow-up failures
+  // caused by missing previous_response_id state. The current CodeMie/LiteLLM
+  // route rejects Chat requests that combine tools with reasoning, so thinking
+  // stays disabled and reasoning-effort metadata is intentionally omitted.
   {
     id: 'gpt-5.5-2026-04-24',
-    apiType: 'responses',
+    apiType: 'chat-completions',
     vision: true,
-    thinking: true,
-    supportsReasoningEffort: GPT_5_XHIGH_EFFORTS,
-    reasoningEffortFormat: 'responses',
+    thinking: false,
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
   {
     id: 'gpt-5.6-luna-2026-07-09',
-    apiType: 'responses',
+    apiType: 'chat-completions',
     vision: true,
-    thinking: true,
-    supportsReasoningEffort: GPT_5_6_EFFORTS,
-    reasoningEffortFormat: 'responses',
+    thinking: false,
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
-  // gpt-5.6-sol-2026-07-09 is intentionally excluded: its CodeMie Responses
-  // route rejects minimal requests, while Chat rejects tools with reasoning.
-  // Re-add only after the Responses route passes live VS Code certification.
+  {
+    id: 'gpt-5.6-sol-2026-07-09',
+    apiType: 'chat-completions',
+    vision: true,
+    thinking: false,
+    maxInputTokens: 922000,
+    maxOutputTokens: 128000,
+  },
   {
     id: 'gpt-5.6-terra-2026-07-09',
-    apiType: 'responses',
+    apiType: 'chat-completions',
     vision: true,
-    thinking: true,
-    supportsReasoningEffort: GPT_5_6_EFFORTS,
-    reasoningEffortFormat: 'responses',
+    thinking: false,
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },


### PR DESCRIPTION
## Summary

Updates VS Code proxy model routing for GPT-5.5 and GPT-5.6 to use Chat Completions for improved tool-calling compatibility and reliable follow-up requests.

## Changes

- Routed GPT-5.5 and GPT-5.6 models through Chat Completions.
- Disabled thinking and removed reasoning-effort metadata for these models.
- Added the GPT-5.6 Sol model to the supported catalog.
- Updated connector coverage and proxy documentation.
- Removed the obsolete GPT-5.1 Codex model definition.

## Impact

GPT-5.5 and GPT-5.6 remain available in VS Code, but reasoning controls are intentionally unavailable. This avoids failures caused by combining tools with reasoning and unreliable Responses API state across load-balanced requests.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
