### PR TITLE
feat(analytics): bring codemie-opencode telemetry to parity with codemie-claude

### DIFF
--- a/src/agents/core/session/BaseSessionAdapter.ts
+++ b/src/agents/core/session/BaseSessionAdapter.ts
@@ -122,9 +122,17 @@ export interface SessionAdapter {
    * Parse session file to unified format.
    * @param filePath - Absolute path to session file
    * @param sessionId - CodeMie session ID (already correlated)
+   * @param agentSessionId - The agent's own session ID, when known. Only needed
+   *   by adapters whose storage holds many sessions in one file (e.g. OpenCode's
+   *   SQLite database) and which therefore must disambiguate. Adapters reading a
+   *   one-session-per-file transcript ignore it.
    * @returns Parsed session in agent-agnostic format
    */
-  parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession>;
+  parseSessionFile(
+    filePath: string,
+    sessionId: string,
+    agentSessionId?: string
+  ): Promise<ParsedSession>;
 
   /**
    * Register a processor to run during session processing.

--- a/src/agents/core/types.ts
+++ b/src/agents/core/types.ts
@@ -360,11 +360,14 @@ export interface AgentMetadata {
  */
 export interface MCPConfigSource {
   /**
-   * Path to config file
-   * - Absolute: starts with '~/' (resolved to home dir)
+   * Path to config file, or several candidate paths tried in order (the first
+   * one that exists and parses wins). Multiple candidates cover agents that
+   * accept more than one config filename — OpenCode reads both `opencode.json`
+   * and `opencode.jsonc`.
+   * - Absolute: an absolute path, or one starting with '~/' (resolved to home)
    * - Relative: resolved from cwd
    */
-  path: string;
+  path: string | string[];
 
   /**
    * JSON path to mcpServers object
@@ -447,6 +450,34 @@ export interface AgentExtensionsConfig {
    * Example: Claude uses subdirectory-per-skill with a 'SKILL.md' entry file
    */
   skillsEntryFile?: string;
+
+  /**
+   * Per-category subdirectory names to scan, overriding the defaults
+   * ('agents', 'commands', 'skills', 'hooks', 'rules').
+   *
+   * Every listed directory is scanned and the results merged, which covers
+   * agents that accept more than one spelling — OpenCode reads both `agent/`
+   * and `agents/`. An empty array means the agent has no such concept and the
+   * category always reports zero.
+   */
+  dirNames?: {
+    agents?: string[];
+    commands?: string[];
+    skills?: string[];
+    hooks?: string[];
+    rules?: string[];
+  };
+
+  /**
+   * Additional global (user-level) roots scanned alongside `global`, for agents
+   * that read extensions from more than one location.
+   */
+  extraGlobalDirs?: string[];
+
+  /**
+   * Additional project-level roots scanned alongside `project`.
+   */
+  extraProjectDirs?: string[];
 }
 
 /**

--- a/src/agents/plugins/codemie-code-hooks/__tests__/shell-hooks-source.test.ts
+++ b/src/agents/plugins/codemie-code-hooks/__tests__/shell-hooks-source.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for SHELL_HOOKS_PLUGIN_SOURCE.
+ *
+ * The plugin ships as an embedded string that only ever runs inside the
+ * OpenCode binary, so tsc cannot see it. These tests transpile it, load it, and
+ * drive the handlers with the payload shapes OpenCode passes, capturing what
+ * would be piped to `codemie hook`.
+ *
+ * This guards the contract the previous version got wrong on every axis: it
+ * exported a plain object with nested hook keys, returned values instead of
+ * mutating `output`, and read a session id from an environment variable nothing
+ * sets — so every invocation shipped an empty session_id and was rejected.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import ts from 'typescript';
+import { SHELL_HOOKS_PLUGIN_SOURCE } from '../shell-hooks-source.js';
+
+interface CapturedPayload {
+  hook_event_name: string;
+  session_id: string;
+  transcript_path: string;
+  prompt?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_output?: string;
+}
+
+type HookHandler = (input: unknown, output?: unknown) => Promise<void>;
+
+const TRANSCRIPT = '/tmp/codemie-test/opencode.db';
+
+let workDir: string;
+let capturePath: string;
+let modulePath: string;
+
+/** Load the plugin factory the way the OpenCode runtime would. */
+async function loadHooks(hookNames: string[]): Promise<Record<string, HookHandler>> {
+  const hooks: Record<string, unknown[]> = {};
+  for (const name of hookNames) {
+    // A shell command that appends whatever arrives on stdin, standing in for
+    // the real `codemie hook` binary.
+    hooks[name] = [{ hooks: [{ type: 'command', command: `cat >> ${capturePath}` }] }];
+  }
+
+  process.env.OPENCODE_HOOKS = JSON.stringify({ hooks });
+  process.env.CODEMIE_OPENCODE_TRANSCRIPT = TRANSCRIPT;
+  delete process.env.OPENCODE_SESSION_ID;
+
+  // Cache-bust so each test re-reads OPENCODE_HOOKS at module load.
+  const imported = await import(`${modulePath}?v=${Math.random()}`);
+  return (await imported.default({})) as Record<string, HookHandler>;
+}
+
+function captured(): CapturedPayload[] {
+  if (!existsSync(capturePath)) return [];
+  const raw = readFileSync(capturePath, 'utf-8');
+  // Payloads are written back-to-back with no separator.
+  return raw.split(/(?<=\})(?=\{)/).filter(Boolean).map(line => JSON.parse(line));
+}
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'codemie-shell-hooks-'));
+  modulePath = join(workDir, 'plugin.mjs');
+
+  const transpiled = ts.transpileModule(SHELL_HOOKS_PLUGIN_SOURCE, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+    reportDiagnostics: true,
+  });
+
+  // A syntax error here would ship a plugin OpenCode silently fails to load.
+  expect(transpiled.diagnostics ?? []).toHaveLength(0);
+
+  writeFileSync(modulePath, transpiled.outputText);
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  delete process.env.OPENCODE_HOOKS;
+  delete process.env.CODEMIE_OPENCODE_TRANSCRIPT;
+});
+
+beforeEach(() => {
+  capturePath = join(workDir, `capture-${Math.random().toString(36).slice(2)}.jsonl`);
+});
+
+describe('SHELL_HOOKS_PLUGIN_SOURCE', () => {
+  it('exports an async factory returning flat dotted-key handlers', async () => {
+    const hooks = await loadHooks(['UserPromptSubmit']);
+
+    expect(Object.keys(hooks).sort()).toEqual([
+      'chat.message',
+      'event',
+      'experimental.session.compacting',
+      'tool.execute.after',
+      'tool.execute.before',
+    ]);
+    // The dead `permission.ask` handler is gone — OpenCode never triggers it.
+    expect(hooks).not.toHaveProperty('permission.ask');
+  });
+
+  it('reads the prompt from output.parts and the session id from input.sessionID', async () => {
+    const hooks = await loadHooks(['UserPromptSubmit']);
+
+    await hooks['chat.message'](
+      { sessionID: 'ses_abc' },
+      { parts: [{ type: 'text', text: 'hello' }, { type: 'file' }, { type: 'text', text: 'world' }] }
+    );
+
+    const payloads = captured();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].hook_event_name).toBe('UserPromptSubmit');
+    expect(payloads[0].session_id).toBe('ses_abc');
+    expect(payloads[0].prompt).toBe('hello\nworld');
+    // codemie hook refuses to re-parse a session without a transcript path.
+    expect(payloads[0].transcript_path).toBe(TRANSCRIPT);
+  });
+
+  it('collapses session.idle and session.status{idle} into a single Stop', async () => {
+    const hooks = await loadHooks(['Stop']);
+
+    // OpenCode publishes the deprecated and current idle signals back to back.
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_1' } } });
+    await hooks['event']({
+      event: { type: 'session.status', properties: { sessionID: 'ses_1', status: { type: 'idle' } } },
+    });
+
+    expect(captured()).toHaveLength(1);
+    expect(captured()[0].hook_event_name).toBe('Stop');
+  });
+
+  it('emits a Stop again after the session goes busy and idles once more', async () => {
+    const hooks = await loadHooks(['Stop']);
+
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_2' } } });
+    await hooks['event']({
+      event: { type: 'session.status', properties: { sessionID: 'ses_2', status: { type: 'busy' } } },
+    });
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_2' } } });
+
+    // One per busy→idle transition; active time would be under-counted otherwise.
+    expect(captured()).toHaveLength(2);
+  });
+
+  it('tracks idle state per session', async () => {
+    const hooks = await loadHooks(['Stop']);
+
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_a' } } });
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_b' } } });
+
+    expect(captured()).toHaveLength(2);
+  });
+
+  it('never invokes a hook without a resolvable session id', async () => {
+    const hooks = await loadHooks(['Stop', 'UserPromptSubmit']);
+
+    await hooks['event']({ event: { type: 'session.idle', properties: {} } });
+    await hooks['chat.message']({}, { parts: [{ type: 'text', text: 'orphan' }] });
+
+    // An empty session_id makes `codemie hook` exit 2 without doing any work.
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('no longer maps session.created or session.deleted to lifecycle events', async () => {
+    const hooks = await loadHooks(['SessionStart', 'SessionEnd']);
+
+    await hooks['event']({ event: { type: 'session.created', properties: { sessionID: 'ses_3' } } });
+    await hooks['event']({ event: { type: 'session.deleted', properties: { sessionID: 'ses_3' } } });
+
+    // Both lifecycle events are raised in-process by the CLI instead.
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('passes tool args through output and merges hook-supplied updates', async () => {
+    const hooks = await loadHooks(['PostToolUse']);
+
+    await hooks['tool.execute.after'](
+      { sessionID: 'ses_4', tool: 'read' },
+      { output: 'file contents' }
+    );
+
+    const payloads = captured();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].tool_name).toBe('read');
+    expect(payloads[0].tool_output).toBe('file contents');
+  });
+
+  it('sends PreToolUse args from output.args', async () => {
+    const hooks = await loadHooks(['PreToolUse']);
+
+    const output = { args: { filePath: 'src/a.ts' } };
+    await hooks['tool.execute.before']({ sessionID: 'ses_5', tool: 'edit' }, output);
+
+    const payloads = captured();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].tool_input).toEqual({ filePath: 'src/a.ts' });
+  });
+
+  it('does nothing when no hooks are configured for the event', async () => {
+    const hooks = await loadHooks(['PreToolUse']);
+
+    await hooks['event']({ event: { type: 'session.idle', properties: { sessionID: 'ses_6' } } });
+
+    expect(captured()).toHaveLength(0);
+  });
+});

--- a/src/agents/plugins/codemie-code-hooks/shell-hooks-source.ts
+++ b/src/agents/plugins/codemie-code-hooks/shell-hooks-source.ts
@@ -8,8 +8,20 @@
  * (Anthropic/Claude Code format) and maps them to OpenCode plugin lifecycle hooks.
  *
  * Why a string constant: The plugin uses `import type { Plugin } from "@opencode-ai/plugin"`
- * which doesn't exist in codemie-code's dependencies. Embedding as a string avoids
+ * which doesn't exist in this package's dependencies. Embedding as a string avoids
  * TypeScript compilation issues. Bun strips the type import at runtime.
+ *
+ * PLUGIN CONTRACT — see reasoning-sanitizer-source.ts for the reference shape:
+ * a Plugin is an async factory returning a FLAT map of dotted-key handlers, and
+ * each handler takes `(input, output)` and MUTATES `output`. Returned values are
+ * discarded. An earlier version of this file exported a plain object with nested
+ * `hooks: { tool: { execute: { before } } }` keys and returned values from every
+ * handler, so none of it ever ran.
+ *
+ * Session id: taken from the payload OpenCode passes in (`input.sessionID`, or
+ * `input.event.properties.sessionID` for bus events). `codemie hook` rejects an
+ * empty session_id with exit code 2, so a hook with no resolvable session id is
+ * skipped rather than invoked.
  */
 
 export const SHELL_HOOKS_PLUGIN_SOURCE = `
@@ -36,7 +48,6 @@ type HookEventName =
   | "PreToolUse"
   | "PostToolUse"
   | "UserPromptSubmit"
-  | "PermissionRequest"
   | "PreCompact"
   | "SessionStart"
   | "SessionEnd"
@@ -81,7 +92,7 @@ function matchesPattern(pattern: string, toolName: string): boolean {
 // ─── Config Loading ──────────────────────────────────────────────────────────
 
 function loadHooksConfig(): HooksConfig {
-  // Priority 1: OPENCODE_HOOKS env var (set by codemie-code)
+  // Priority 1: OPENCODE_HOOKS env var (set by the CodeMie CLI)
   const envHooks = process.env.OPENCODE_HOOKS;
   if (envHooks) {
     try {
@@ -141,7 +152,26 @@ function getMatchingCommands(
   return result;
 }
 
-// ─── Shell Execution ─────────────────────────────────────────────────────────
+// ─── Session / Payload Helpers ───────────────────────────────────────────────
+
+// OPENCODE_SESSION_ID is a last-resort fallback only: nothing sets it today, and
+// relying on it is what made every previous hook invocation ship an empty
+// session_id and get rejected with exit code 2.
+function resolveSessionId(input: any): string {
+  return (
+    input?.sessionID ||
+    input?.event?.properties?.sessionID ||
+    input?.event?.properties?.info?.id ||
+    process.env.OPENCODE_SESSION_ID ||
+    ""
+  );
+}
+
+// codemie hook needs a transcript path to re-parse the session; for OpenCode
+// that is the SQLite database, exported by the CLI before spawning.
+function transcriptPath(): string {
+  return process.env.CODEMIE_OPENCODE_TRANSCRIPT || "";
+}
 
 function buildEnvVars(sessionId: string, event: string): Record<string, string> {
   const projectDir = process.env.OPENCODE_PROJECT_DIR || process.cwd();
@@ -152,6 +182,18 @@ function buildEnvVars(sessionId: string, event: string): Record<string, string> 
     CLAUDE_PROJECT_DIR: projectDir, // Anthropic alias
   };
 }
+
+function basePayload(event: HookEventName, sessionId: string): HookStdinPayload {
+  return {
+    hook_event_name: event,
+    session_id: sessionId,
+    cwd: process.cwd(),
+    permission_mode: "default",
+    transcript_path: transcriptPath(),
+  };
+}
+
+// ─── Shell Execution ─────────────────────────────────────────────────────────
 
 interface ExecResult {
   stdout: string;
@@ -194,7 +236,13 @@ function execCommandAsync(
     stdio: ["pipe", "ignore", "ignore"],
     detached: true,
   });
+  // A ChildProcess or stdin 'error' with no listener is an UNHANDLED error
+  // event, which throws inside the host OpenCode process. Stop is configured
+  // async, so this is the production path: a failed spawn (ENOENT for sh,
+  // EAGAIN) or a broken pipe must degrade telemetry, never kill the session.
+  child.on("error", () => {});
   if (child.stdin) {
+    child.stdin.on("error", () => {});
     child.stdin.write(stdin);
     child.stdin.end();
   }
@@ -207,7 +255,6 @@ interface ParsedResponse {
   blocked: boolean;
   reason?: string;
   updatedInput?: Record<string, unknown>;
-  permissionDecision?: "allow" | "deny" | "ask";
   additionalContext?: string;
 }
 
@@ -226,39 +273,23 @@ function parseResponse(
     return { blocked: false };
   }
 
-  // Parse stdout JSON
   const trimmed = result.stdout.trim();
   if (!trimmed) return { blocked: false };
 
   try {
     const json = JSON.parse(trimmed);
 
-    // PreToolUse: check for hookSpecificOutput.updatedInput or plain object → merge into args
+    // PreToolUse: hookSpecificOutput.updatedInput, or a bare object → merged args
     if (event === "PreToolUse") {
       const updated = json.hookSpecificOutput?.updatedInput || json.updatedInput;
       if (updated && typeof updated === "object") {
         return { blocked: false, updatedInput: updated };
       }
-      // If it's a plain object without known keys, treat as updatedInput
       if (typeof json === "object" && !json.hookSpecificOutput && !json.decision) {
         return { blocked: false, updatedInput: json };
       }
     }
 
-    // PermissionRequest: check for permissionDecision
-    if (event === "PermissionRequest") {
-      const decision =
-        json.hookSpecificOutput?.permissionDecision || json.permissionDecision;
-      if (decision && ["allow", "deny", "ask"].includes(decision)) {
-        return { blocked: false, permissionDecision: decision };
-      }
-      // Plain string
-      if (typeof json === "string" && ["allow", "deny", "ask"].includes(json)) {
-        return { blocked: false, permissionDecision: json };
-      }
-    }
-
-    // PreCompact: additionalContext
     if (event === "PreCompact") {
       const context = json.additionalContext || json.context;
       if (typeof context === "string") {
@@ -273,250 +304,174 @@ function parseResponse(
   }
 }
 
+/** Run every configured command for an event. Returns the parsed responses. */
+function runCommands(
+  event: HookEventName,
+  sessionId: string,
+  payload: HookStdinPayload,
+  commands: Array<{ command: string; timeout: number; isAsync: boolean }>,
+  swallowErrors: boolean,
+): ParsedResponse[] {
+  const env = buildEnvVars(sessionId, event);
+  const stdin = JSON.stringify(payload);
+  const responses: ParsedResponse[] = [];
+
+  for (const cmd of commands) {
+    if (cmd.isAsync) {
+      execCommandAsync(cmd.command, stdin, env);
+      continue;
+    }
+    if (swallowErrors) {
+      try {
+        responses.push(parseResponse(execCommand(cmd.command, stdin, env, cmd.timeout), event));
+      } catch {
+        // Fire-and-forget events must never break the session.
+      }
+      continue;
+    }
+    responses.push(parseResponse(execCommand(cmd.command, stdin, env, cmd.timeout), event));
+  }
+
+  return responses;
+}
+
+// ─── Idle Deduplication ──────────────────────────────────────────────────────
+
+// OpenCode publishes both the deprecated \`session.idle\` and the newer
+// \`session.status\` {type:"idle"} back to back. Subscribing to only one risks
+// silently losing active-time accounting if it is removed upstream, so both are
+// handled and collapsed on the busy→idle transition.
+const idleState = new Map<string, boolean>();
+
+function shouldEmitIdle(sessionId: string, isIdle: boolean): boolean {
+  const wasIdle = idleState.get(sessionId) === true;
+  idleState.set(sessionId, isIdle);
+  return isIdle && !wasIdle;
+}
+
 // ─── Plugin Definition ───────────────────────────────────────────────────────
 
 const config = loadHooksConfig();
-const hasHooks = config.hooks && Object.keys(config.hooks).length > 0;
 
-const plugin: Plugin = {
-  name: "shell-hooks",
-  ...(hasHooks
-    ? {
-        hooks: {
-          // PreToolUse → tool.execute.before (blocking)
-          tool: {
-            execute: {
-              before: async (input) => {
-                const commands = getMatchingCommands(config, "PreToolUse", input.tool);
-                if (commands.length === 0) return input;
+const ShellHooksPlugin: Plugin = async (_input) => ({
+  // PreToolUse → tool.execute.before (blocking; mutate output.args)
+  "tool.execute.before": async (input: any, output: any) => {
+    const commands = getMatchingCommands(config, "PreToolUse", input?.tool);
+    if (commands.length === 0) return;
 
-                const sessionId = process.env.OPENCODE_SESSION_ID || "";
-                const env = buildEnvVars(sessionId, "PreToolUse");
-                const payload: HookStdinPayload = {
-                  hook_event_name: "PreToolUse",
-                  session_id: sessionId,
-                  cwd: process.cwd(),
-                  permission_mode: "default",
-                  transcript_path: "",
-                  tool_name: input.tool,
-                  tool_input: input.args as Record<string, unknown>,
-                };
-                const stdin = JSON.stringify(payload);
+    const sessionId = resolveSessionId(input);
+    if (!sessionId) return;
 
-                let mergedInput = { ...input };
-                for (const cmd of commands) {
-                  if (cmd.isAsync) {
-                    execCommandAsync(cmd.command, stdin, env);
-                    continue;
-                  }
-                  const result = execCommand(cmd.command, stdin, env, cmd.timeout);
-                  const parsed = parseResponse(result, "PreToolUse");
-                  if (parsed.blocked) {
-                    throw new Error(parsed.reason || "Hook blocked tool execution");
-                  }
-                  if (parsed.updatedInput) {
-                    mergedInput = {
-                      ...mergedInput,
-                      args: { ...(mergedInput.args as Record<string, unknown>), ...parsed.updatedInput },
-                    };
-                  }
-                }
-                return mergedInput;
-              },
+    const payload = basePayload("PreToolUse", sessionId);
+    payload.tool_name = input?.tool;
+    payload.tool_input = output?.args as Record<string, unknown>;
 
-              // PostToolUse → tool.execute.after (fire-and-forget)
-              after: async (output) => {
-                const commands = getMatchingCommands(config, "PostToolUse", output.tool);
-                if (commands.length === 0) return output;
-
-                const sessionId = process.env.OPENCODE_SESSION_ID || "";
-                const env = buildEnvVars(sessionId, "PostToolUse");
-                const payload: HookStdinPayload = {
-                  hook_event_name: "PostToolUse",
-                  session_id: sessionId,
-                  cwd: process.cwd(),
-                  permission_mode: "default",
-                  transcript_path: "",
-                  tool_name: output.tool,
-                  tool_input: output.args as Record<string, unknown>,
-                  tool_output: typeof output.result === "string" ? output.result : JSON.stringify(output.result),
-                };
-                const stdin = JSON.stringify(payload);
-
-                for (const cmd of commands) {
-                  if (cmd.isAsync) {
-                    execCommandAsync(cmd.command, stdin, env);
-                    continue;
-                  }
-                  try {
-                    execCommand(cmd.command, stdin, env, cmd.timeout);
-                  } catch {
-                    // PostToolUse is fire-and-forget
-                  }
-                }
-                return output;
-              },
-            },
-          },
-
-          // UserPromptSubmit → chat.message (blocking)
-          chat: {
-            message: async (input) => {
-              const commands = getMatchingCommands(config, "UserPromptSubmit");
-              if (commands.length === 0) return input;
-
-              const sessionId = process.env.OPENCODE_SESSION_ID || "";
-              const env = buildEnvVars(sessionId, "UserPromptSubmit");
-              const payload: HookStdinPayload = {
-                hook_event_name: "UserPromptSubmit",
-                session_id: sessionId,
-                cwd: process.cwd(),
-                permission_mode: "default",
-                transcript_path: "",
-                prompt: Array.isArray(input.parts)
-                  ? input.parts
-                      .filter((p: any) => p.type === "text")
-                      .map((p: any) => p.text)
-                      .join("\\n")
-                  : String(input.parts),
-              };
-              const stdin = JSON.stringify(payload);
-
-              for (const cmd of commands) {
-                if (cmd.isAsync) {
-                  execCommandAsync(cmd.command, stdin, env);
-                  continue;
-                }
-                const result = execCommand(cmd.command, stdin, env, cmd.timeout);
-                const parsed = parseResponse(result, "UserPromptSubmit");
-                if (parsed.blocked) {
-                  // Clear message parts to block submission
-                  return { ...input, parts: [] };
-                }
-              }
-              return input;
-            },
-          },
-
-          // PermissionRequest → permission.ask (blocking)
-          permission: {
-            ask: async (input) => {
-              const commands = getMatchingCommands(config, "PermissionRequest", input.tool);
-              if (commands.length === 0) return input;
-
-              const sessionId = process.env.OPENCODE_SESSION_ID || "";
-              const env = buildEnvVars(sessionId, "PermissionRequest");
-              const payload: HookStdinPayload = {
-                hook_event_name: "PermissionRequest",
-                session_id: sessionId,
-                cwd: process.cwd(),
-                permission_mode: "default",
-                transcript_path: "",
-                tool_name: input.tool,
-                tool_input: input.args as Record<string, unknown>,
-              };
-              const stdin = JSON.stringify(payload);
-
-              for (const cmd of commands) {
-                if (cmd.isAsync) {
-                  execCommandAsync(cmd.command, stdin, env);
-                  continue;
-                }
-                const result = execCommand(cmd.command, stdin, env, cmd.timeout);
-                const parsed = parseResponse(result, "PermissionRequest");
-                if (parsed.permissionDecision === "allow") {
-                  return { ...input, allowed: true };
-                }
-                if (parsed.permissionDecision === "deny") {
-                  return { ...input, allowed: false };
-                }
-              }
-              return input;
-            },
-          },
-
-          // PreCompact → experimental.session.compacting (non-blocking)
-          experimental: {
-            session: {
-              compacting: async (input) => {
-                const commands = getMatchingCommands(config, "PreCompact");
-                if (commands.length === 0) return input;
-
-                const sessionId = process.env.OPENCODE_SESSION_ID || "";
-                const env = buildEnvVars(sessionId, "PreCompact");
-                const payload: HookStdinPayload = {
-                  hook_event_name: "PreCompact",
-                  session_id: sessionId,
-                  cwd: process.cwd(),
-                  permission_mode: "default",
-                  transcript_path: "",
-                };
-                const stdin = JSON.stringify(payload);
-
-                for (const cmd of commands) {
-                  if (cmd.isAsync) {
-                    execCommandAsync(cmd.command, stdin, env);
-                    continue;
-                  }
-                  try {
-                    const result = execCommand(cmd.command, stdin, env, cmd.timeout);
-                    const parsed = parseResponse(result, "PreCompact");
-                    if (parsed.additionalContext) {
-                      return {
-                        ...input,
-                        context: ((input as any).context || "") + "\\n" + parsed.additionalContext,
-                      };
-                    }
-                  } catch {
-                    // Non-blocking
-                  }
-                }
-                return input;
-              },
-            },
-          },
-
-          // SessionStart/SessionEnd/Stop/Notification → event (non-blocking)
-          event: async (input) => {
-            let hookEvent: HookEventName | undefined;
-            const eventType = (input as any).type || (input as any).event;
-            if (eventType === "session.created") hookEvent = "SessionStart";
-            else if (eventType === "session.deleted") hookEvent = "SessionEnd";
-            else if (eventType === "session.idle") hookEvent = "Stop";
-            else if (eventType === "session.error") hookEvent = "Notification";
-
-            if (!hookEvent) return;
-
-            const commands = getMatchingCommands(config, hookEvent);
-            if (commands.length === 0) return;
-
-            const sessionId = process.env.OPENCODE_SESSION_ID || "";
-            const env = buildEnvVars(sessionId, hookEvent);
-            const payload: HookStdinPayload = {
-              hook_event_name: hookEvent,
-              session_id: sessionId,
-              cwd: process.cwd(),
-              permission_mode: "default",
-              transcript_path: "",
-            };
-            const stdin = JSON.stringify(payload);
-
-            for (const cmd of commands) {
-              if (cmd.isAsync) {
-                execCommandAsync(cmd.command, stdin, env);
-                continue;
-              }
-              try {
-                execCommand(cmd.command, stdin, env, cmd.timeout);
-              } catch {
-                // Event hooks are non-blocking
-              }
-            }
-          },
-        },
+    for (const parsed of runCommands("PreToolUse", sessionId, payload, commands, false)) {
+      if (parsed.blocked) {
+        throw new Error(parsed.reason || "Hook blocked tool execution");
       }
-    : {}),
-};
+      if (parsed.updatedInput && output) {
+        output.args = { ...(output.args || {}), ...parsed.updatedInput };
+      }
+    }
+  },
 
-export default plugin;
+  // PostToolUse → tool.execute.after (fire-and-forget)
+  "tool.execute.after": async (input: any, output: any) => {
+    const commands = getMatchingCommands(config, "PostToolUse", input?.tool);
+    if (commands.length === 0) return;
+
+    const sessionId = resolveSessionId(input);
+    if (!sessionId) return;
+
+    const payload = basePayload("PostToolUse", sessionId);
+    payload.tool_name = input?.tool;
+    payload.tool_output =
+      typeof output?.output === "string" ? output.output : JSON.stringify(output?.output ?? null);
+
+    runCommands("PostToolUse", sessionId, payload, commands, true);
+  },
+
+  // UserPromptSubmit → chat.message. Marks the start of an active period;
+  // codemie hook forwards it to SessionStore.startActivityTracking.
+  "chat.message": async (input: any, output: any) => {
+    const sessionId = resolveSessionId(input);
+    if (!sessionId) return;
+
+    // A new prompt opens a new active period, so the session is busy again.
+    // Clearing the flag here is what lets the NEXT idle emit a Stop: on a build
+    // that publishes session.idle without session.status, nothing else ever
+    // resets it, so every turn after the first would be suppressed and
+    // active_duration_ms would count only turn one.
+    idleState.set(sessionId, false);
+
+    const commands = getMatchingCommands(config, "UserPromptSubmit");
+    if (commands.length === 0) return;
+
+    // The message parts live on output, not input.
+    const parts = output?.parts;
+    const payload = basePayload("UserPromptSubmit", sessionId);
+    payload.prompt = Array.isArray(parts)
+      ? parts
+          .filter((p: any) => p?.type === "text")
+          .map((p: any) => p.text)
+          .join("\\n")
+      : "";
+
+    runCommands("UserPromptSubmit", sessionId, payload, commands, true);
+  },
+
+  // PreCompact → experimental.session.compacting (non-blocking)
+  "experimental.session.compacting": async (input: any, output: any) => {
+    const commands = getMatchingCommands(config, "PreCompact");
+    if (commands.length === 0) return;
+
+    const sessionId = resolveSessionId(input);
+    if (!sessionId) return;
+
+    const responses = runCommands(
+      "PreCompact", sessionId, basePayload("PreCompact", sessionId), commands, true
+    );
+
+    for (const parsed of responses) {
+      if (parsed.additionalContext && output) {
+        output.context = (output.context || "") + "\\n" + parsed.additionalContext;
+      }
+    }
+  },
+
+  // Stop / Notification → event bus (non-blocking).
+  // SessionStart and SessionEnd are deliberately NOT mapped here: session.created
+  // and session.deleted do not correspond to CLI process start/exit, and the
+  // CodeMie CLI raises both lifecycle events in-process instead.
+  "event": async (input: any) => {
+    const eventType = input?.event?.type;
+    if (typeof eventType !== "string") return;
+
+    const sessionId = resolveSessionId(input);
+    if (!sessionId) return;
+
+    let hookEvent: HookEventName | undefined;
+
+    if (eventType === "session.idle") {
+      if (!shouldEmitIdle(sessionId, true)) return;
+      hookEvent = "Stop";
+    } else if (eventType === "session.status") {
+      const isIdle = input?.event?.properties?.status?.type === "idle";
+      if (!shouldEmitIdle(sessionId, isIdle)) return;
+      hookEvent = "Stop";
+    } else if (eventType === "session.error") {
+      hookEvent = "Notification";
+    }
+
+    if (!hookEvent) return;
+
+    const commands = getMatchingCommands(config, hookEvent);
+    if (commands.length === 0) return;
+
+    runCommands(hookEvent, sessionId, basePayload(hookEvent, sessionId), commands, true);
+  },
+});
+
+export default ShellHooksPlugin;
 `;

--- a/src/agents/plugins/opencode/__tests__/opencode-session-lifecycle.test.ts
+++ b/src/agents/plugins/opencode/__tests__/opencode-session-lifecycle.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the OpenCode plugin's session lifecycle wiring.
+ *
+ * The ordering guarded here is load-bearing: BaseAgentAdapter runs
+ * onSessionStart (creating the real session record) before beforeRun (which
+ * calls ensureSessionFile). ensureSessionFile writes a placeholder carrying
+ * `status: 'completed'`, a fabricated startTime and `agentSessionId: 'unknown'`;
+ * if it ever won the race, every tool-usage metric would ship
+ * session_id "unknown" and a meaningless session_duration_ms.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const processEvent = vi.fn();
+const startIncrementalSync = vi.fn();
+const stopIncrementalSync = vi.fn();
+const ensureSessionFile = vi.fn();
+
+vi.mock('../../../../cli/commands/hook.js', () => ({ processEvent }));
+vi.mock('../opencode.incremental-sync.js', () => ({
+  startOpenCodeIncrementalSync: startIncrementalSync,
+  stopOpenCodeIncrementalSync: stopIncrementalSync,
+}));
+vi.mock('../../../core/session/ensure-session.js', () => ({ ensureSessionFile }));
+vi.mock('../opencode.paths.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../opencode.paths.js')>()),
+  getOpenCodeDbPath: () => '/data/opencode/opencode.db',
+}));
+vi.mock('../../codemie-code-hooks/index.js', () => ({
+  getHooksPluginFileUrl: () => 'file:///tmp/codemie-hooks/shell-hooks.ts',
+  cleanupHooksPlugin: vi.fn(),
+}));
+
+const { OpenCodePluginMetadata } = await import('../opencode.plugin.js');
+
+function baseEnv(): NodeJS.ProcessEnv {
+  return {
+    CODEMIE_SESSION_ID: 'codemie-uuid-1',
+    CODEMIE_AGENT: 'opencode',
+    CODEMIE_PROVIDER: 'ai-run-sso',
+    CODEMIE_URL: 'https://sso.example.com',
+    CODEMIE_CLI_VERSION: '9.9.9',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('OpenCode onSessionStart', () => {
+  it('emits a SessionStart lifecycle event carrying the CodeMie session id', async () => {
+    const env = baseEnv();
+
+    await OpenCodePluginMetadata.lifecycle!.onSessionStart!('codemie-uuid-1', env);
+
+    expect(processEvent).toHaveBeenCalledTimes(1);
+    const [event, config] = processEvent.mock.calls[0];
+
+    expect(event.hook_event_name).toBe('SessionStart');
+    // OpenCode's own ses_* id does not exist yet; using it here would leave the
+    // started and completed rows uncorrelatable.
+    expect(event.session_id).toBe('codemie-uuid-1');
+    expect(event.source).toBe('startup');
+    expect(config.clientType).toBe('codemie-opencode');
+    expect(config.sessionId).toBe('codemie-uuid-1');
+  });
+
+  it('starts the incremental sync failsafe', async () => {
+    const env = baseEnv();
+
+    await OpenCodePluginMetadata.lifecycle!.onSessionStart!('codemie-uuid-1', env);
+
+    expect(startIncrementalSync).toHaveBeenCalledTimes(1);
+    const options = startIncrementalSync.mock.calls[0][0];
+    expect(options.sessionId).toBe('codemie-uuid-1');
+    expect(options.cwd).toBe(process.cwd());
+    expect(options.buildContext().clientType).toBe('codemie-opencode');
+  });
+
+  it('does not block startup when the lifecycle event fails', async () => {
+    processEvent.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      OpenCodePluginMetadata.lifecycle!.onSessionStart!('codemie-uuid-1', baseEnv())
+    ).resolves.toBeUndefined();
+
+    // The failsafe timer must still start.
+    expect(startIncrementalSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OpenCode beforeRun', () => {
+  it('always registers the telemetry hooks and injects the plugin', async () => {
+    const env = { ...baseEnv(), CODEMIE_BASE_URL: 'http://localhost:1234' };
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    const hooks = JSON.parse(env.OPENCODE_HOOKS!).hooks;
+    expect(Object.keys(hooks).sort()).toEqual(['Stop', 'UserPromptSubmit']);
+    // Stop is detached: the plugin runs sync hooks with execSync, which would
+    // otherwise stall OpenCode while the child re-parses SQLite.
+    expect(hooks.Stop[0].hooks[0].async).toBe(true);
+
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT!);
+    expect(config.plugin).toContain('file:///tmp/codemie-hooks/shell-hooks.ts');
+  });
+
+  it('registers the telemetry hooks even when the profile defines none', async () => {
+    const env = { ...baseEnv(), CODEMIE_BASE_URL: 'http://localhost:1234' };
+    delete env.CODEMIE_PROFILE_CONFIG;
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    // The old guard injected the plugin only when the profile happened to
+    // define hooks, so active-time tracking never ran for most users.
+    expect(env.OPENCODE_HOOKS).toBeDefined();
+    expect(Object.keys(JSON.parse(env.OPENCODE_HOOKS!).hooks).sort())
+      .toEqual(['Stop', 'UserPromptSubmit']);
+  });
+
+  it('still exports the transcript path when no proxy config is produced', async () => {
+    const env = baseEnv(); // no CODEMIE_BASE_URL — beforeRun returns early
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    // Without a base URL no OpenCode config is written, so the plugin cannot be
+    // injected and active-duration tracking is unavailable in that setup; the
+    // in-process lifecycle metrics and sync timer still run.
+    expect(env.CODEMIE_OPENCODE_TRANSCRIPT).toBe('/data/opencode/opencode.db');
+    expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined();
+  });
+
+  it('merges profile hooks on top of the defaults', async () => {
+    const env = {
+      ...baseEnv(),
+      CODEMIE_BASE_URL: 'http://localhost:1234',
+      CODEMIE_PROFILE_CONFIG: JSON.stringify({
+        hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+      }),
+    };
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    const hooks = JSON.parse(env.OPENCODE_HOOKS!).hooks;
+    expect(Object.keys(hooks).sort()).toEqual(['PreToolUse', 'Stop', 'UserPromptSubmit']);
+  });
+
+  it('exports the transcript path the hook needs to re-parse the session', async () => {
+    const env = { ...baseEnv(), CODEMIE_BASE_URL: 'http://localhost:1234' };
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    // performIncrementalSync bails out on any event without a transcript_path.
+    expect(env.CODEMIE_OPENCODE_TRANSCRIPT).toBe('/data/opencode/opencode.db');
+  });
+
+  it('does not redirect XDG_DATA_HOME away from the user\'s own storage', async () => {
+    const env = { ...baseEnv(), CODEMIE_BASE_URL: 'http://localhost:1234' };
+
+    await OpenCodePluginMetadata.lifecycle!.beforeRun!(env, {} as never);
+
+    // Redirecting it would orphan the session history users already have.
+    expect(env.XDG_DATA_HOME).toBeUndefined();
+  });
+});
+
+describe('OpenCode onSessionEnd', () => {
+  it('stops the timer and routes through the full SessionEnd pipeline', async () => {
+    const env = baseEnv();
+
+    await OpenCodePluginMetadata.lifecycle!.onSessionEnd!(0, env);
+
+    expect(stopIncrementalSync).toHaveBeenCalledWith('codemie-uuid-1');
+
+    const [event, config] = processEvent.mock.calls[0];
+    expect(event.hook_event_name).toBe('SessionEnd');
+    expect(event.session_id).toBe('codemie-uuid-1');
+    expect(event.reason).toBe('exit');
+    expect(config.clientType).toBe('codemie-opencode');
+  });
+
+  it('reports a non-zero exit code in the reason', async () => {
+    await OpenCodePluginMetadata.lifecycle!.onSessionEnd!(3, baseEnv());
+
+    expect(processEvent.mock.calls[0][0].reason).toBe('exit(3)');
+  });
+
+  it('skips entirely without a CodeMie session id', async () => {
+    await OpenCodePluginMetadata.lifecycle!.onSessionEnd!(0, {});
+
+    expect(processEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('OpenCode telemetry metadata', () => {
+  it('excludes shell errors using the lower-cased tool name', () => {
+    // filterErrorTools does an exact match and the processor lower-cases tool
+    // names, so the global ['Bash','Execute','Shell'] default never matches.
+    expect(OpenCodePluginMetadata.metricsConfig?.excludeErrorsFromTools).toEqual(['bash']);
+  });
+
+  it('declares MCP and extension locations so the scans report non-zero', () => {
+    expect(OpenCodePluginMetadata.mcpConfig?.project?.jsonPath).toBe('mcp');
+    expect(OpenCodePluginMetadata.mcpConfig?.project?.path).toEqual([
+      'opencode.json',
+      'opencode.jsonc',
+    ]);
+
+    const extensions = OpenCodePluginMetadata.extensionsConfig!;
+    expect(extensions.project).toBe('.opencode');
+    expect(extensions.dirNames?.agents).toEqual(['agent', 'agents']);
+    // OpenCode has no hooks/ directory; plugins occupy that metric slot.
+    expect(extensions.dirNames?.hooks).toEqual(['plugin', 'plugins']);
+    // ...and no rules/ concept at all, so rules_* stays at zero.
+    expect(extensions.dirNames?.rules).toEqual([]);
+  });
+});

--- a/src/agents/plugins/opencode/__tests__/opencode-session-record.test.ts
+++ b/src/agents/plugins/opencode/__tests__/opencode-session-record.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Risk 1 regression guard — ensureSessionFile must never clobber the real
+ * session record.
+ *
+ * The design for the codemie-opencode telemetry work calls this out explicitly:
+ * `executeOnSessionStart` (BaseAgentAdapter:542) creates the real record with
+ * `status: 'active'` and `correlation.agentSessionId` set to the CodeMie session
+ * id, and `executeBeforeRun` (:578) then runs `ensureSessionFile` as a safety
+ * net. That is safe ONLY because of the ordering and because ensureSessionFile
+ * early-returns on an existing record. If either property breaks, every
+ * tool-usage row silently ships `session_id: "unknown"` and
+ * `session_duration_ms` is destroyed.
+ *
+ * These tests exercise the REAL SessionStore and the REAL ensureSessionFile
+ * against an isolated CODEMIE_HOME — no mocks — because a mocked
+ * ensureSessionFile cannot prove anything about what lands on disk.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const SESSION_ID = 'a1b2c3d4-0000-4000-8000-000000000001';
+
+let codemieHome: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  codemieHome = mkdtempSync(join(tmpdir(), 'codemie-session-record-'));
+  originalHome = process.env.CODEMIE_HOME;
+  process.env.CODEMIE_HOME = codemieHome;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.CODEMIE_HOME;
+  } else {
+    process.env.CODEMIE_HOME = originalHome;
+  }
+  rmSync(codemieHome, { recursive: true, force: true });
+});
+
+/** Mirrors the record createSessionRecord writes during SessionStart. */
+async function writeActiveSessionRecord(): Promise<void> {
+  const { SessionStore } = await import('../../../core/session/SessionStore.js');
+  const store = new SessionStore();
+
+  await store.saveSession({
+    sessionId: SESSION_ID,
+    agentName: 'opencode',
+    provider: 'codemie',
+    status: 'active',
+    startTime: Date.now(),
+    workingDirectory: process.cwd(),
+    gitBranch: 'feat/opencode-telemetry-parity',
+    correlation: { agentSessionId: SESSION_ID },
+  } as never);
+}
+
+describe('ensureSessionFile (Risk 1 — session record clobbering)', () => {
+  it('leaves an existing active record untouched', async () => {
+    await writeActiveSessionRecord();
+
+    const { ensureSessionFile } = await import('../../../core/session/ensure-session.js');
+    await ensureSessionFile(SESSION_ID, { CODEMIE_AGENT: 'opencode' } as NodeJS.ProcessEnv, 'opencode');
+
+    const { SessionStore } = await import('../../../core/session/SessionStore.js');
+    const session = await new SessionStore().loadSession(SESSION_ID);
+
+    // The two fields the whole telemetry pipeline keys on.
+    expect(session?.status).toBe('active');
+    expect(session?.correlation?.agentSessionId).toBe(SESSION_ID);
+    expect(session?.correlation?.agentSessionId).not.toBe('unknown');
+  });
+
+  it('preserves startTime, so session_duration_ms is not destroyed', async () => {
+    await writeActiveSessionRecord();
+
+    const { SessionStore } = await import('../../../core/session/SessionStore.js');
+    const store = new SessionStore();
+    const before = await store.loadSession(SESSION_ID);
+
+    const { ensureSessionFile } = await import('../../../core/session/ensure-session.js');
+    await ensureSessionFile(SESSION_ID, { CODEMIE_AGENT: 'opencode' } as NodeJS.ProcessEnv, 'opencode');
+
+    const after = await store.loadSession(SESSION_ID);
+    expect(after?.startTime).toBe(before?.startTime);
+  });
+
+  it('documents the residual risk: with no prior record it writes an unknown-correlation placeholder', async () => {
+    // This is the failure mode the design flags as still live — onSessionStart
+    // swallows a processEvent throw, and nothing has written the real record by
+    // the time beforeRun runs. Pinning it means a future change that makes
+    // onSessionStart rethrow (or that fixes the placeholder) fails loudly here
+    // rather than silently shipping session_id "unknown" to analytics.
+    const { ensureSessionFile } = await import('../../../core/session/ensure-session.js');
+    await ensureSessionFile(SESSION_ID, { CODEMIE_AGENT: 'opencode' } as NodeJS.ProcessEnv, 'opencode');
+
+    const { SessionStore } = await import('../../../core/session/SessionStore.js');
+    const session = await new SessionStore().loadSession(SESSION_ID);
+
+    expect(session).not.toBeNull();
+    expect(session?.correlation?.agentSessionId).toBe('unknown');
+  });
+});

--- a/src/agents/plugins/opencode/node-sqlite.d.ts
+++ b/src/agents/plugins/opencode/node-sqlite.d.ts
@@ -12,6 +12,11 @@ declare module 'node:sqlite' {
 
   interface DatabaseSyncOptions {
     open?: boolean;
+    /**
+     * Open the database in read-only mode. Required when reading OpenCode's
+     * live database, which the `opencode` binary may be writing concurrently.
+     */
+    readOnly?: boolean;
   }
 
   class DatabaseSync {

--- a/src/agents/plugins/opencode/opencode-message-types.ts
+++ b/src/agents/plugins/opencode/opencode-message-types.ts
@@ -37,7 +37,8 @@ export interface OpenCodeMessageBase {
   role: 'user' | 'assistant';
   // Numeric timestamp
   time: {
-    created: number;  // Unix timestamp (ms)
+    created: number;      // Unix timestamp (ms)
+    completed?: number;   // Unix timestamp (ms), set once the turn finishes
   };
 }
 
@@ -68,6 +69,16 @@ export interface OpenCodeAssistantMessage extends OpenCodeMessageBase {
   path?: string[];
   // Legacy: agent field (may still exist in some sessions)
   agent?: string;
+  /**
+   * Turn-level failure (provider error, aborted turn, ...).
+   * This is OpenCode's equivalent of Claude's `isApiErrorMessage` transcript
+   * entries and is the ONLY source of MetricDelta.apiErrorMessage — tool
+   * failures are reported through toolStatus instead, matching codemie-claude.
+   */
+  error?: {
+    name: string;
+    data?: { message?: string };
+  };
 }
 
 /**

--- a/src/agents/plugins/opencode/opencode.incremental-sync.ts
+++ b/src/agents/plugins/opencode/opencode.incremental-sync.ts
@@ -1,0 +1,204 @@
+// src/agents/plugins/opencode/opencode.incremental-sync.ts
+/**
+ * OpenCode Incremental Sync Timer
+ *
+ * In-process timer that periodically re-parses the active OpenCode session and
+ * writes new metric deltas + conversation payloads to JSONL, then uploads
+ * anything still PENDING via SessionSyncer.
+ *
+ * Why this exists: turn boundaries are reported by the injected shell-hooks
+ * plugin, which can fail to load, be filtered out by OpenCode's per-directory
+ * event routing, or be disabled entirely. Everything the timer needs is already
+ * durable in opencode.db, so this path keeps metrics and conversations flowing
+ * even when no hook ever fires — only active_duration_ms depends on the hooks.
+ *
+ * Mirrors codex.incremental-sync.ts.
+ */
+
+import { realpath as fsRealpath } from 'fs/promises';
+import type { AgentMetadata } from '../../core/types.js';
+import type { ProcessingContext } from '../../core/session/BaseProcessor.js';
+import { OpenCodeSessionAdapter } from './opencode.session.js';
+import { logger } from '../../../utils/logger.js';
+
+export interface StartOpenCodeIncrementalSyncOptions {
+  /** CodeMie session id (file naming key). */
+  sessionId: string;
+  /** ms-since-epoch lower bound used to ignore stale sessions. */
+  startedAt: number;
+  /** Working directory to match the OpenCode session's directory against. */
+  cwd: string;
+  /** OpenCode agent metadata (passed straight to OpenCodeSessionAdapter). */
+  metadata: AgentMetadata;
+  /** Builds a fresh ProcessingContext on each tick (cookies/version may rotate). */
+  buildContext: () => ProcessingContext;
+  /** CodeMie SSO URL used to load stored credentials (e.g. env.CODEMIE_URL). */
+  ssoUrl?: string;
+  /** Sync API base URL for the upload context (env.CODEMIE_SYNC_API_URL ?? env.CODEMIE_BASE_URL). */
+  syncApiUrl?: string;
+  /** CLI version string forwarded to the upload context. */
+  cliVersion?: string;
+}
+
+/**
+ * 60s rather than Codex's 30s: the Stop hook and this timer both write
+ * {id}_metrics.jsonl, and MetricsSyncProcessor rewrites that file atomically
+ * while MetricsWriter appends to it. A slower tick narrows the window in which
+ * an appended delta can be lost to an interleaved rewrite.
+ */
+const DEFAULT_INTERVAL_MS = 60_000;
+
+/** Lower bound for the override, so a bad value cannot spin on the live DB. */
+const MIN_INTERVAL_MS = 5_000;
+const STARTED_AT_GRACE_MS = 10_000;
+
+const activeTimers = new Map<string, NodeJS.Timeout>();
+const tickInFlight = new Map<string, boolean>();
+
+export function startOpenCodeIncrementalSync(options: StartOpenCodeIncrementalSyncOptions): void {
+  if (process.env.CODEMIE_OPENCODE_SYNC_ENABLED === 'false') {
+    logger.debug('[opencode-incremental-sync] Disabled by CODEMIE_OPENCODE_SYNC_ENABLED=false');
+    return;
+  }
+  if (activeTimers.has(options.sessionId)) {
+    logger.debug(`[opencode-incremental-sync] Already running for session ${options.sessionId}`);
+    return;
+  }
+
+  // Floor the interval: every tick re-parses the user's live SQLite DB, so a
+  // small or negative override (setInterval clamps <1 to 1ms) would spin on it.
+  const intervalMs = Math.max(
+    MIN_INTERVAL_MS,
+    Number(process.env.CODEMIE_OPENCODE_SYNC_INTERVAL_MS) || DEFAULT_INTERVAL_MS
+  );
+
+  const tick = async (): Promise<void> => {
+    if (tickInFlight.get(options.sessionId)) return;
+    tickInFlight.set(options.sessionId, true);
+
+    try {
+      const adapter = new OpenCodeSessionAdapter(options.metadata);
+      // cwd is pushed into the SQL predicate, so this never scans other repos'
+      // sessions out of the user's shared opencode.db.
+      const sessions = await adapter.discoverSessions({
+        maxAgeDays: 1,
+        limit: 10,
+        cwd: options.cwd,
+      });
+      if (sessions.length === 0) return;
+
+      const cwdReal = await safeRealpath(options.cwd);
+
+      for (const descriptor of sessions) {
+        if (descriptor.createdAt < options.startedAt - STARTED_AT_GRACE_MS) continue;
+
+        const projectPath = descriptor.projectPath;
+        if (!projectPath) continue;
+        if ((await safeRealpath(projectPath)) !== cwdReal) continue;
+
+        try {
+          const result = await adapter.processSession(
+            descriptor.filePath,
+            options.sessionId,
+            { ...options.buildContext(), agentSessionId: descriptor.sessionId }
+          );
+          logger.debug(
+            `[opencode-incremental-sync] tick ok session=${options.sessionId} records=${result.totalRecords}`
+          );
+        } catch (error) {
+          logger.error('[opencode-incremental-sync] processSession failed:', error);
+        }
+
+        if (options.ssoUrl && options.syncApiUrl) {
+          try {
+            const uploadContext = await buildUploadContext(
+              options.sessionId,
+              options.ssoUrl,
+              options.syncApiUrl,
+              options.cliVersion
+            );
+            if (uploadContext) {
+              const { SessionSyncer } = await import('../../../providers/plugins/sso/session/SessionSyncer.js');
+              const syncer = new SessionSyncer();
+              const syncResult = await syncer.sync(options.sessionId, uploadContext);
+              logger.debug(
+                `[opencode-incremental-sync] upload ${syncResult.success ? 'ok' : 'partial'}: ${syncResult.message}`
+              );
+            }
+          } catch (error) {
+            logger.error('[opencode-incremental-sync] upload failed:', error);
+          }
+        }
+
+        return; // Only the most recent matching session per tick.
+      }
+    } catch (error) {
+      logger.error('[opencode-incremental-sync] tick failed:', error);
+    } finally {
+      tickInFlight.set(options.sessionId, false);
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  // Don't pin the Node event loop alive solely on this timer; if the parent
+  // process is otherwise idle we want it to exit cleanly when OpenCode finishes.
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+  activeTimers.set(options.sessionId, timer);
+
+  logger.debug(
+    `[opencode-incremental-sync] Started (session=${options.sessionId}, intervalMs=${intervalMs})`
+  );
+}
+
+export function stopOpenCodeIncrementalSync(sessionId: string): void {
+  const timer = activeTimers.get(sessionId);
+  if (!timer) return;
+
+  clearInterval(timer);
+  activeTimers.delete(sessionId);
+  tickInFlight.delete(sessionId);
+  logger.debug(`[opencode-incremental-sync] Stopped (session=${sessionId})`);
+}
+
+async function buildUploadContext(
+  sessionId: string,
+  ssoUrl: string,
+  syncApiUrl: string,
+  version = '0.0.0'
+): Promise<ProcessingContext | null> {
+  try {
+    const { CodeMieSSO } = await import('../../../providers/plugins/sso/sso.auth.js');
+    const sso = new CodeMieSSO();
+    const credentials = await sso.getStoredCredentials(ssoUrl);
+    if (!credentials?.cookies) {
+      logger.debug('[opencode-incremental-sync] No SSO credentials available, skipping upload');
+      return null;
+    }
+    const cookies = Object.entries(credentials.cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+    return {
+      apiBaseUrl: syncApiUrl,
+      cookies,
+      clientType: 'codemie-opencode',
+      version,
+      dryRun: false,
+      sessionId,
+    };
+  } catch (error) {
+    logger.debug('[opencode-incremental-sync] Failed to build upload context:', error);
+    return null;
+  }
+}
+
+async function safeRealpath(p: string): Promise<string> {
+  try {
+    return await fsRealpath(p);
+  } catch {
+    return p;
+  }
+}

--- a/src/agents/plugins/opencode/opencode.paths.ts
+++ b/src/agents/plugins/opencode/opencode.paths.ts
@@ -132,6 +132,43 @@ export function getOpenCodeStoragePath(): string | null {
 }
 
 /**
+ * Get OpenCode's data directory (the parent of both `storage/` and `opencode.db`).
+ *
+ * Unlike getOpenCodeStoragePath() this never gates on existence: a SQLite-only
+ * install has no `storage/` subdirectory at all, so gating there would make the
+ * database undiscoverable.
+ *
+ * Priority mirrors getOpenCodeStoragePath():
+ * 1. dirname(OPENCODE_STORAGE_PATH)
+ * 2. XDG_DATA_HOME/opencode
+ * 3. Platform-specific defaults
+ */
+export function getOpenCodeDataDir(): string {
+  const home = homedir();
+
+  if (process.env.OPENCODE_STORAGE_PATH) {
+    return dirname(process.env.OPENCODE_STORAGE_PATH);
+  }
+
+  if (process.env.XDG_DATA_HOME) {
+    return join(process.env.XDG_DATA_HOME, 'opencode');
+  }
+
+  switch (process.platform) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', 'opencode');
+    case 'win32': {
+      const appData = process.env.LOCALAPPDATA;
+      return appData
+        ? join(appData, 'opencode')
+        : join(home, '.local', 'share', 'opencode');
+    }
+    default:
+      return join(home, '.local', 'share', 'opencode');
+  }
+}
+
+/**
  * Get OpenCode sessions directory path
  * Sessions are stored at: storage/session/{projectID}/{sessionID}.json
  *
@@ -190,16 +227,16 @@ export function getOpenCodeConfigDir(): string {
 /**
  * Get path to OpenCode's SQLite database (opencode.db)
  *
- * The DB lives one level above the storage/ directory:
- *   ~/.codemie/opencode-storage/opencode/opencode.db
+ * The DB is a sibling of the storage/ directory:
+ *   ~/.local/share/opencode/opencode.db
+ *
+ * Resolved via getOpenCodeDataDir() rather than getOpenCodeStoragePath() so a
+ * SQLite-only install (no storage/ directory) is still discovered.
  *
  * @returns Path to opencode.db or null if not found
  */
 export function getOpenCodeDbPath(): string | null {
-  const storagePath = getOpenCodeStoragePath();
-  if (!storagePath) return null;
-
-  const dbPath = join(dirname(storagePath), 'opencode.db');
+  const dbPath = join(getOpenCodeDataDir(), 'opencode.db');
   if (existsSync(dbPath)) {
     logger.debug(`[opencode-paths] Found SQLite DB: ${dbPath}`);
     return dbPath;

--- a/src/agents/plugins/opencode/opencode.plugin.ts
+++ b/src/agents/plugins/opencode/opencode.plugin.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import type { AgentMetadata, AgentConfig } from '../../core/types.js';
 import { logger } from '../../../utils/logger.js';
 import { getModelConfig, getChatCompletionsModelConfigs, getResponsesApiModelConfigs } from './opencode-model-configs.js';
@@ -7,12 +8,88 @@ import type { SessionAdapter } from '../../core/session/BaseSessionAdapter.js';
 import type { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
 import { commandExists } from '../../../utils/processes.js';
 import { OpenCodeSessionAdapter } from './opencode.session.js';
+import { getOpenCodeConfigDir, getOpenCodeDbPath, getOpenCodeDataDir } from './opencode.paths.js';
+import {
+  startOpenCodeIncrementalSync,
+  stopOpenCodeIncrementalSync,
+} from './opencode.incremental-sync.js';
 import { getHooksPluginFileUrl, cleanupHooksPlugin } from '../codemie-code-hooks/index.js';
+import type { HookProcessingConfig } from '../../../cli/commands/hook.js';
 import { toBedrockModelId } from '../../../providers/plugins/bedrock/bedrock.utils.js';
 import { MAX_ENV_SIZE, writeConfigToTempFile } from '../../core/temp-config.js';
 import { ensureSessionFile } from '../../core/session/ensure-session.js';
 
 const OPENCODE_SUBCOMMANDS = ['run', 'chat', 'config', 'init', 'help', 'version'];
+
+const OPENCODE_CLIENT_TYPE = 'codemie-opencode';
+
+/**
+ * Hooks the CodeMie CLI always registers with OpenCode, on top of anything the
+ * user's profile defines. They measure active session time:
+ *   UserPromptSubmit → SessionStore.startActivityTracking
+ *   Stop             → SessionStore.accumulateActiveDuration + incremental sync
+ *
+ * Stop is async (detached spawn) because the plugin executes synchronous hooks
+ * with execSync, which would otherwise block OpenCode's event loop while the
+ * child re-parses SQLite and rewrites JSONL.
+ */
+const DEFAULT_HOOKS: Record<string, unknown[]> = {
+  UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'codemie hook', timeout: 5 }] }],
+  Stop: [{ hooks: [{ type: 'command', command: 'codemie hook', timeout: 10, async: true }] }],
+};
+
+/**
+ * Merge the CodeMie telemetry hooks with any hooks the active profile defines.
+ *
+ * Entries are appended per event name rather than spread over the object: a
+ * shallow spread lets a profile that defines its own Stop or UserPromptSubmit
+ * REPLACE the telemetry hook, which silently zeroes active_duration_ms for
+ * exactly the users who customise hooks.
+ */
+function buildMergedHooks(env: NodeJS.ProcessEnv): Record<string, unknown[]> {
+  const mergedHooks: Record<string, unknown[]> = { ...DEFAULT_HOOKS };
+
+  if (!env.CODEMIE_PROFILE_CONFIG) {
+    return mergedHooks;
+  }
+
+  try {
+    const profileConfig = JSON.parse(env.CODEMIE_PROFILE_CONFIG);
+    if (profileConfig.hooks && typeof profileConfig.hooks === 'object') {
+      for (const [eventName, entries] of Object.entries(profileConfig.hooks)) {
+        if (!Array.isArray(entries)) {
+          logger.warn(`[opencode] Ignoring non-array profile hook entry: ${eventName}`);
+          continue;
+        }
+        mergedHooks[eventName] = [...(mergedHooks[eventName] ?? []), ...entries];
+      }
+      logger.debug('[opencode] Merged profile hooks with defaults');
+    }
+  } catch {
+    // Non-critical — profile config parse failure doesn't block startup
+  }
+
+  return mergedHooks;
+}
+
+/**
+ * Build a hook config object from environment variables.
+ * Used by both onSessionStart and onSessionEnd lifecycle hooks.
+ */
+function buildHookConfig(env: NodeJS.ProcessEnv, sessionId: string): HookProcessingConfig {
+  return {
+    agentName: env.CODEMIE_AGENT || 'opencode',
+    sessionId,
+    provider: env.CODEMIE_PROVIDER,
+    apiBaseUrl: env.CODEMIE_BASE_URL,
+    ssoUrl: env.CODEMIE_URL,
+    version: env.CODEMIE_CLI_VERSION,
+    profileName: env.CODEMIE_PROFILE_NAME,
+    project: env.CODEMIE_PROJECT,
+    model: env.CODEMIE_MODEL,
+    clientType: OPENCODE_CLIENT_TYPE,
+  };
+}
 
 export const OpenCodePluginMetadata: AgentMetadata = {
   name: 'opencode',
@@ -34,7 +111,55 @@ export const OpenCodePluginMetadata: AgentMetadata = {
     model: []
   },
   supportedProviders: ['litellm', 'ai-run-sso', 'ollama', 'bedrock', 'bearer-auth'],
-  ssoConfig: { enabled: true, clientType: 'codemie-opencode' },
+  ssoConfig: { enabled: true, clientType: OPENCODE_CLIENT_TYPE },
+
+  // Tool names are lower-cased before they reach the aggregator, and
+  // filterErrorTools does an exact match — the global default
+  // ['Bash','Execute','Shell'] would silently never match here.
+  metricsConfig: {
+    excludeErrorsFromTools: ['bash'],
+  },
+
+  // MCP servers live under a top-level `mcp` key. OpenCode accepts both the
+  // .json and .jsonc filenames, so each scope lists candidates in priority order.
+  mcpConfig: {
+    project: {
+      path: ['opencode.json', 'opencode.jsonc'],
+      jsonPath: 'mcp',
+    },
+    local: {
+      path: ['.opencode/opencode.json', '.opencode/opencode.jsonc'],
+      jsonPath: 'mcp',
+    },
+    user: {
+      path: [
+        join(getOpenCodeConfigDir(), 'opencode.json'),
+        join(getOpenCodeConfigDir(), 'opencode.jsonc'),
+        '~/.opencode/opencode.json',
+      ],
+      jsonPath: 'mcp',
+    },
+  },
+
+  // OpenCode accepts singular and plural directory names for every category.
+  // Two deliberate mappings:
+  //   hooks → plugin/ + plugins/  (OpenCode has no hooks/ directory; plugins are
+  //                                the closest equivalent extension point)
+  //   rules → []                  (OpenCode has no rules/ concept, so the
+  //                                rules_* metric fields stay at zero)
+  extensionsConfig: {
+    project: '.opencode',
+    global: getOpenCodeConfigDir(),
+    extraGlobalDirs: ['~/.opencode'],
+    skillsEntryFile: 'SKILL.md',
+    dirNames: {
+      agents: ['agent', 'agents'],
+      commands: ['command', 'commands'],
+      skills: ['skill', 'skills'],
+      hooks: ['plugin', 'plugins'],
+      rules: [],
+    },
+  },
 
   flagMappings: {
     '--resume': {
@@ -52,22 +177,101 @@ export const OpenCodePluginMetadata: AgentMetadata = {
   },
 
   lifecycle: {
+    /**
+     * Emit the `started` codemie_cli_session_total row and scan MCP/extensions.
+     *
+     * Runs in-process rather than via a hook: OpenCode's session.created event
+     * does not correspond to CLI startup, and this must happen before
+     * ensureSessionFile in beforeRun — otherwise the placeholder record with
+     * agentSessionId 'unknown' and a fabricated startTime wins, and every
+     * downstream metric inherits it.
+     *
+     * session_id is the CodeMie session UUID: OpenCode's own ses_* id does not
+     * exist yet, and using it only at SessionEnd would leave the started and
+     * completed rows uncorrelatable.
+     *
+     * SIDE EFFECT (user-visible, accepted): routing SessionStart through
+     * processEvent means handleSessionStart's syncSkillsToClaude step now runs
+     * for codemie-opencode too, so running this agent creates
+     * `{cwd}/.claude/skills/` in the user's project and copies CodeMie-managed
+     * skills into it — the same behaviour codemie-claude has always had.
+     * OpenCode does read those skills, so this is intentional rather than
+     * incidental, but it means a project where the user only ever ran opencode
+     * will now gain a .claude/ directory. Call this out in the release notes
+     * for any version that ships this change.
+     */
+    async onSessionStart(sessionId: string, env: NodeJS.ProcessEnv) {
+      try {
+        const { processEvent } = await import('../../../cli/commands/hook.js');
+        await processEvent(
+          {
+            hook_event_name: 'SessionStart',
+            session_id: sessionId,
+            transcript_path: '',
+            permission_mode: 'default',
+            cwd: process.cwd(),
+            source: 'startup',
+          },
+          buildHookConfig(env, sessionId)
+        );
+        logger.info(`[opencode] SessionStart hook completed for session ${sessionId}`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`[opencode] SessionStart hook failed (non-blocking): ${msg}`);
+      }
+
+      // Failsafe path for metrics and conversations: everything it reads is
+      // already durable in opencode.db, so deltas keep flowing even if the
+      // injected plugin never loads.
+      startOpenCodeIncrementalSync({
+        sessionId,
+        startedAt: Date.now(),
+        cwd: process.cwd(),
+        metadata: OpenCodePluginMetadata,
+        buildContext: () => ({
+          sessionId,
+          apiBaseUrl: env.CODEMIE_SYNC_API_URL || env.CODEMIE_BASE_URL || '',
+          cookies: '',
+          clientType: OPENCODE_CLIENT_TYPE,
+          version: env.CODEMIE_CLI_VERSION || '0.0.0',
+          dryRun: false,
+          gitBranch: env.CODEMIE_GIT_BRANCH,
+        }),
+        ssoUrl: env.CODEMIE_URL,
+        syncApiUrl: env.CODEMIE_SYNC_API_URL || env.CODEMIE_BASE_URL,
+        cliVersion: env.CODEMIE_CLI_VERSION,
+      });
+    },
+
     // NOTE: beforeRun signature is (env, config) per AgentLifecycle interface
     // Claude plugin only uses (env), but interface supports both
     async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig) {
-      // Create session metadata file at startup (before config setup)
-      // This ensures SessionSyncer can sync metrics to v1/metrics API (matching Claude/Gemini)
+      // Safety net only — onSessionStart normally created the record already,
+      // and ensureSessionFile early-returns when it exists.
       const sessionId = env.CODEMIE_SESSION_ID;
       if (sessionId) {
         try {
-          logger.debug(`[opencode] Creating session metadata file before startup`);
           await ensureSessionFile(sessionId, env, 'opencode');
-          logger.debug(`[opencode] Session metadata file ready for SessionSyncer`);
         } catch (error) {
           logger.error('[opencode] Failed to create session file in beforeRun', { error });
           // Don't throw - let OpenCode run even if session file creation fails
         }
       }
+
+      // Point the injected plugin at the transcript codemie hook must re-parse.
+      // performIncrementalSync skips any event without a transcript_path.
+      // getOpenCodeDbPath() gates on existsSync, and the DB is only created once
+      // opencode itself first writes it — i.e. after beforeRun. Falling back to
+      // the expected location keeps transcript_path non-empty on a first-ever
+      // run; without it validateHookEvent rejects every UserPromptSubmit and
+      // Stop with exit 2 for that entire first session.
+      env.CODEMIE_OPENCODE_TRANSCRIPT = getOpenCodeDbPath() ?? join(getOpenCodeDataDir(), 'opencode.db');
+
+      // Register the telemetry hooks BEFORE the base-URL early returns below.
+      // Hook registration does not depend on the proxy config, and leaving it
+      // downstream meant any run without CODEMIE_BASE_URL got no turn
+      // boundaries at all, so active_duration_ms stayed 0.
+      env.OPENCODE_HOOKS = JSON.stringify({ hooks: buildMergedHooks(env) });
 
       const provider = env.CODEMIE_PROVIDER;
       const baseUrl = env.CODEMIE_BASE_URL;
@@ -169,27 +373,13 @@ export const OpenCodePluginMetadata: AgentMetadata = {
         model: `${activeProvider}/${isBedrock ? toBedrockModelId(modelConfig.id, env.AWS_REGION || env.CODEMIE_AWS_REGION) : modelConfig.id}`
       };
 
-      // --- Hooks injection ---
-      // 1. Forward hooks configuration from profile
-      if (env.CODEMIE_PROFILE_CONFIG) {
-        try {
-          const profileConfig = JSON.parse(env.CODEMIE_PROFILE_CONFIG);
-          if (profileConfig.hooks && Object.keys(profileConfig.hooks).length > 0) {
-            env.OPENCODE_HOOKS = JSON.stringify({ hooks: profileConfig.hooks });
-            logger.debug('[opencode] Forwarded hooks config to opencode binary');
-          }
-        } catch {
-          // Non-critical — profile config parse failure doesn't block startup
-        }
-      }
-
-      // 2. Inject shell-hooks plugin if hooks are configured
-      if (env.OPENCODE_HOOKS) {
-        const pluginUrl = getHooksPluginFileUrl();
-        openCodeConfig.plugin = (openCodeConfig.plugin as string[] | undefined) || [];
-        (openCodeConfig.plugin as string[]).push(pluginUrl);
-        logger.debug(`[opencode] Injected hooks plugin: ${pluginUrl}`);
-      }
+      // Inject the shell-hooks plugin — it is what delivers OPENCODE_HOOKS
+      // (already registered above, before the base-URL early return) to
+      // `codemie hook`. Only this half genuinely depends on the proxy config.
+      const pluginUrl = getHooksPluginFileUrl();
+      openCodeConfig.plugin = (openCodeConfig.plugin as string[] | undefined) || [];
+      (openCodeConfig.plugin as string[]).push(pluginUrl);
+      logger.debug(`[opencode] Injected hooks plugin: ${pluginUrl}`);
 
       env.OPENCODE_DISABLE_SHARE = 'true';
       const configJson = JSON.stringify(openCodeConfig);
@@ -239,82 +429,68 @@ export const OpenCodePluginMetadata: AgentMetadata = {
     },
 
     /**
-     * Process OpenCode session metrics before SessionSyncer runs
+     * Close out the session: flush remaining deltas and conversations, upload
+     * them, emit the `completed` codemie_cli_session_total row, and archive the
+     * spool files.
      *
-     * Called by BaseAgentAdapter when OpenCode session ends, BEFORE SessionSyncer.
-     * This hook ensures metrics are written to JSONL in time for SessionSyncer's
-     * metrics-sync processor to send them to v1/metrics API.
+     * Routed through processEvent rather than calling the adapter directly, so
+     * the full SessionEnd pipeline runs in the right order:
+     *   accumulateActiveDuration → incremental sync → SessionSyncer upload →
+     *   session-end metrics → status update → rename to completed_*
      *
-     * Lifecycle order:
-     * 1. OpenCode exits
-     * 2. Grace period (wait for file writes)
-     * 3. onSessionEnd ← WE ARE HERE (process metrics to JSONL)
-     * 4. SessionSyncer runs (reads JSONL, sends to v1/metrics)
-     * 5. Proxy stops
-     * 6. afterRun (cleanup)
-     *
-     * This matches Claude/Gemini real-time sync behavior where SessionSyncer
-     * automatically sends metrics during the session lifecycle.
+     * The previous implementation only wrote JSONL, with an empty cookie jar
+     * and no SessionSyncer call, and relied on the proxy's shutdown timer to
+     * upload whatever happened to be on disk.
      */
     async onSessionEnd(exitCode: number, env: NodeJS.ProcessEnv) {
       const sessionId = env.CODEMIE_SESSION_ID;
 
       if (!sessionId) {
-        logger.debug('[opencode] No CODEMIE_SESSION_ID in environment, skipping metrics processing');
+        logger.debug('[opencode] No CODEMIE_SESSION_ID in environment, skipping session end');
         return;
       }
 
+      stopOpenCodeIncrementalSync(sessionId);
+
       try {
-        logger.info(`[opencode] Processing session metrics before SessionSyncer (code=${exitCode})`);
-
-        // 1. Initialize session adapter
-        const adapter = new OpenCodeSessionAdapter(OpenCodePluginMetadata);
-
-        // 2. Discover recent sessions (last 24 hours)
-        const sessions = await adapter.discoverSessions({ maxAgeDays: 1 });
-
-        if (sessions.length === 0) {
-          logger.warn('[opencode] No recent OpenCode sessions found for processing');
-          return;
+        // Discover the transcript to re-parse. Constrained to this working
+        // directory: the CLI reads the user's shared opencode.db, which holds
+        // sessions from every project they have open.
+        let transcriptPath = '';
+        try {
+          const adapter = new OpenCodeSessionAdapter(OpenCodePluginMetadata);
+          const sessions = await adapter.discoverSessions({
+            maxAgeDays: 1,
+            limit: 1,
+            cwd: process.cwd(),
+          });
+          if (sessions.length > 0) {
+            transcriptPath = sessions[0].filePath;
+            logger.debug(`[opencode] Discovered OpenCode session: ${sessions[0].sessionId}`);
+          } else {
+            logger.debug('[opencode] No recent OpenCode sessions found for this directory');
+          }
+        } catch (discoverError) {
+          const msg = discoverError instanceof Error ? discoverError.message : String(discoverError);
+          logger.debug(`[opencode] Session discovery failed (non-blocking): ${msg}`);
         }
 
-        // 3. Process the most recent session
-        const latestSession = sessions[0];
-        logger.debug(`[opencode] Processing latest session: ${latestSession.sessionId}`);
-        logger.debug(`[opencode] OpenCode session ID: ${latestSession.sessionId}`);
-        logger.debug(`[opencode] CodeMie session ID: ${sessionId}`);
-
-        // 4. Build processing context (same as CLI command)
-        const context = {
-          sessionId,
-          apiBaseUrl: env.CODEMIE_BASE_URL || '',
-          cookies: '', // Will be loaded by processors if needed
-          clientType: 'codemie-opencode',
-          version: env.CODEMIE_CLI_VERSION || '1.0.0',
-          dryRun: false
-        };
-
-        // 5. Process session (extracts metrics + conversations to JSONL)
-        const result = await adapter.processSession(
-          latestSession.filePath,
-          sessionId,
-          context
+        const { processEvent } = await import('../../../cli/commands/hook.js');
+        await processEvent(
+          {
+            hook_event_name: 'SessionEnd',
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            permission_mode: 'default',
+            cwd: process.cwd(),
+            reason: exitCode === 0 ? 'exit' : `exit(${exitCode})`,
+          },
+          buildHookConfig(env, sessionId)
         );
-
-        if (result.success) {
-          logger.info(`[opencode] Metrics processing complete: ${result.totalRecords} records processed`);
-          logger.info(`[opencode] Metrics written to JSONL - SessionSyncer will sync to v1/metrics next`);
-        } else {
-          logger.warn(`[opencode] Metrics processing had failures: ${result.failedProcessors.join(', ')}`);
-        }
-
-        // Note: SessionSyncer runs IMMEDIATELY after this hook completes.
-        // It will read the JSONL deltas we just wrote and send them to v1/metrics API.
-        // This matches Claude/Gemini real-time sync behavior during session lifecycle.
-
+        logger.info(`[opencode] SessionEnd hook completed for session ${sessionId}`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error(`[opencode] Failed to process session metrics automatically: ${errorMessage}`);
+        logger.error(`[opencode] SessionEnd hook failed (non-blocking): ${errorMessage}`);
         // Don't throw - metrics failure shouldn't block exit
       } finally {
         cleanupHooksPlugin();

--- a/src/agents/plugins/opencode/opencode.session.ts
+++ b/src/agents/plugins/opencode/opencode.session.ts
@@ -110,10 +110,14 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
    * UPDATED (GPT-5.9): OpenCode uses numeric timestamps (time.created/time.updated)
    * not ISO strings. We convert to ISO for CodeMie's canonical format.
    */
-  async parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession> {
+  async parseSessionFile(
+    filePath: string,
+    sessionId: string,
+    openCodeSessionId?: string
+  ): Promise<ParsedSession> {
     // Route to SQLite parsing if filePath points to a .db file
     if (filePath.endsWith('.db')) {
-      return this.parseSessionFromDb(filePath, sessionId);
+      return this.parseSessionFromDb(filePath, sessionId, openCodeSessionId);
     }
 
     try {
@@ -181,20 +185,26 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
   /**
    * Parse a session from SQLite database.
    * Reads session, messages, and all parts in bulk from opencode.db.
+   *
+   * @param openCodeSessionId - OpenCode's own `ses_*` id when known. The plugin
+   *   Stop hook supplies it via ProcessingContext.agentSessionId; the in-process
+   *   SessionEnd path cannot (OpenCode's id does not exist when the CodeMie
+   *   session record is created), so selection falls back to a cwd match.
    */
-  private async parseSessionFromDb(dbPath: string, sessionId: string): Promise<ParsedSession> {
+  private async parseSessionFromDb(
+    dbPath: string,
+    sessionId: string,
+    openCodeSessionId?: string
+  ): Promise<ParsedSession> {
     try {
       logger.debug(`[opencode-adapter] Parsing session ${sessionId} from SQLite: ${dbPath}`);
 
-      // Read session data
-      // Note: sessionId may be a CodeMie UUID (not an OpenCode ses_* ID).
-      // Try exact match first, then fallback to most recent session (sorted by time_created DESC).
       const sessions = await readSessionsFromDb(dbPath, { maxAgeDays: 1 });
-      const session = sessions.find(s => s.id === sessionId) ?? sessions[0];
+      const session = this.selectSessionFromDb(sessions, openCodeSessionId);
       if (!session) {
         throw new Error(`Session ${sessionId} not found in SQLite DB: ${dbPath}`);
       }
-      if (session.id !== sessionId) {
+      if (session.id !== openCodeSessionId) {
         logger.debug(`[opencode-adapter] Mapped CodeMie session ${sessionId} → OpenCode session ${session.id}`);
       }
 
@@ -228,6 +238,9 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
         openCodeVersion: session.version,
         partsMap,
         storageType: 'sqlite',
+        // gitBranch is overlaid by processSession from ProcessingContext when
+        // available; the metrics processor falls back to detecting it from
+        // projectPath.
       };
 
       return {
@@ -241,6 +254,42 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
       logger.error(`[opencode-adapter] Failed to parse SQLite session ${sessionId}:`, error);
       throw error;
     }
+  }
+
+  /**
+   * Pick which OpenCode session a set of DB rows refers to.
+   *
+   * Ordering matters: the previous implementation used
+   * `sessions.find(s => s.id === sessionId) ?? sessions[0]` where `sessionId`
+   * is a CodeMie UUID. That match can never succeed, so it always degraded to
+   * "newest session in any directory" — silently attributing another
+   * repository's session to this one.
+   *
+   * @param sessions - Rows already sorted newest-first by readSessionsFromDb
+   */
+  private selectSessionFromDb(
+    sessions: OpenCodeSession[],
+    openCodeSessionId?: string
+  ): OpenCodeSession | undefined {
+    // 1. Exact match on OpenCode's own id (plugin Stop path).
+    if (openCodeSessionId?.startsWith('ses_')) {
+      const exact = sessions.find(s => s.id === openCodeSessionId);
+      if (exact) return exact;
+    }
+
+    // 2. Newest session started in this working directory (in-process SessionEnd path).
+    const cwd = process.cwd().replace(/\/+$/, '');
+    const byCwd = sessions.find(s => s.directory.replace(/\/+$/, '') === cwd);
+    if (byCwd) return byCwd;
+
+    // 3. Newest session overall — may belong to another repository.
+    if (sessions.length > 0) {
+      logger.warn(
+        `[opencode-adapter] No OpenCode session matched id=${openCodeSessionId ?? 'n/a'} or cwd=${cwd}; ` +
+        `falling back to newest session ${sessions[0].id} (directory=${sessions[0].directory})`
+      );
+    }
+    return sessions[0];
   }
 
   /**
@@ -349,8 +398,21 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
     try {
       logger.debug(`[opencode-adapter] Processing session ${sessionId} with ${this.processors.length} processors`);
 
-      // 1. Parse session once
-      const parsedSession = await this.parseSessionFile(filePath, sessionId);
+      // 1. Parse session once.
+      //    context.agentSessionId is OpenCode's ses_* id on the plugin Stop path
+      //    and the CodeMie UUID on the in-process SessionEnd path; the adapter
+      //    distinguishes them by prefix.
+      const parsedSession = await this.parseSessionFile(
+        filePath,
+        sessionId,
+        context.agentSessionId
+      );
+
+      // Carry the branch resolved by the CLI through to the processors so every
+      // MetricDelta is attributed to a branch (the aggregator groups on it).
+      if (context.gitBranch && parsedSession.metadata) {
+        (parsedSession.metadata as Record<string, unknown>).gitBranch = context.gitBranch;
+      }
 
       // 2. Run processors in priority order
       const processorResults: Record<string, {
@@ -418,9 +480,12 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
     if (dbPath && await isSqliteAvailable()) {
       logger.debug(`[opencode-discovery] Using SQLite storage: ${dbPath}`);
       try {
+        // Age, directory and limit predicates are applied in SQL — this query
+        // runs on every incremental-sync tick against the user's live database.
         const sessions = await readSessionsFromDb(dbPath, {
           maxAgeDays: options?.maxAgeDays ?? 30,
           cwd: options?.cwd,
+          limit: options?.limit,
         });
 
         const descriptors: SessionDescriptor[] = sessions.map(session => ({
@@ -432,15 +497,9 @@ export class OpenCodeSessionAdapter implements SessionAdapter {
           agentName: 'opencode',
         }));
 
-        // Sort by createdAt descending (newest first)
+        // Already ordered by time_created DESC in SQL; re-sort defensively for
+        // the sqlite3 CLI fallback path.
         descriptors.sort((a, b) => b.createdAt - a.createdAt);
-
-        // Apply limit
-        if (options?.limit && options.limit > 0) {
-          const limited = descriptors.slice(0, options.limit);
-          logger.debug(`[opencode-discovery] Found ${descriptors.length} SQLite sessions, returning ${limited.length} (limit: ${options.limit})`);
-          return limited;
-        }
 
         logger.debug(`[opencode-discovery] Found ${descriptors.length} SQLite sessions`);
         return descriptors;

--- a/src/agents/plugins/opencode/opencode.sqlite-reader.ts
+++ b/src/agents/plugins/opencode/opencode.sqlite-reader.ts
@@ -59,18 +59,30 @@ export function getDbPathFromStorage(storagePath: string): string | null {
   return existsSync(dbPath) ? dbPath : null;
 }
 
+/** Values accepted as bound SQL parameters. */
+type SqlParam = string | number;
+
 /**
  * Execute a read-only SQLite query using Node.js native node:sqlite (Node.js 22.5+).
  *
+ * The database is opened READ-ONLY: codemie-opencode reads the user's live
+ * ~/.local/share/opencode/opencode.db, which the plain `opencode` binary may be
+ * writing to concurrently. Opening read-write risks lock contention and, worse,
+ * WAL recovery writes into a database we do not own.
+ *
  * @returns Parsed rows, or null if node:sqlite is unavailable or the query fails
  */
-async function queryDbViaNative<T>(dbPath: string, sql: string): Promise<T[] | null> {
+async function queryDbViaNative<T>(
+  dbPath: string,
+  sql: string,
+  params: SqlParam[]
+): Promise<T[] | null> {
   try {
     const { DatabaseSync } = await import('node:sqlite');
-    const db = new DatabaseSync(dbPath, { open: true });
+    const db = new DatabaseSync(dbPath, { open: true, readOnly: true });
     try {
       const stmt = db.prepare(sql);
-      return stmt.all() as unknown as T[];
+      return stmt.all(...params) as unknown as T[];
     } finally {
       db.close();
     }
@@ -80,25 +92,38 @@ async function queryDbViaNative<T>(dbPath: string, sql: string): Promise<T[] | n
 }
 
 /**
+ * Inline bound parameters into a SQL string for the sqlite3 CLI fallback,
+ * which has no parameter-binding interface.
+ */
+function inlineParams(sql: string, params: SqlParam[]): string {
+  let index = 0;
+  return sql.replace(/\?/g, () => {
+    const value = params[index++];
+    return typeof value === 'number' ? String(value) : `'${escapeSqlString(String(value))}'`;
+  });
+}
+
+/**
  * Execute a read-only SQLite query and return parsed JSON rows.
  *
  * Tries node:sqlite first (Node.js 22.5+, no external tools required).
  * Falls back to the sqlite3 CLI if node:sqlite is unavailable.
  *
  * @param dbPath - Path to the SQLite database
- * @param sql - SQL query to execute
+ * @param sql - SQL query with `?` placeholders
+ * @param params - Values bound to the placeholders
  * @returns Parsed rows as an array of objects
  */
-async function queryDb<T>(dbPath: string, sql: string): Promise<T[]> {
+async function queryDb<T>(dbPath: string, sql: string, params: SqlParam[] = []): Promise<T[]> {
   // Try native node:sqlite first (no external tool required)
-  const nativeResult = await queryDbViaNative<T>(dbPath, sql);
+  const nativeResult = await queryDbViaNative<T>(dbPath, sql, params);
   if (nativeResult !== null) {
     return nativeResult;
   }
 
   // Fallback to sqlite3 CLI
   try {
-    const result = await exec('sqlite3', ['-json', '-readonly', dbPath, sql], {
+    const result = await exec('sqlite3', ['-json', '-readonly', dbPath, inlineParams(sql, params)], {
       timeout: 10_000,
     });
 
@@ -157,59 +182,60 @@ interface PartRow {
 /**
  * Read sessions from the SQLite database.
  *
+ * Age, directory and row-count predicates are pushed into SQL rather than
+ * applied in JS: this query runs on every incremental-sync tick against the
+ * user's live database, which can hold thousands of sessions across every
+ * project they have ever opened.
+ *
  * @param dbPath - Path to opencode.db
- * @param options - Optional filtering (maxAgeDays, cwd)
- * @returns Array of OpenCodeSession objects
+ * @param options - Optional filtering (maxAgeDays, cwd, limit)
+ * @returns Array of OpenCodeSession objects, newest first
  */
 export async function readSessionsFromDb(
   dbPath: string,
-  options?: { maxAgeDays?: number; cwd?: string }
+  options?: { maxAgeDays?: number; cwd?: string; limit?: number }
 ): Promise<OpenCodeSession[]> {
-  const rows = await queryDb<SessionRow>(
-    dbPath,
-    `SELECT id, project_id, slug, directory, title, version, time_created, time_updated FROM session ORDER BY time_created DESC`
-  );
-
-  const sessions: OpenCodeSession[] = [];
   const maxAgeMs = (options?.maxAgeDays ?? 30) * 24 * 60 * 60 * 1000;
   const cutoff = Date.now() - maxAgeMs;
   const normalizedCwd = options?.cwd?.replace(/\/+$/, '');
 
-  for (const row of rows) {
-    const session: OpenCodeSession = {
-      id: row.id,
-      title: row.title,
-      directory: row.directory || '',
-      time: {
-        created: row.time_created ?? 0,
-        updated: row.time_updated ?? 0,
-      },
-      projectID: row.project_id,
-      slug: row.slug,
-      version: row.version,
-    };
+  const conditions: string[] = ['(time_created IS NULL OR time_created >= ?)'];
+  const params: SqlParam[] = [cutoff];
 
-    // Apply age filter
-    if (session.time.created && session.time.created < cutoff) {
-      continue;
-    }
-
-    // Apply cwd filter
-    if (normalizedCwd && session.directory) {
-      const normalizedDir = session.directory.replace(/\/+$/, '');
-      if (normalizedDir !== normalizedCwd) {
-        continue;
-      }
-    }
-
-    sessions.push(session);
+  if (normalizedCwd) {
+    // OpenCode stores `directory` without a trailing separator; accept both forms.
+    conditions.push('(directory = ? OR directory = ?)');
+    params.push(normalizedCwd, `${normalizedCwd}/`);
   }
 
-  return sessions;
+  let sql =
+    `SELECT id, project_id, slug, directory, title, version, time_created, time_updated ` +
+    `FROM session WHERE ${conditions.join(' AND ')} ORDER BY time_created DESC`;
+
+  if (options?.limit && options.limit > 0) {
+    sql += ' LIMIT ?';
+    params.push(options.limit);
+  }
+
+  const rows = await queryDb<SessionRow>(dbPath, sql, params);
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    directory: row.directory || '',
+    time: {
+      created: row.time_created ?? 0,
+      updated: row.time_updated ?? 0,
+    },
+    projectID: row.project_id,
+    slug: row.slug,
+    version: row.version,
+  }));
 }
 
 /**
  * Escape a string for safe use in SQL single-quoted literals.
+ * Only needed for the sqlite3 CLI fallback, which cannot bind parameters.
  */
 function escapeSqlString(value: string): string {
   return value.replace(/'/g, "''");
@@ -226,10 +252,10 @@ export async function readMessagesFromDb(
   dbPath: string,
   sessionId: string
 ): Promise<OpenCodeMessage[]> {
-  const escapedId = escapeSqlString(sessionId);
   const rows = await queryDb<MessageRow>(
     dbPath,
-    `SELECT id, session_id, data FROM message WHERE session_id = '${escapedId}'`
+    `SELECT id, session_id, data FROM message WHERE session_id = ?`,
+    [sessionId]
   );
 
   const messages: OpenCodeMessage[] = [];
@@ -238,16 +264,22 @@ export async function readMessagesFromDb(
     try {
       const data = JSON.parse(row.data) as Record<string, unknown>;
       const role = data.role as string;
+      const time = data.time as { created?: number; completed?: number } | undefined;
 
       const base = {
         id: row.id,
         sessionID: row.session_id,
         time: {
-          created: (data.time as any)?.created ?? 0,
+          created: time?.created ?? 0,
+          ...(typeof time?.completed === 'number' && { completed: time.completed }),
         },
       };
 
       if (role === 'assistant') {
+        // NOTE: token/cost columns are deliberately NOT carried across.
+        // codemie-claude sends no token or cost fields on any metric, and
+        // codemie-opencode mirrors that exactly. See MetricDelta in
+        // src/agents/core/metrics/types.ts.
         const msg: OpenCodeAssistantMessage = {
           ...base,
           role: 'assistant',
@@ -255,6 +287,7 @@ export async function readMessagesFromDb(
           modelID: data.modelID as string | undefined,
           path: data.path as string[] | undefined,
           agent: data.agent as string | undefined,
+          error: data.error as OpenCodeAssistantMessage['error'],
         };
         messages.push(msg);
       } else {
@@ -289,10 +322,10 @@ export async function readAllPartsForSessionFromDb(
   dbPath: string,
   sessionId: string
 ): Promise<Record<string, OpenCodePart[]>> {
-  const escapedId = escapeSqlString(sessionId);
   const rows = await queryDb<PartRow>(
     dbPath,
-    `SELECT id, message_id, session_id, data FROM part WHERE session_id = '${escapedId}' ORDER BY id ASC`
+    `SELECT id, message_id, session_id, data FROM part WHERE session_id = ? ORDER BY id ASC`,
+    [sessionId]
   );
 
   const partsMap: Record<string, OpenCodePart[]> = {};

--- a/src/agents/plugins/opencode/opencode.storage-utils.ts
+++ b/src/agents/plugins/opencode/opencode.storage-utils.ts
@@ -77,3 +77,62 @@ export async function readJsonWithRetry<T>(
 export async function readJsonlTolerant<T>(filePath: string): Promise<T[]> {
   return readJSONLTolerant<T>(filePath, '[opencode-storage]');
 }
+
+/**
+ * Load the parts belonging to one message, from either backend.
+ *
+ * SQLite-backed sessions arrive with every part pre-loaded in `partsMap` (one
+ * bulk query per session); file-backed sessions read storage/part/{messageID}/.
+ * Parts are validated against their owning message and session before use —
+ * OpenCode's storage has been observed to retain orphaned part files.
+ *
+ * @param storagePath - Path to the OpenCode `storage/` directory
+ * @param messageId - Message whose parts to load
+ * @param expectedSessionId - When set, drop parts belonging to another session
+ * @param partsMap - Pre-loaded parts keyed by message id (SQLite path)
+ * @returns Parts sorted by id (their creation order)
+ */
+export async function loadPartsForMessage<T extends { id: string; messageID: string; sessionID: string }>(
+  storagePath: string,
+  messageId: string,
+  expectedSessionId?: string,
+  partsMap?: Record<string, T[]>
+): Promise<T[]> {
+  const isValid = (part: T): boolean => {
+    if (part.messageID !== messageId) {
+      logger.debug(`[opencode-storage] Skipping orphaned part ${part.id}: messageID mismatch`);
+      return false;
+    }
+    if (expectedSessionId && part.sessionID !== expectedSessionId) {
+      logger.debug(`[opencode-storage] Skipping part ${part.id}: sessionID mismatch`);
+      return false;
+    }
+    return true;
+  };
+
+  if (partsMap?.[messageId]) {
+    return partsMap[messageId].filter(isValid).sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  const { existsSync } = await import('fs');
+  const { readdir } = await import('fs/promises');
+  const { join } = await import('path');
+
+  const partsDir = join(storagePath, 'part', messageId);
+  if (!existsSync(partsDir)) {
+    return [];
+  }
+
+  const parts: T[] = [];
+  try {
+    for (const file of await readdir(partsDir)) {
+      if (!file.endsWith('.json')) continue;
+      const part = await readJsonWithRetry<T>(join(partsDir, file));
+      if (part && isValid(part)) parts.push(part);
+    }
+  } catch (error) {
+    logger.debug(`[opencode-storage] Error loading parts from ${partsDir}:`, error);
+  }
+
+  return parts.sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/src/agents/plugins/opencode/session/processors/__tests__/opencode.metrics-processor.test.ts
+++ b/src/agents/plugins/opencode/session/processors/__tests__/opencode.metrics-processor.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the OpenCode metrics processor.
+ *
+ * Focused on the extraction rules that were previously broken or absent:
+ * diff-derived line counts, per-file apply_patch operation kinds (the only
+ * route to files_deleted), turn-level errors, and the bare model id.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, readFileSync } from 'fs';
+import { OpenCodeMetricsProcessor, countDiffLines } from '../opencode.metrics-processor.js';
+import { getSessionMetricsPath } from '../../../../../core/session/session-config.js';
+import type { ParsedSession } from '../../../../../core/session/BaseSessionAdapter.js';
+import type { ProcessingContext } from '../../../../../core/session/BaseProcessor.js';
+import type { MetricDelta } from '../../../../../core/metrics/types.js';
+
+const OC_SESSION_ID = 'ses_test';
+
+let sessionId: string;
+
+const context: ProcessingContext = {
+  apiBaseUrl: 'http://localhost',
+  cookies: '',
+  clientType: 'codemie-opencode',
+  version: '1.0.0',
+  dryRun: true,
+  gitBranch: 'main',
+  agentSessionId: OC_SESSION_ID,
+};
+
+/** Build a ParsedSession in the SQLite shape (parts pre-loaded via partsMap). */
+function buildSession(
+  messages: Array<Record<string, unknown>>,
+  partsMap: Record<string, Array<Record<string, unknown>>>
+): ParsedSession {
+  return {
+    sessionId,
+    agentName: 'OpenCode CLI',
+    messages: messages as never,
+    metadata: {
+      storagePath: '/nonexistent/storage',
+      openCodeSessionId: OC_SESSION_ID,
+      projectPath: '/repo',
+      partsMap,
+      storageType: 'sqlite',
+    },
+  } as unknown as ParsedSession;
+}
+
+function toolPart(
+  id: string,
+  tool: string,
+  state: Record<string, unknown>
+): Record<string, unknown> {
+  return { id, messageID: 'msg-a', sessionID: OC_SESSION_ID, type: 'tool', callID: `call-${id}`, tool, state };
+}
+
+const assistantMessage = {
+  id: 'msg-a',
+  sessionID: OC_SESSION_ID,
+  role: 'assistant',
+  time: { created: 1_700_000_000_000 },
+  providerID: 'codemie-proxy',
+  modelID: 'kimi-k2.7-code',
+};
+
+async function run(session: ParsedSession): Promise<MetricDelta[]> {
+  const result = await new OpenCodeMetricsProcessor().process(session, context);
+  expect(result.success).toBe(true);
+
+  const path = getSessionMetricsPath(sessionId);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .trim().split('\n').filter(Boolean)
+    .map(line => JSON.parse(line) as MetricDelta);
+}
+
+/** Flatten every file operation across deltas. */
+function fileOps(deltas: MetricDelta[]): NonNullable<MetricDelta['fileOperations']> {
+  return deltas.flatMap(d => d.fileOperations ?? []);
+}
+
+beforeEach(() => {
+  sessionId = `test-oc-metrics-${Math.random().toString(36).slice(2)}`;
+});
+
+afterEach(() => {
+  rmSync(getSessionMetricsPath(sessionId), { force: true });
+});
+
+describe('countDiffLines', () => {
+  it('counts added and removed content lines', () => {
+    const patch = [
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -1,3 +1,5 @@',
+      ' unchanged',
+      '+added one',
+      '+added two',
+      '-removed one',
+    ].join('\n');
+
+    // The ---/+++ header pair and @@ hunk markers are not content.
+    expect(countDiffLines(patch)).toEqual({ linesAdded: 2, linesRemoved: 1 });
+  });
+
+  it('returns zeros for absent or non-string patches', () => {
+    expect(countDiffLines(undefined)).toEqual({ linesAdded: 0, linesRemoved: 0 });
+    expect(countDiffLines('')).toEqual({ linesAdded: 0, linesRemoved: 0 });
+    expect(countDiffLines({ not: 'a patch' })).toEqual({ linesAdded: 0, linesRemoved: 0 });
+  });
+});
+
+describe('OpenCodeMetricsProcessor', () => {
+  it('counts every line of a write as an addition', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'write', {
+        status: 'completed',
+        input: { filePath: 'src/new.ts', content: 'a\nb\nc' },
+      })],
+    }));
+
+    const ops = fileOps(deltas);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({ type: 'write', path: 'src/new.ts', linesAdded: 3 });
+  });
+
+  it('derives edit line counts from the filediff patch', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'edit', {
+        status: 'completed',
+        input: { filePath: 'src/a.ts' },
+        metadata: {
+          filediff: { file: 'src/a.ts', patch: '@@ -1 +1,3 @@\n+one\n+two\n+three\n-old' },
+        },
+      })],
+    }));
+
+    // OpenCode never emits numeric additions/deletions, so the old code that
+    // read file.additions produced zeros for every edit.
+    expect(fileOps(deltas)[0]).toMatchObject({ type: 'edit', linesAdded: 3, linesRemoved: 1 });
+  });
+
+  it('maps apply_patch per-file kinds onto create/modify/delete', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'apply_patch', {
+        status: 'completed',
+        input: {},
+        metadata: {
+          files: [
+            { filePath: 'src/added.ts', type: 'add', patch: '@@\n+one\n+two' },
+            { filePath: 'src/changed.ts', type: 'update', patch: '@@\n+new\n-old' },
+            { filePath: 'src/gone.ts', type: 'delete', patch: '@@\n-a\n-b' },
+          ],
+        },
+      })],
+    }));
+
+    const ops = fileOps(deltas);
+    expect(ops.map(op => op.type)).toEqual(['write', 'edit', 'delete']);
+    // files_deleted was structurally unreachable before this mapping existed.
+    expect(ops.find(op => op.type === 'delete')).toMatchObject({
+      path: 'src/gone.ts',
+      linesRemoved: 2,
+    });
+    expect(ops.find(op => op.type === 'write')).toMatchObject({ linesAdded: 2 });
+  });
+
+  it('records a failed tool without inventing an apiErrorMessage', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'read', {
+        status: 'error',
+        input: { filePath: 'missing.ts' },
+        error: 'ENOENT: no such file or directory',
+      })],
+    }));
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].toolStatus).toEqual({ read: { success: 0, failure: 1 } });
+    // Parity with codemie-claude: tool failures surface as failed_tool_calls
+    // only. Promoting them to apiErrorMessage would push raw tool stderr into
+    // the error_messages wire field, which filterErrorTools does not scrub.
+    expect(deltas[0].apiErrorMessage).toBeUndefined();
+    expect(deltas[0].fileOperations).toBeUndefined();
+  });
+
+  it('reports a turn-level failure as an api error', async () => {
+    const deltas = await run(buildSession([
+      { ...assistantMessage, error: { name: 'MessageAbortedError', data: { message: 'aborted by user' } } },
+    ], { 'msg-a': [] }));
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].recordId).toBe('msg-a:error');
+    expect(deltas[0].apiErrorMessage).toBe('MessageAbortedError: aborted by user');
+  });
+
+  it('emits an error delta even when the turn produced nothing else', async () => {
+    const deltas = await run(buildSession([
+      { ...assistantMessage, error: { name: 'ProviderError' } },
+    ], { 'msg-a': [] }));
+
+    // The old "skip when no tools and no file ops" guard swallowed these.
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].apiErrorMessage).toBe('ProviderError');
+  });
+
+  it('strips the provider prefix from the model id', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } })],
+    }));
+
+    // Was 'codemie-proxy/kimi-k2.7-code', which splits one model across two
+    // buckets in backend analytics.
+    expect(deltas[0].models).toEqual(['kimi-k2.7-code']);
+  });
+
+  it('stamps the branch from the processing context on every delta', async () => {
+    const deltas = await run(buildSession([
+      { id: 'msg-u', sessionID: OC_SESSION_ID, role: 'user', time: { created: 1 } },
+      assistantMessage,
+    ], {
+      'msg-u': [{ id: 'pu', messageID: 'msg-u', sessionID: OC_SESSION_ID, type: 'text', text: 'do it' }],
+      'msg-a': [toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } })],
+    }));
+
+    expect(deltas.length).toBeGreaterThan(1);
+    // Including the prompt delta — otherwise prompts and tools split across two
+    // branch buckets in the aggregator.
+    for (const delta of deltas) {
+      expect(delta.gitBranch).toBe('main');
+    }
+  });
+
+  it('gives each tool call its own record and skips in-flight tools', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [
+        toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } }),
+        toolPart('p2', 'read', { status: 'completed', input: { filePath: 'b.ts' } }),
+        toolPart('p3', 'bash', { status: 'running', input: {} }),
+      ],
+    }));
+
+    expect(deltas.map(d => d.recordId)).toEqual(['msg-a:call-p1', 'msg-a:call-p2']);
+  });
+
+  it('does not re-emit deltas on a second pass', async () => {
+    const session = buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } })],
+    });
+
+    const first = await run(session);
+    const second = await run(session);
+
+    // Stable recordIds are what make the incremental sync timer safe to run.
+    expect(second).toHaveLength(first.length);
+  });
+
+  it('picks up tools appended to a message after an earlier pass', async () => {
+    const parts = [toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } })];
+    const first = await run(buildSession([assistantMessage], { 'msg-a': parts }));
+    expect(first).toHaveLength(1);
+
+    parts.push(toolPart('p2', 'write', {
+      status: 'completed',
+      input: { filePath: 'b.ts', content: 'x' },
+    }));
+    const second = await run(buildSession([assistantMessage], { 'msg-a': parts }));
+
+    // With a bare message-id recordId the message was claimed on the first pass
+    // and every tool it accumulated afterwards was lost.
+    expect(second.map(d => d.recordId)).toEqual(['msg-a:call-p1', 'msg-a:call-p2']);
+  });
+
+  it('carries no token or cost fields', async () => {
+    const deltas = await run(buildSession([assistantMessage], {
+      'msg-a': [toolPart('p1', 'read', { status: 'completed', input: { filePath: 'a.ts' } })],
+    }));
+
+    // codemie-claude sends none, so codemie-opencode sends none.
+    for (const delta of deltas) {
+      expect(delta).not.toHaveProperty('tokens');
+      expect(delta).not.toHaveProperty('cost');
+    }
+  });
+});

--- a/src/agents/plugins/opencode/session/processors/opencode.conversations-processor.ts
+++ b/src/agents/plugins/opencode/session/processors/opencode.conversations-processor.ts
@@ -1,165 +1,501 @@
 // src/agents/plugins/opencode/session/processors/opencode.conversations-processor.ts
+/**
+ * OpenCode Conversations Processor
+ *
+ * Transforms OpenCode messages and parts into incremental CodeMie conversation
+ * payloads and queues them in {sessionId}_conversation.jsonl, where the shared
+ * conversation-sync processor picks them up and PUTs them to
+ * /v1/conversations/{id}/history.
+ *
+ * Shape matches the other agents: the visible history holds the user prompt and
+ * the assistant's reply, while tool calls and reasoning are attached as
+ * `thoughts` on the assistant entry.
+ *
+ * Structurally modelled on codex.conversations-processor.ts — same checkpoint
+ * sentinel, turn-continuation handling and syncUpdates contract.
+ */
+
 import type { SessionProcessor, ProcessingContext, ProcessingResult } from '../../../../core/session/BaseProcessor.js';
 import type { ParsedSession } from '../../../../core/session/BaseSessionAdapter.js';
-import type { BaseNormalizedMessage } from '../../../../core/session/types.js';
-// FIXED (GPT-5.10/5.11): Import type guards from opencode-message-types.js instead of redefining
-// This removes duplicate function definitions that shadowed the imports
 import type {
   OpenCodeMessage,
   OpenCodeAssistantMessage,
-  OpenCodePart
+  OpenCodePart,
+  OpenCodeMetadata,
 } from '../../opencode-message-types.js';
 import {
   isTextPart,
   isToolPart,
-  isFilePart,
-  isReasoningPart
+  isReasoningPart,
 } from '../../opencode-message-types.js';
+import type { ConversationPayloadRecord } from '../../../../../providers/plugins/sso/session/processors/conversations/types.js';
+import { CONVERSATION_SYNC_STATUS } from '../../../../../providers/plugins/sso/session/processors/conversations/types.js';
+import { CODEMIE_ASSISTANT_ID } from '../../../../../providers/plugins/sso/session/processors/conversations/constants.js';
+import { getSessionConversationPath } from '../../../../core/session/session-config.js';
+import { loadPartsForMessage } from '../../opencode.storage-utils.js';
 import { logger } from '../../../../../utils/logger.js';
 
-// NOTE (GPT-5.10/5.11): Type guards are now imported from opencode-message-types.js
-// DO NOT redefine them here - the original code had duplicate definitions that shadowed the imports
-
 /**
- * Normalized conversation message format
- * Aligns with CodeMie's conversation sync API
+ * The conversation folder these payloads are filed under in CodeMie.
+ * Set explicitly so the payload does not depend on the sync processor's
+ * client-type fallback, which defaults to 'Claude Desktop'.
  */
-interface NormalizedMessage extends BaseNormalizedMessage {
-  id: string;
-  timestamp: string;  // non-optional override
+const OPENCODE_CONVERSATION_FOLDER = 'opencode';
+
+type OpenCodeEventKind = 'user_prompt' | 'assistant_reply' | 'reasoning' | 'tool_call';
+
+interface OpenCodeNormalizedEvent {
+  kind: OpenCodeEventKind;
+  /** Position in the flattened (message, part) stream — the checkpoint unit. */
+  sourceIndex: number;
+  date: string;
+  text?: string;
+  toolName?: string;
+  inputText?: string;
+  callId?: string;
+  error?: boolean;
   model?: string;
-  agent?: string;
-  toolUse?: Array<{
-    name: string;
-    input: Record<string, unknown>;
-    output?: string;
-  }>;
-  fileReferences?: string[];
-  thinking?: string;
 }
 
-/**
- * OpenCode Conversations Processor
- *
- * Normalizes OpenCode messages and parts into unified conversation format.
- * Implements SessionProcessor interface for processor chain.
- */
+interface OpenCodeConversationTurn {
+  user: OpenCodeNormalizedEvent;
+  events: OpenCodeNormalizedEvent[];
+  historyIndex: number;
+  isTurnContinuation: boolean;
+}
+
+interface OpenCodeThought {
+  id: string;
+  parent_id: string | null;
+  metadata: Record<string, unknown>;
+  in_progress: boolean;
+  input_text: string;
+  message: string;
+  author_type: 'Tool' | 'Agent';
+  author_name: string;
+  output_format: string;
+  error: boolean;
+  interrupted: boolean;
+  aborted: boolean;
+  children: unknown[];
+}
+
 export class OpenCodeConversationsProcessor implements SessionProcessor {
   readonly name = 'opencode-conversations';
   readonly priority = 2;  // Run after metrics
 
-  /**
-   * Check if session has data to process
-   */
   shouldProcess(session: ParsedSession): boolean {
     if (process.env.CODEMIE_CONV_SYNC_DISABLED === '1') return false;
     return session.messages.length > 0;
   }
 
-  /**
-   * Process session to normalize conversations
-   */
+  // _context is intentionally unused: conversation identity comes from
+  // session.metadata.openCodeSessionId, never from context.agentSessionId,
+  // which differs between the timer/Stop and in-process SessionEnd paths.
   async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
     try {
-      const messages = session.messages as OpenCodeMessage[];
-      const normalizedMessages: NormalizedMessage[] = [];
+      const metadata = session.metadata as (OpenCodeMetadata & { storagePath?: string }) | undefined;
+      const openCodeSessionId = metadata?.openCodeSessionId;
+      const storagePath = metadata?.storagePath;
 
-      for (const message of messages) {
-        // UPDATED (GPT-5.9): Use time.created (numeric) instead of createdAt (string)
-        // For full implementation, parts would be loaded from part/{messageId}/*.json
-        // For now, create basic normalized message from message data
-        const normalized: NormalizedMessage = {
-          id: message.id,
-          role: message.role,
-          content: '',  // Would be populated from text parts (AC-EXT-1)
-          // UPDATED (GPT-5.9): Convert numeric timestamp to ISO string
-          timestamp: message.time?.created
-            ? new Date(message.time.created).toISOString()
-            : new Date().toISOString(),
-          // UPDATED (GPT-5.9): modelID is on assistant messages only
-          model: message.role === 'assistant'
-            ? (message as OpenCodeAssistantMessage).modelID
-            : undefined,
-          agent: message.role === 'assistant'
-            ? (message as OpenCodeAssistantMessage).agent
-            : undefined
+      if (!openCodeSessionId || !storagePath) {
+        return {
+          success: false,
+          message: 'Missing openCodeSessionId or storagePath in session.metadata',
+          metadata: { failureReason: 'NO_OPENCODE_SESSION_ID' }
         };
-
-        normalizedMessages.push(normalized);
       }
 
+      const messages = session.messages as OpenCodeMessage[];
+      const events = await normalizeEvents(messages, storagePath, openCodeSessionId, metadata?.partsMap);
+
       logger.debug(
-        `[opencode-conversations] Normalized ${normalizedMessages.length} messages`
+        `[opencode-conversations] Normalised ${events.length} events from ${messages.length} messages`
       );
+
+      if (events.length === 0) {
+        return { success: true, message: 'No conversation events generated', metadata: { recordsProcessed: 0 } };
+      }
+
+      const { SessionStore } = await import('../../../../core/session/SessionStore.js');
+      const sessionStore = new SessionStore();
+      const sessionMetadata = await sessionStore.loadSession(session.sessionId);
+      const persistedHistoryIndex = sessionMetadata?.sync?.conversations?.lastSyncedHistoryIndex ?? -1;
+      const lastSyncedSourceIndex = parseLastSyncedSourceIndex(
+        sessionMetadata?.sync?.conversations?.lastSyncedMessageUuid,
+        persistedHistoryIndex
+      );
+
+      const conversationsPath = getSessionConversationPath(session.sessionId);
+      const { readJSONL } = await import('../../../../../providers/plugins/sso/session/utils/jsonl-reader.js');
+      const existingPayloads = await readJSONL<ConversationPayloadRecord>(conversationsPath);
+
+      // Payloads already queued but not yet uploaded also advance the watermark,
+      // otherwise every tick re-queues the same turn.
+      const queuedCheckpoint = getQueuedCheckpoint(existingPayloads);
+      const effectiveSourceIndex = Math.max(lastSyncedSourceIndex, queuedCheckpoint.sourceIndex);
+      const effectiveHistoryIndex = Math.max(persistedHistoryIndex, queuedCheckpoint.historyIndex);
+
+      const turn = buildIncrementalTurn(events, effectiveSourceIndex, effectiveHistoryIndex);
+
+      if (!turn) {
+        logger.debug(
+          `[opencode-conversations] No complete turn past source index ${effectiveSourceIndex} for ${openCodeSessionId}`
+        );
+        return { success: true, message: 'No new conversation messages', metadata: { recordsProcessed: 0 } };
+      }
+
+      const newTurnEvents = turn.events.filter(event => event.sourceIndex > effectiveSourceIndex);
+      const endSourceIndex = Math.max(...newTurnEvents.map(event => event.sourceIndex));
+      const sentinel = `${openCodeSessionId}@${endSourceIndex}`;
+
+      if (existingPayloads.some(payload => payload.lastProcessedMessageUuid === sentinel)) {
+        logger.debug(`[opencode-conversations] Window ${sentinel} already queued, skipping`);
+        return { success: true, message: 'Window already queued', metadata: { recordsProcessed: 0 } };
+      }
+
+      const history = turnToHistory(turn, effectiveSourceIndex);
+
+      if (history.length === 0) {
+        logger.debug(`[opencode-conversations] Turn resolved but produced no visible history for ${sentinel}`);
+        return { success: true, message: 'No visible history generated', metadata: { recordsProcessed: 0 } };
+      }
+
+      const { appendFile, mkdir } = await import('fs/promises');
+      const { dirname } = await import('path');
+      await mkdir(dirname(conversationsPath), { recursive: true });
+
+      const payloadRecord: ConversationPayloadRecord = {
+        payloadId: sentinel,
+        timestamp: Date.now(),
+        isTurnContinuation: turn.isTurnContinuation,
+        historyIndices: history.map(entry => entry.history_index),
+        messageCount: history.length,
+        lastProcessedMessageUuid: sentinel,
+        payload: {
+          // Always the opencode ses_* id, never context.agentSessionId. That
+          // field carries ses_* on the timer and Stop paths but the CodeMie UUID
+          // on the in-process SessionEnd path, and conversationId is the PUT
+          // path id — so keying off it filed a session's final turn under a
+          // second conversation and split the history in two. The checkpoint
+          // sentinel already keys on openCodeSessionId, so this is the identity
+          // the rest of the pipeline is built around.
+          conversationId: openCodeSessionId,
+          assistantId: CODEMIE_ASSISTANT_ID,
+          folder: OPENCODE_CONVERSATION_FOLDER,
+          llmModel: resolveTurnModel(turn.events),
+          history,
+        },
+        status: CONVERSATION_SYNC_STATUS.PENDING,
+      };
+
+      await appendFile(conversationsPath, JSON.stringify(payloadRecord) + '\n', 'utf-8');
 
       return {
         success: true,
-        message: `Normalized ${normalizedMessages.length} messages`,
+        message: `Generated 1 conversation payload from ${newTurnEvents.length} new events`,
         metadata: {
-          recordsProcessed: normalizedMessages.length,
-          userMessages: normalizedMessages.filter(m => m.role === 'user').length,
-          assistantMessages: normalizedMessages.filter(m => m.role === 'assistant').length
+          recordsProcessed: newTurnEvents.length,
+          userMessages: history.filter(entry => entry.role === 'User').length,
+          assistantMessages: history.filter(entry => entry.role === 'Assistant').length,
+          syncUpdates: {
+            conversations: {
+              lastSyncedMessageUuid: sentinel,
+              lastSyncedHistoryIndex: turn.historyIndex,
+              // Same identity as payload.conversationId above — see the note there.
+              conversationId: openCodeSessionId,
+              totalMessagesSynced: history.length,
+              totalSyncAttempts: 1,
+              lastSyncAt: Date.now(),
+            },
+          },
         }
       };
+
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`[opencode-conversations] Processing failed:`, error);
-      return {
-        success: false,
-        message: `Conversations processing failed: ${errorMessage}`
-      };
+      logger.error('[opencode-conversations] Processing failed:', error);
+      return { success: false, message: `Conversations processing failed: ${errorMessage}` };
     }
   }
+}
 
-  /**
-   * Process parts for a message (helper for full implementation)
-   * Parts are loaded from part/{messageID}/*.json
-   *
-   * UPDATED (GPT-5.9): Use new part schema:
-   * - Tool parts: callID, tool, state.input, state (not toolName, toolInput, toolOutput)
-   * - File parts: mime, url, source, filename (not filePath, content)
-   */
-  private processParts(parts: OpenCodePart[]): {
-    content: string;
-    toolUse: NormalizedMessage['toolUse'];
-    fileReferences: string[];
-    thinking: string;
-  } {
-    const textParts: string[] = [];
-    const toolUse: NonNullable<NormalizedMessage['toolUse']> = [];
-    const fileReferences: string[] = [];
-    const thinkingParts: string[] = [];
+/**
+ * Flatten messages and their parts into a single ordered event stream.
+ *
+ * `sourceIndex` counts across the flattened (message, part) sequence. OpenCode
+ * only ever appends — new parts land on the newest message, new messages at the
+ * end — so an index already emitted keeps its position on later ticks, which is
+ * what makes it usable as a sync watermark.
+ */
+async function normalizeEvents(
+  messages: OpenCodeMessage[],
+  storagePath: string,
+  openCodeSessionId: string,
+  partsMap?: Record<string, OpenCodePart[]>
+): Promise<OpenCodeNormalizedEvent[]> {
+  const events: OpenCodeNormalizedEvent[] = [];
+  let sourceIndex = 0;
+
+  for (const message of messages) {
+    const date = toIsoDate(message.time?.created);
+    const parts = await loadPartsForMessage<OpenCodePart>(
+      storagePath, message.id, openCodeSessionId, partsMap
+    );
+
+    if (message.role === 'user') {
+      // Burn the index unconditionally, exactly as the assistant branch does.
+      // A user message whose parts have not flushed yet yields no text on this
+      // tick but will on the next one; consuming the index only when text is
+      // present would shift every later sourceIndex by one between ticks and
+      // silently move the checkpoint onto a different event.
+      const index = sourceIndex++;
+
+      const text = parts
+        .filter(part => isTextPart(part) && !isIgnoredPart(part))
+        .map(part => (part as { text: string }).text)
+        .filter(value => value?.trim())
+        .join('\n');
+
+      if (text) {
+        events.push({ kind: 'user_prompt', sourceIndex: index, date, text });
+      }
+      continue;
+    }
+
+    const assistant = message as OpenCodeAssistantMessage;
+    // Bare model id, consistent with the metrics pipeline.
+    const model = assistant.modelID?.trim() || undefined;
 
     for (const part of parts) {
-      // Use type guards for safe narrowing
-      if (isTextPart(part)) {
-        textParts.push(part.text);
-      } else if (isToolPart(part)) {
-        // UPDATED (GPT-5.9): New tool part schema
-        toolUse.push({
-          name: part.tool,  // Was: part.toolName
-          input: part.state.input || {},  // Input is inside state
-          output: part.state?.output  // Was: part.toolOutput
-        });
-      } else if (isFilePart(part)) {
-        // UPDATED (GPT-5.9): New file part schema
-        // Use url or construct reference from filename
-        if (part.url) {
-          fileReferences.push(part.url);
-        } else if (part.filename) {
-          fileReferences.push(part.filename);
+      const index = sourceIndex++;
+
+      if (isReasoningPart(part)) {
+        if (part.text?.trim()) {
+          events.push({ kind: 'reasoning', sourceIndex: index, date, text: part.text, model });
         }
-      } else if (isReasoningPart(part)) {
-        thinkingParts.push(part.text);
+        continue;
       }
-      // step-finish parts are skipped (metadata only - tokens/cost handled by metrics)
+
+      if (isToolPart(part)) {
+        events.push({
+          kind: 'tool_call',
+          sourceIndex: index,
+          date,
+          callId: part.callID || part.id,
+          toolName: part.tool,
+          inputText: stringify(part.state.input),
+          text: part.state.status === 'error'
+            ? (part.state.error ?? '')
+            : stringify(part.state.output),
+          error: part.state.status === 'error',
+          model,
+        });
+        continue;
+      }
+
+      if (isTextPart(part) && !isIgnoredPart(part) && part.text?.trim()) {
+        events.push({ kind: 'assistant_reply', sourceIndex: index, date, text: part.text, model });
+      }
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Resolve the window of events to publish next.
+ *
+ * A turn runs from a user prompt to the next user prompt. When new events land
+ * inside a turn that was already partially published, the turn is re-emitted as
+ * a continuation under its original history index so the backend appends rather
+ * than duplicating.
+ */
+function buildIncrementalTurn(
+  events: OpenCodeNormalizedEvent[],
+  effectiveSourceIndex: number,
+  effectiveHistoryIndex: number
+): OpenCodeConversationTurn | null {
+  const firstNewEvent = events.find(event => event.sourceIndex > effectiveSourceIndex);
+  if (!firstNewEvent) return null;
+
+  const userEvents = events.filter(event => event.kind === 'user_prompt');
+
+  let userEvent: OpenCodeNormalizedEvent | undefined;
+  let historyIndex = effectiveHistoryIndex;
+  let isTurnContinuation = false;
+
+  if (firstNewEvent.kind === 'user_prompt') {
+    userEvent = firstNewEvent;
+    historyIndex = effectiveHistoryIndex + 1;
+  } else {
+    for (let index = userEvents.length - 1; index >= 0; index -= 1) {
+      if (userEvents[index].sourceIndex < firstNewEvent.sourceIndex) {
+        userEvent = userEvents[index];
+        break;
+      }
     }
 
-    return {
-      content: textParts.join('\n'),
-      toolUse: toolUse.length > 0 ? toolUse : undefined,
-      fileReferences: fileReferences.length > 0 ? fileReferences : [],
-      thinking: thinkingParts.join('\n')
-    };
+    if (!userEvent || effectiveHistoryIndex < 0) return null;
+
+    historyIndex = effectiveHistoryIndex;
+    isTurnContinuation = true;
   }
+
+  const nextUserEvent = userEvents.find(event => event.sourceIndex > userEvent.sourceIndex);
+  const turnEndExclusive = nextUserEvent?.sourceIndex ?? Number.MAX_SAFE_INTEGER;
+  const turnEvents = events.filter(event =>
+    event.sourceIndex >= userEvent.sourceIndex && event.sourceIndex < turnEndExclusive
+  );
+
+  const hasNewReply = turnEvents.some(event =>
+    event.kind === 'assistant_reply' && event.sourceIndex > effectiveSourceIndex
+  );
+  const shouldEmitUser = userEvent.sourceIndex > effectiveSourceIndex;
+
+  // Hold the turn back until the assistant has actually said something —
+  // publishing a prompt with no reply would leave a dangling history entry.
+  if (!shouldEmitUser && !hasNewReply) return null;
+
+  return { user: userEvent, events: turnEvents, historyIndex, isTurnContinuation };
+}
+
+function turnToHistory(
+  turn: OpenCodeConversationTurn,
+  effectiveSourceIndex: number
+): Array<Record<string, unknown> & { role: string; history_index: number }> {
+  const history: Array<Record<string, unknown> & { role: string; history_index: number }> = [];
+  const finalReply = getFinalReply(turn.events);
+
+  if (turn.user.sourceIndex > effectiveSourceIndex) {
+    history.push({
+      role: 'User',
+      message: turn.user.text,
+      message_raw: turn.user.text,
+      date: turn.user.date,
+      history_index: turn.historyIndex,
+      file_names: [],
+    });
+  }
+
+  if (finalReply && finalReply.sourceIndex > effectiveSourceIndex) {
+    const thoughts = buildThoughts(turn.events, turn.historyIndex);
+    history.push({
+      role: 'Assistant',
+      message: finalReply.text,
+      message_raw: finalReply.text,
+      date: finalReply.date,
+      history_index: turn.historyIndex,
+      response_time: calculateResponseTime(turn.user.date, finalReply.date),
+      assistant_id: CODEMIE_ASSISTANT_ID,
+      ...(thoughts.length > 0 && { thoughts }),
+    });
+  }
+
+  return history;
+}
+
+/**
+ * Build the thought tree hung off the assistant entry: one node per tool call
+ * (input and output together, since OpenCode keeps both on the same part) and
+ * one per reasoning block.
+ */
+function buildThoughts(events: OpenCodeNormalizedEvent[], historyIndex: number): OpenCodeThought[] {
+  const thoughts: OpenCodeThought[] = [];
+
+  for (const event of events) {
+    if (event.kind === 'user_prompt' || event.kind === 'assistant_reply') continue;
+
+    const isTool = event.kind === 'tool_call';
+
+    thoughts.push({
+      id: isTool
+        ? (event.callId || `opencode-tool-${historyIndex}-${event.sourceIndex}`)
+        : `opencode-reasoning-${historyIndex}-${event.sourceIndex}`,
+      parent_id: null,
+      metadata: {
+        timestamp: event.date,
+        source_index: event.sourceIndex,
+        event_kind: event.kind,
+        ...(isTool && { call_id: event.callId }),
+      },
+      in_progress: false,
+      input_text: event.inputText ?? '',
+      message: event.text || (isTool ? '' : '[reasoning]'),
+      author_type: isTool ? 'Tool' : 'Agent',
+      author_name: isTool ? (event.toolName || 'Unknown Tool') : 'OpenCode Reasoning',
+      output_format: 'text',
+      error: event.error === true,
+      interrupted: false,
+      aborted: false,
+      children: [],
+    });
+  }
+
+  return thoughts;
+}
+
+function getFinalReply(events: OpenCodeNormalizedEvent[]): OpenCodeNormalizedEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index].kind === 'assistant_reply') return events[index];
+  }
+  return undefined;
+}
+
+function resolveTurnModel(events: OpenCodeNormalizedEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index].model) return events[index].model;
+  }
+  return undefined;
+}
+
+/** Parts OpenCode marks as ignored or synthetic are not user-authored content. */
+function isIgnoredPart(part: OpenCodePart): boolean {
+  const flags = part as { ignored?: boolean; synthetic?: boolean };
+  return flags.ignored === true || flags.synthetic === true;
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toIsoDate(timestamp: number | undefined): string {
+  return new Date(typeof timestamp === 'number' && timestamp > 0 ? timestamp : Date.now()).toISOString();
+}
+
+function parseLastSyncedSourceIndex(value: unknown, fallback: number): number {
+  if (typeof value === 'string') {
+    const index = Number.parseInt(value.slice(value.lastIndexOf('@') + 1), 10);
+    if (Number.isFinite(index)) return index;
+  }
+  return fallback;
+}
+
+function getQueuedCheckpoint(
+  payloads: ConversationPayloadRecord[]
+): { sourceIndex: number; historyIndex: number } {
+  let sourceIndex = -1;
+  let historyIndex = -1;
+
+  for (const payload of payloads) {
+    sourceIndex = Math.max(sourceIndex, parseLastSyncedSourceIndex(payload.lastProcessedMessageUuid, -1));
+    if (payload.historyIndices.length > 0) {
+      historyIndex = Math.max(historyIndex, Math.max(...payload.historyIndices));
+    }
+  }
+
+  return { sourceIndex, historyIndex };
+}
+
+function calculateResponseTime(start: string, end: string): number | undefined {
+  const startMs = new Date(start).getTime();
+  const endMs = new Date(end).getTime();
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return undefined;
+  return Math.max(0, Math.round(((endMs - startMs) / 1000) * 100) / 100);
 }

--- a/src/agents/plugins/opencode/session/processors/opencode.metrics-processor.ts
+++ b/src/agents/plugins/opencode/session/processors/opencode.metrics-processor.ts
@@ -24,15 +24,64 @@ import type {
   OpenCodeMetadata,
 } from '../../opencode-message-types.js';
 import { isToolPart } from '../../opencode-message-types.js';
-import { readJsonWithRetry, readJsonlTolerant } from '../../opencode.storage-utils.js';
+import { readJsonlTolerant, loadPartsForMessage } from '../../opencode.storage-utils.js';
 import { logger } from '../../../../../utils/logger.js';
-import { getCodemiePath } from '../../../../../utils/paths.js';
-import { readdir, readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-// Cooldown to prevent concurrent processing of same session (ADR-18)
-const REPROCESS_COOLDOWN_MS = 60_000; // 60 seconds
+// NOTE: the former 60s REPROCESS_COOLDOWN_MS gate was removed deliberately.
+// It predated incremental sync and would swallow every timer tick, stranding
+// deltas on disk. Deduplication on `recordId` already makes process()
+// idempotent, and the sync timer holds its own in-flight guard.
+
+/**
+ * Map an apply_patch/patch per-file operation kind to a MetricDelta file
+ * operation type. The aggregator counts 'write' as files_created, 'edit' as
+ * files_modified and 'delete' as files_deleted.
+ */
+function mapPatchFileType(type: unknown): FileOperationType {
+  switch (type) {
+    case 'add': return 'write';
+    case 'delete': return 'delete';
+    case 'update': return 'edit';
+    default: return 'edit';
+  }
+}
+
+/** Emitted delta shape before MetricsWriter stamps sync bookkeeping onto it. */
+type PendingDelta = Omit<MetricDelta, 'syncStatus' | 'syncAttempts'>;
+
+/** File operation entry as carried on a MetricDelta. */
+type DeltaFileOperation = NonNullable<MetricDelta['fileOperations']>[number];
+
+/**
+ * Count added/removed lines in a unified diff.
+ *
+ * OpenCode reports edits as patch text (`state.metadata.filediff.patch`,
+ * `state.metadata.diff`, `apply_patch` per-file `patch`); unlike Claude it never
+ * emits numeric additions/deletions, so the counts have to come from the diff.
+ */
+export function countDiffLines(patch: unknown): { linesAdded: number; linesRemoved: number } {
+  if (typeof patch !== 'string' || patch.length === 0) {
+    return { linesAdded: 0, linesRemoved: 0 };
+  }
+
+  let linesAdded = 0;
+  let linesRemoved = 0;
+
+  for (const line of patch.split('\n')) {
+    // Skip hunk headers and the ---/+++ file header pair, which are not content.
+    // The header test requires the trailing space git always emits ("--- a/x"),
+    // so a *content* line that merely starts with --- or +++ (a markdown rule, a
+    // YAML document separator) is still counted instead of silently dropped.
+    if (line.startsWith('@@')) continue;
+    if (line.startsWith('+++ ') || line.startsWith('--- ')) continue;
+    if (line.startsWith('+')) linesAdded++;
+    else if (line.startsWith('-')) linesRemoved++;
+  }
+
+  return { linesAdded, linesRemoved };
+}
 
 /**
  * OpenCode Metrics Processor
@@ -43,12 +92,6 @@ const REPROCESS_COOLDOWN_MS = 60_000; // 60 seconds
 export class OpenCodeMetricsProcessor implements SessionProcessor {
   readonly name = 'opencode-metrics';
   readonly priority = 1;  // Run first (before conversations)
-
-  private readonly cacheDir: string;
-
-  constructor() {
-    this.cacheDir = getCodemiePath('cache', 'opencode');
-  }
 
   /**
    * Check if session has data to process
@@ -62,7 +105,7 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
    *
    * Per tech spec ADR-1/G2: Validate metadata at START before any processing
    */
-  async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
+  async process(session: ParsedSession, context: ProcessingContext): Promise<ProcessingResult> {
     try {
       // MANDATORY: Validate metadata has required fields (ADR-1, Review 13 G2)
       const metadata = session.metadata as Record<string, unknown>;
@@ -80,15 +123,6 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
       const storagePath = metadata.storagePath;
       const openCodeSessionId = (metadata.openCodeSessionId as string) || 'unknown';
 
-      // Check concurrent processing prevention (ADR-18)
-      if (!await this.shouldProcessSession(session.sessionId)) {
-        return {
-          success: true,
-          message: 'Session recently processed, skipping',
-          metadata: { skippedReason: 'RECENTLY_PROCESSED' }
-        };
-      }
-
       const messages = session.messages as OpenCodeMessage[];
 
       // Transform messages to deltas
@@ -104,12 +138,18 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
         storageType: metadata.storageType as 'sqlite' | 'file' | undefined,
       };
 
+      // Branch attribution: the aggregator groups deltas by gitBranch and emits
+      // one codemie_cli_tool_usage_total per branch. Without this every delta
+      // lands in the empty-string bucket.
+      const gitBranch = await this.resolveBranch(context, openCodeMetadata);
+
       const { deltas, stats } = await this.transformMessagesToDeltas(
         messages,
         session.sessionId,
         openCodeSessionId,
         storagePath,
-        openCodeMetadata
+        openCodeMetadata,
+        gitBranch
       );
 
       if (deltas.length === 0) {
@@ -146,9 +186,6 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
         await writer.appendDelta(delta);
       }
 
-      // Mark session as processed (ADR-18)
-      await this.markSessionProcessed(session.sessionId);
-
       logger.info(`[opencode-metrics] Wrote ${deltas.length} deltas for session ${session.sessionId}`);
       logger.info(`[opencode-metrics] Metrics file: ${writer.getFilePath()}`);
 
@@ -175,143 +212,166 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
   }
 
   /**
-   * Check if session should be processed (cooldown check per ADR-18)
-   */
-  private async shouldProcessSession(sessionId: string): Promise<boolean> {
-    try {
-      const lastProcessedPath = join(this.cacheDir, `${sessionId}_last_processed`);
-
-      if (existsSync(lastProcessedPath)) {
-        const lastProcessed = parseInt(await readFile(lastProcessedPath, 'utf-8'), 10);
-        if (Date.now() - lastProcessed < REPROCESS_COOLDOWN_MS) {
-          logger.debug(`[opencode-metrics] Session ${sessionId} processed recently, skipping`);
-          return false;
-        }
-      }
-    } catch {
-      // File corrupt or missing, proceed with processing
-    }
-
-    return true;
-  }
-
-  /**
-   * Mark session as processed (ADR-18)
-   */
-  private async markSessionProcessed(sessionId: string): Promise<void> {
-    try {
-      const { mkdir } = await import('fs/promises');
-      if (!existsSync(this.cacheDir)) {
-        await mkdir(this.cacheDir, { recursive: true });
-      }
-      const lastProcessedPath = join(this.cacheDir, `${sessionId}_last_processed`);
-      await writeFile(lastProcessedPath, Date.now().toString());
-    } catch (error) {
-      logger.debug(`[opencode-metrics] Failed to mark session processed: ${error}`);
-    }
-  }
-
-  /**
-   * Transform messages to MetricDelta records
+   * Resolve the git branch every delta in this batch is attributed to.
    *
-   * Per ADR-16: One delta per assistant message with tokens
+   * Mirrors codex.metrics-processor's resolveBranch: prefer the branch the CLI
+   * already resolved (BaseAgentAdapter sets CODEMIE_GIT_BRANCH before spawning),
+   * then the value the adapter overlaid onto session metadata, then detect it.
+   */
+  private async resolveBranch(
+    context: ProcessingContext,
+    sessionMetadata: OpenCodeMetadata & { gitBranch?: string }
+  ): Promise<string | undefined> {
+    if (context.gitBranch) return context.gitBranch;
+    if (sessionMetadata.gitBranch) return sessionMetadata.gitBranch;
+    if (!sessionMetadata.projectPath) return undefined;
+
+    try {
+      const { detectGitBranch } = await import('../../../../../utils/processes.js');
+      return (await detectGitBranch(sessionMetadata.projectPath)) ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Transform messages to MetricDelta records.
+   *
+   * One delta per tool call (`{messageId}:{callID}`), per user prompt
+   * (`{messageId}:prompt`) and per failed turn (`{messageId}:error`).
+   *
+   * Granularity matters: when the recordId was the bare assistant message id,
+   * the first incremental tick claimed the message and every tool that message
+   * accumulated afterwards was deduped away and never reported.
    */
   private async transformMessagesToDeltas(
     messages: OpenCodeMessage[],
     codemieSessionId: string,
     openCodeSessionId: string,
     storagePath: string,
-    sessionMetadata: OpenCodeMetadata
+    sessionMetadata: OpenCodeMetadata,
+    gitBranch: string | undefined
   ): Promise<{
-    deltas: Array<Omit<MetricDelta, 'syncStatus' | 'syncAttempts'>>;
-    stats: {
-      skippedDueToDedup: number;
-    };
+    deltas: PendingDelta[];
+    stats: { skippedDueToDedup: number };
   }> {
-    const deltas: Array<Omit<MetricDelta, 'syncStatus' | 'syncAttempts'>> = [];
-    const stats = {
-      skippedDueToDedup: 0
-    };
+    const deltas: PendingDelta[] = [];
+    const stats = { skippedDueToDedup: 0 };
 
-    // Get existing record IDs for deduplication (ADR-5)
+    // Single read of the existing JSONL — recordId dedup is the only state needed.
     const existingRecordIds = await this.getExistingRecordIds(codemieSessionId);
-    const existingDeltas = await this.readExistingDeltas(codemieSessionId);
 
-    // Track already-attached user prompts (ADR-21)
-    const alreadyAttachedPrompts = new Set<string>();
-    for (const delta of existingDeltas) {
-      if (delta.userPrompts) {
-        for (const prompt of delta.userPrompts) {
-          if (prompt.text) alreadyAttachedPrompts.add(prompt.text);
-        }
-      }
-    }
-
-    // Extract all user prompts (pass partsMap for SQLite-backed sessions)
-    const allUserPrompts = await this.extractUserPrompts(messages, storagePath, openCodeSessionId, sessionMetadata.partsMap);
-
-    // Filter to only NEW prompts
-    const newPrompts = allUserPrompts.filter(p => !alreadyAttachedPrompts.has(p.text));
-    let promptsAttached = false;
+    const base = (recordId: string, timestamp: number): PendingDelta => ({
+      recordId,
+      sessionId: codemieSessionId,
+      agentSessionId: openCodeSessionId,
+      timestamp,
+      ...(gitBranch && { gitBranch }),
+    });
 
     for (const msg of messages) {
-      if (msg.role !== 'assistant') continue;
+      const timestamp = this.resolveTimestamp(msg, sessionMetadata);
+
+      if (msg.role === 'user') {
+        const recordId = `${msg.id}:prompt`;
+        if (existingRecordIds.has(recordId)) {
+          stats.skippedDueToDedup++;
+          continue;
+        }
+
+        const text = await this.extractUserPromptText(
+          msg, storagePath, openCodeSessionId, sessionMetadata.partsMap
+        );
+        if (!text) continue;
+
+        deltas.push({ ...base(recordId, timestamp), userPrompts: [{ count: 1, text }] });
+        continue;
+      }
 
       const assistantMsg = msg as OpenCodeAssistantMessage;
+      const modelString = this.getValidModelString(assistantMsg.modelID);
 
-      // Check deduplication (ADR-5, ADR-15)
-      if (existingRecordIds.has(assistantMsg.id)) {
-        stats.skippedDueToDedup++;
-        continue;
+      const parts = await loadPartsForMessage(
+        storagePath, assistantMsg.id, openCodeSessionId, sessionMetadata.partsMap
+      );
+
+      for (const part of parts.filter(isToolPart) as OpenCodeToolPart[]) {
+        // callID is the semantically meaningful key, but older sessions and
+        // some tools omit it; part.id is the storage primary key and is always
+        // present, so it guarantees the recordId stays collision-free.
+        const recordId = `${assistantMsg.id}:${part.callID || part.id}`;
+        if (existingRecordIds.has(recordId)) {
+          stats.skippedDueToDedup++;
+          continue;
+        }
+
+        const toolDelta = this.buildToolDelta(part, base(recordId, timestamp), modelString);
+        if (toolDelta) deltas.push(toolDelta);
       }
 
-      // Load parts for this message (use pre-loaded partsMap if available from SQLite)
-      const parts = await this.loadPartsForMessage(storagePath, assistantMsg.id, openCodeSessionId, sessionMetadata.partsMap);
+      // Turn-level failure. This is OpenCode's analogue of Claude's
+      // isApiErrorMessage entries and the ONLY source of apiErrorMessage —
+      // tool failures stay in toolStatus, exactly as codemie-claude does, so
+      // raw tool output never reaches the error_messages wire field.
+      if (assistantMsg.error) {
+        const recordId = `${assistantMsg.id}:error`;
+        if (existingRecordIds.has(recordId)) {
+          stats.skippedDueToDedup++;
+          continue;
+        }
 
-      // Extract tool metrics
-      const { tools, toolStatus, fileOperations } = this.extractToolMetrics(parts);
-
-      // Skip if no tools, file ops, and not a prompt carrier (nothing meaningful to record)
-      const hasData = Object.keys(tools).length > 0 || fileOperations.length > 0;
-      const isPromptCarrier = !promptsAttached && newPrompts.length > 0;
-      if (!hasData && !isPromptCarrier) {
-        continue;
+        const detail = assistantMsg.error.data?.message;
+        deltas.push({
+          ...base(recordId, timestamp),
+          apiErrorMessage: detail
+            ? `${assistantMsg.error.name}: ${detail}`
+            : assistantMsg.error.name,
+          ...(modelString && { models: [modelString] }),
+        });
       }
-
-      // Build delta (ADR-15: recordId is message.id)
-      const delta: Omit<MetricDelta, 'syncStatus' | 'syncAttempts'> = {
-        recordId: assistantMsg.id,
-        sessionId: codemieSessionId,
-        agentSessionId: openCodeSessionId,
-        timestamp: this.resolveTimestamp(assistantMsg, sessionMetadata),
-        tools,
-        ...(Object.keys(toolStatus).length > 0 && { toolStatus }),
-        ...(fileOperations.length > 0 && { fileOperations })
-      };
-
-      // Add model if present (ADR-6)
-      const modelString = this.getValidModelString(assistantMsg.providerID, assistantMsg.modelID);
-      if (modelString) {
-        delta.models = [modelString];
-      }
-
-      // Attach user prompts to first NEW delta only (ADR-21)
-      if (!promptsAttached && newPrompts.length > 0) {
-        (delta as any).userPrompts = newPrompts;
-        promptsAttached = true;
-      }
-
-      deltas.push(delta);
     }
 
     return { deltas, stats };
   }
 
   /**
+   * Build a single-tool delta, or undefined when the tool is still in flight.
+   */
+  private buildToolDelta(
+    part: OpenCodeToolPart,
+    delta: PendingDelta,
+    modelString: string | undefined
+  ): PendingDelta | undefined {
+    const toolName = part.tool.toLowerCase();
+    const statusResult = this.mapToolStatus(part.state.status);
+
+    // pending/running tools are not counted at all — a later tick picks them up
+    // once they settle, and the recordId keeps that second visit idempotent.
+    if (statusResult === 'skip') return undefined;
+
+    const fileOperations = statusResult === 'success'
+      ? this.extractFileOperation(part.tool, part.state.input, part.state.metadata)
+      : [];
+
+    return {
+      ...delta,
+      tools: { [toolName]: 1 },
+      toolStatus: {
+        [toolName]: {
+          success: statusResult === 'success' ? 1 : 0,
+          failure: statusResult === 'failure' ? 1 : 0,
+        },
+      },
+      ...(fileOperations.length > 0 && { fileOperations }),
+      ...(modelString && { models: [modelString] }),
+    };
+  }
+
+  /**
    * Resolve timestamp with fallback chain (ADR-13 G4)
    */
   private resolveTimestamp(
-    msg: OpenCodeAssistantMessage,
+    msg: OpenCodeMessage,
     sessionMetadata: OpenCodeMetadata
   ): number {
     // Primary: message timestamp
@@ -331,126 +391,6 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
     // Last resort: current time
     logger.warn(`[opencode-metrics] Missing timestamp for message ${msg.id}, using Date.now()`);
     return Date.now();
-  }
-
-  /**
-   * Load parts for a message (ADR-11 - part-message validation)
-   *
-   * When partsMap is provided (SQLite-backed sessions), uses pre-loaded parts
-   * directly instead of reading from the filesystem.
-   */
-  private async loadPartsForMessage(
-    storagePath: string,
-    messageId: string,
-    expectedSessionId?: string,
-    partsMap?: Record<string, OpenCodePart[]>
-  ): Promise<OpenCodePart[]> {
-    // Use pre-loaded partsMap if available (from SQLite bulk query)
-    if (partsMap && partsMap[messageId]) {
-      const parts = partsMap[messageId];
-      // Apply same validation as file-based path
-      return parts.filter(part => {
-        if (part.messageID !== messageId) {
-          logger.debug(`[opencode-metrics] Skipping orphaned part ${part.id}: messageID mismatch`);
-          return false;
-        }
-        if (expectedSessionId && part.sessionID !== expectedSessionId) {
-          logger.debug(`[opencode-metrics] Skipping part ${part.id}: sessionID mismatch`);
-          return false;
-        }
-        return true;
-      }).sort((a, b) => a.id.localeCompare(b.id));
-    }
-
-    // File-based loading fallback
-    const partsDir = join(storagePath, 'part', messageId);
-
-    if (!existsSync(partsDir)) {
-      return [];
-    }
-
-    const parts: OpenCodePart[] = [];
-
-    try {
-      const files = await readdir(partsDir);
-
-      for (const file of files) {
-        if (!file.endsWith('.json')) continue;
-
-        const part = await readJsonWithRetry<OpenCodePart>(join(partsDir, file));
-        if (!part) continue;
-
-        // Validate part belongs to this message (ADR-11)
-        if (part.messageID !== messageId) {
-          logger.debug(`[opencode-metrics] Skipping orphaned part ${part.id}: messageID mismatch`);
-          continue;
-        }
-
-        // Optionally validate session correlation
-        if (expectedSessionId && part.sessionID !== expectedSessionId) {
-          logger.debug(`[opencode-metrics] Skipping part ${part.id}: sessionID mismatch`);
-          continue;
-        }
-
-        parts.push(part);
-      }
-    } catch (error) {
-      logger.debug(`[opencode-metrics] Error loading parts from ${partsDir}:`, error);
-    }
-
-    return parts.sort((a, b) => a.id.localeCompare(b.id));
-  }
-
-  /**
-   * Extract tool metrics from parts (ADR-8, ADR-14)
-   */
-  private extractToolMetrics(parts: OpenCodePart[]): {
-    tools: Record<string, number>;
-    toolStatus: Record<string, { success: number; failure: number }>;
-    fileOperations: Array<{
-      type: FileOperationType;
-      path?: string;
-      pattern?: string;
-      linesAdded?: number;
-      linesRemoved?: number;
-    }>;
-  } {
-    const tools: Record<string, number> = {};
-    const toolStatus: Record<string, { success: number; failure: number }> = {};
-    const fileOperations: Array<{
-      type: FileOperationType;
-      path?: string;
-      pattern?: string;
-      linesAdded?: number;
-      linesRemoved?: number;
-    }> = [];
-
-    const toolParts = parts.filter(isToolPart) as OpenCodeToolPart[];
-
-    for (const part of toolParts) {
-      const toolName = part.tool.toLowerCase();
-      tools[toolName] = (tools[toolName] || 0) + 1;
-
-      const statusResult = this.mapToolStatus(part.state.status);
-      if (statusResult !== 'skip') {
-        if (!toolStatus[toolName]) {
-          toolStatus[toolName] = { success: 0, failure: 0 };
-        }
-        toolStatus[toolName][statusResult]++;
-
-        // Extract file operations only for completed tools (ADR-8)
-        if (statusResult === 'success') {
-          const ops = this.extractFileOperation(
-            part.tool,
-            part.state.input,
-            part.state.metadata
-          );
-          fileOperations.push(...ops);
-        }
-      }
-    }
-
-    return { tools, toolStatus, fileOperations };
   }
 
   /**
@@ -479,21 +419,9 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
     toolName: string,
     input: Record<string, unknown> | undefined,
     metadata?: Record<string, unknown>
-  ): Array<{
-    type: FileOperationType;
-    path?: string;
-    pattern?: string;
-    linesAdded?: number;
-    linesRemoved?: number;
-  }> {
+  ): DeltaFileOperation[] {
     const toolLower = toolName.toLowerCase();
-    const operations: Array<{
-      type: FileOperationType;
-      path?: string;
-      pattern?: string;
-      linesAdded?: number;
-      linesRemoved?: number;
-    }> = [];
+    const operations: DeltaFileOperation[] = [];
 
     // Map tools to allowed types (ADR-8)
     const typeMapping: Record<string, FileOperationType> = {
@@ -502,39 +430,38 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
       'edit': 'edit',
       'glob': 'glob',
       'grep': 'grep',
-      'apply_patch': 'edit',  // Map to edit, not patch
+      'apply_patch': 'edit',  // per-file type refines this below
+      'patch': 'edit',        // per-file type refines this below
       'multiedit': 'edit',    // Map to edit, not multiedit
     };
 
     const mappedType = typeMapping[toolLower];
     if (!mappedType) return [];
 
-    // Handle apply_patch - extract from state.metadata.files (ADR-17)
-    if (toolLower === 'apply_patch') {
+    // apply_patch / patch — state.metadata.files carries one entry per touched
+    // file with its own operation kind and diff (ADR-17). The per-file `type` is
+    // what makes files_deleted reachable; mapping every entry to 'edit' left it
+    // permanently 0.
+    if (toolLower === 'apply_patch' || toolLower === 'patch') {
       const files = metadata?.files as Array<{
         filePath?: string;
         relativePath?: string;
         type?: string;
-        additions?: number;
-        deletions?: number;
+        patch?: string;
       }> | undefined;
 
       if (Array.isArray(files)) {
         for (const file of files) {
           const path = file.filePath || file.relativePath;
-          if (typeof path === 'string') {
-            const op: any = { type: 'edit', path };
+          if (typeof path !== 'string') continue;
 
-            // Add line metrics from apply_patch (ADR-8)
-            if (typeof file.additions === 'number') {
-              op.linesAdded = file.additions;
-            }
-            if (typeof file.deletions === 'number') {
-              op.linesRemoved = file.deletions;
-            }
-
-            operations.push(op);
-          }
+          const { linesAdded, linesRemoved } = countDiffLines(file.patch);
+          operations.push({
+            type: mapPatchFileType(file.type),
+            path,
+            ...(linesAdded > 0 && { linesAdded }),
+            ...(linesRemoved > 0 && { linesRemoved }),
+          });
         }
       }
       return operations;
@@ -553,8 +480,7 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
       return operations;
     }
 
-    // Standard file operations
-    const fileOp: any = { type: mappedType };
+    const fileOp: DeltaFileOperation = { type: mappedType };
 
     // Per ADR-17: field names are camelCase (filePath, not file_path)
     const filePath = input?.filePath || input?.path;
@@ -566,31 +492,25 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
       fileOp.pattern = input.pattern;
     }
 
-    operations.push(fileOp);
-    return operations;
-  }
-
-  /**
-   * Extract user prompts from messages (ADR-10, ADR-20)
-   */
-  private async extractUserPrompts(
-    messages: OpenCodeMessage[],
-    storagePath: string,
-    sessionId?: string,
-    partsMap?: Record<string, OpenCodePart[]>
-  ): Promise<Array<{ count: number; text: string }>> {
-    const prompts: Array<{ count: number; text: string }> = [];
-
-    for (const msg of messages) {
-      if (msg.role !== 'user') continue;
-
-      const text = await this.extractUserPromptText(msg, storagePath, sessionId, partsMap);
-      if (text) {
-        prompts.push({ count: 1, text });
+    if (toolLower === 'write') {
+      // A write creates the whole file, so every line is an addition. Matches
+      // claude-file-operation.ts, which counts Write content lines the same way.
+      const content = input?.content;
+      if (typeof content === 'string' && content.length > 0) {
+        fileOp.linesAdded = content.split('\n').length;
       }
     }
 
-    return prompts;
+    if (toolLower === 'edit') {
+      // OpenCode reports the edit as diff text; there is no numeric count.
+      const filediff = metadata?.filediff as { patch?: string } | undefined;
+      const { linesAdded, linesRemoved } = countDiffLines(filediff?.patch ?? metadata?.diff);
+      if (linesAdded > 0) fileOp.linesAdded = linesAdded;
+      if (linesRemoved > 0) fileOp.linesRemoved = linesRemoved;
+    }
+
+    operations.push(fileOp);
+    return operations;
   }
 
   /**
@@ -605,7 +525,7 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
     // Try pre-loaded partsMap first (SQLite path), then file-based
     const hasParts = partsMap?.[msg.id] || existsSync(join(storagePath, 'part', msg.id));
     if (hasParts) {
-      const parts = await this.loadPartsForMessage(storagePath, msg.id, sessionId, partsMap);
+      const parts = await loadPartsForMessage(storagePath, msg.id, sessionId, partsMap);
       // Filter: exclude ignored and synthetic parts (ADR-10)
       const textParts = parts.filter(p =>
         p.type === 'text' &&
@@ -636,12 +556,19 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
   }
 
   /**
-   * Get existing record IDs for deduplication (ADR-5)
-   * Uses tolerant JSONL reading to handle corrupted lines.
+   * Get existing record IDs for deduplication (ADR-5).
+   * Single tolerant read of the JSONL — corrupted lines are skipped.
    */
   private async getExistingRecordIds(sessionId: string): Promise<Set<string>> {
     try {
-      const existingDeltas = await this.readExistingDeltas(sessionId);
+      const { MetricsWriter } = await import('../../../../../providers/plugins/sso/session/processors/metrics/MetricsWriter.js');
+      const writer = new MetricsWriter(sessionId);
+
+      if (!writer.exists()) {
+        return new Set();
+      }
+
+      const existingDeltas = await readJsonlTolerant<MetricDelta>(writer.getFilePath());
       return new Set(existingDeltas.map(d => d.recordId));
     } catch (error) {
       logger.warn('[opencode-metrics] Could not read existing deltas:', error);
@@ -650,34 +577,15 @@ export class OpenCodeMetricsProcessor implements SessionProcessor {
   }
 
   /**
-   * Read existing deltas from JSONL file (ADR-5, ADR-21)
+   * Get valid model string (ADR-6).
+   *
+   * Returns the BARE model id. codemie-claude reports `llm_model` without a
+   * provider prefix, so emitting `codemie-proxy/<model>` here would split the
+   * same model into two buckets in backend analytics. The provider stays on
+   * session metadata for local traceability.
    */
-  private async readExistingDeltas(sessionId: string): Promise<MetricDelta[]> {
-    try {
-      const { MetricsWriter } = await import('../../../../../providers/plugins/sso/session/processors/metrics/MetricsWriter.js');
-      const writer = new MetricsWriter(sessionId);
-
-      if (!writer.exists()) {
-        return [];
-      }
-
-      // Use tolerant read that skips corrupted lines
-      return await readJsonlTolerant<MetricDelta>(writer.getFilePath());
-    } catch (error) {
-      logger.debug('[opencode-metrics] Could not read existing deltas:', error);
-      return [];
-    }
-  }
-
-  /**
-   * Get valid model string (ADR-6)
-   */
-  private getValidModelString(providerID?: string, modelID?: string): string | undefined {
-    const model = modelID?.trim();
-    if (!model) return undefined;
-
-    const provider = providerID?.toLowerCase().trim();
-    return provider ? `${provider}/${model}` : model;
+  private getValidModelString(modelID?: string): string | undefined {
+    return modelID?.trim() || undefined;
   }
 
 }

--- a/src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts
@@ -271,6 +271,9 @@ function resolveConversationFolder(clientType?: string, agentName?: string): str
   if (clientType === 'codemie-claude' || agentName === 'claude') {
     return 'claude';
   }
+  if (clientType === 'codemie-opencode' || agentName === 'opencode') {
+    return 'opencode';
+  }
   return DEFAULT_CONVERSATION_FOLDER;
 }
 

--- a/src/utils/__tests__/extensions-scan.test.ts
+++ b/src/utils/__tests__/extensions-scan.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for extensions scanning.
+ *
+ * Covers the multi-directory support added for OpenCode (singular/plural
+ * spellings, extra global roots) and pins the existing Claude-shaped behaviour
+ * so those additions stay backwards compatible.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getExtensionsScanSummary } from '../extensions-scan.js';
+import type { AgentExtensionsConfig } from '../../agents/core/types.js';
+
+let root: string;
+
+function write(relativePath: string, content = 'x'): void {
+  const full = join(root, relativePath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'codemie-ext-scan-'));
+
+  // Claude-shaped project layout (plural directories).
+  write('claude-project/.claude/agents/explorer.md');
+  write('claude-project/.claude/commands/deploy.md');
+  write('claude-project/.claude/commands/README.md');       // ignored by design
+  write('claude-project/.claude/skills/my-skill/SKILL.md');
+  write('claude-project/.claude/hooks/pre-commit.sh');
+  write('claude-project/.claude/rules/style.md');
+
+  // Namespaced subdirectories sharing a basename — a normal Claude layout, and
+  // the one input where cross-directory de-duplication could regress counts.
+  write('claude-nested/.claude/commands/a/build.md');
+  write('claude-nested/.claude/commands/b/build.md');
+  write('claude-nested/.claude/agents/team-x/review.md');
+  write('claude-nested/.claude/agents/team-y/review.md');
+
+  // OpenCode-shaped project layout: singular directories, plugins not hooks.
+  write('oc-project/.opencode/agent/reviewer.md');
+  write('oc-project/.opencode/command/build.md');
+  write('oc-project/.opencode/skill/deep-dive/SKILL.md');
+  write('oc-project/.opencode/plugin/telemetry.ts');
+
+  // Same OpenCode project also using the plural spellings.
+  write('oc-both/.opencode/agent/reviewer.md');
+  write('oc-both/.opencode/agents/reviewer.md');            // duplicate name
+  write('oc-both/.opencode/agents/second.md');
+  write('oc-both/.opencode/plugins/extra.js');
+
+  // Two global roots, both of which OpenCode reads.
+  write('global-xdg/opencode/agent/from-xdg.md');
+  write('global-home/.opencode/agent/from-home.md');
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('getExtensionsScanSummary', () => {
+  it('returns zeros when the agent declares no extensions config', async () => {
+    const summary = await getExtensionsScanSummary(undefined, root);
+
+    expect(summary.project).toEqual({ agents: 0, commands: 0, skills: 0, hooks: 0, rules: 0 });
+    expect(summary.global).toEqual({ agents: 0, commands: 0, skills: 0, hooks: 0, rules: 0 });
+    expect(summary.projectNames.agents).toEqual([]);
+  });
+
+  it('scans the default plural directories unchanged (Claude behaviour)', async () => {
+    const config: AgentExtensionsConfig = {
+      project: '.claude',
+      global: '.claude-global-absent',
+      skillsEntryFile: 'SKILL.md',
+    };
+
+    const summary = await getExtensionsScanSummary(config, join(root, 'claude-project'));
+
+    expect(summary.project).toEqual({ agents: 1, commands: 1, skills: 1, hooks: 1, rules: 1 });
+    expect(summary.projectNames.agents).toEqual(['explorer']);
+    expect(summary.projectNames.commands).toEqual(['deploy']);
+    // skillsEntryFile makes the skill's directory name the reported name.
+    expect(summary.projectNames.skills).toEqual(['my-skill']);
+    expect(summary.projectNames.hooks).toEqual(['pre-commit.sh']);
+    expect(summary.projectNames.rules).toEqual(['style']);
+  });
+
+  it('counts same-named files in different subdirectories separately (Claude regression)', async () => {
+    // Regression guard: de-duplicating names across a single directory's
+    // recursive listing silently shrank commands_count / agents_count for every
+    // agent using namespaced subdirectories. Only cross-directory duplicates
+    // (the same extension under two spellings) may collapse.
+    const config: AgentExtensionsConfig = {
+      project: '.claude',
+      global: '.claude-global-absent',
+      skillsEntryFile: 'SKILL.md',
+    };
+
+    const summary = await getExtensionsScanSummary(config, join(root, 'claude-nested'));
+
+    expect(summary.project.commands).toBe(2);
+    expect(summary.project.agents).toBe(2);
+    expect(summary.projectNames.commands).toEqual(['build', 'build']);
+    expect(summary.projectNames.agents).toEqual(['review', 'review']);
+  });
+
+  it('scans singular directory names when the agent declares them', async () => {
+    const config: AgentExtensionsConfig = {
+      project: '.opencode',
+      skillsEntryFile: 'SKILL.md',
+      dirNames: {
+        agents: ['agent', 'agents'],
+        commands: ['command', 'commands'],
+        skills: ['skill', 'skills'],
+        hooks: ['plugin', 'plugins'],
+        rules: [],
+      },
+    };
+
+    const summary = await getExtensionsScanSummary(config, join(root, 'oc-project'));
+
+    expect(summary.project.agents).toBe(1);
+    expect(summary.project.commands).toBe(1);
+    expect(summary.project.skills).toBe(1);
+    // OpenCode has no hooks/ directory; plugins stand in for that slot.
+    expect(summary.project.hooks).toBe(1);
+    expect(summary.projectNames.hooks).toEqual(['telemetry.ts']);
+    // An empty dirNames list means the concept does not exist for this agent.
+    expect(summary.project.rules).toBe(0);
+  });
+
+  it('merges singular and plural directories without double counting', async () => {
+    const config: AgentExtensionsConfig = {
+      project: '.opencode',
+      dirNames: { agents: ['agent', 'agents'], hooks: ['plugin', 'plugins'] },
+    };
+
+    const summary = await getExtensionsScanSummary(config, join(root, 'oc-both'));
+
+    // 'reviewer' appears under both spellings but counts once.
+    expect(summary.projectNames.agents).toEqual(['reviewer', 'second']);
+    expect(summary.project.agents).toBe(2);
+    expect(summary.projectNames.hooks).toEqual(['extra.js']);
+  });
+
+  it('scans extra global roots alongside the primary one', async () => {
+    const config: AgentExtensionsConfig = {
+      global: join(root, 'global-xdg', 'opencode'),
+      extraGlobalDirs: [join(root, 'global-home', '.opencode')],
+      dirNames: { agents: ['agent', 'agents'] },
+    };
+
+    const summary = await getExtensionsScanSummary(config, root);
+
+    expect(summary.globalNames.agents).toEqual(['from-home', 'from-xdg']);
+    expect(summary.global.agents).toBe(2);
+  });
+
+  it('degrades to zeros for directories that do not exist', async () => {
+    const config: AgentExtensionsConfig = {
+      project: '.does-not-exist',
+      global: join(root, 'also-missing'),
+    };
+
+    const summary = await getExtensionsScanSummary(config, root);
+
+    expect(summary.project.agents).toBe(0);
+    expect(summary.global.agents).toBe(0);
+  });
+});

--- a/src/utils/__tests__/mcp-config.test.ts
+++ b/src/utils/__tests__/mcp-config.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for MCP config detection.
+ *
+ * Covers the multi-candidate `path` support added for OpenCode (which accepts
+ * both opencode.json and opencode.jsonc) and pins the single-path behaviour the
+ * other agents rely on.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getMCPConfigSummary } from '../mcp-config.js';
+import type { AgentMCPConfig } from '../../agents/core/types.js';
+
+let root: string;
+
+function writeJson(relativePath: string, value: unknown): void {
+  const full = join(root, relativePath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, typeof value === 'string' ? value : JSON.stringify(value));
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'codemie-mcp-'));
+
+  // Single-path, Claude-style project config.
+  writeJson('claude/.mcp.json', { mcpServers: { github: {}, jira: {} } });
+
+  // OpenCode keeps servers under a top-level `mcp` key.
+  writeJson('oc-json/opencode.json', { mcp: { fetch: {}, sonar: {} } });
+
+  // Only the .jsonc variant exists — the second candidate must be tried.
+  writeJson('oc-jsonc/opencode.jsonc', { mcp: { fetch: {} } });
+
+  // Both exist: the first candidate wins.
+  writeJson('oc-both/opencode.json', { mcp: { fromJson: {} } });
+  writeJson('oc-both/opencode.jsonc', { mcp: { fromJsonc: {} } });
+
+  // A .jsonc carrying comments cannot be JSON.parse'd; it must be skipped
+  // rather than throwing, and the next candidate should still be tried.
+  writeJson('oc-comments/opencode.jsonc', '{ // a comment\n "mcp": { "x": {} } }');
+  writeJson('oc-comments/opencode.json', { mcp: { recovered: {} } });
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('getMCPConfigSummary', () => {
+  it('returns an empty summary when the agent declares no MCP config', async () => {
+    const summary = await getMCPConfigSummary(undefined, root);
+
+    expect(summary.totalServers).toBe(0);
+    expect(summary.serverNames).toEqual([]);
+  });
+
+  it('reads a single string path unchanged', async () => {
+    const config: AgentMCPConfig = { project: { path: '.mcp.json', jsonPath: 'mcpServers' } };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'claude'));
+
+    expect(summary.projectServers).toBe(2);
+    expect(summary.totalServers).toBe(2);
+    expect(summary.serverNames).toEqual(['github', 'jira']);
+  });
+
+  it('reads the first candidate when several paths are declared', async () => {
+    const config: AgentMCPConfig = {
+      project: { path: ['opencode.json', 'opencode.jsonc'], jsonPath: 'mcp' },
+    };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'oc-json'));
+
+    expect(summary.serverNames).toEqual(['fetch', 'sonar']);
+  });
+
+  it('falls through to a later candidate when the first is absent', async () => {
+    const config: AgentMCPConfig = {
+      project: { path: ['opencode.json', 'opencode.jsonc'], jsonPath: 'mcp' },
+    };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'oc-jsonc'));
+
+    expect(summary.serverNames).toEqual(['fetch']);
+  });
+
+  it('prefers the earlier candidate when both exist', async () => {
+    const config: AgentMCPConfig = {
+      project: { path: ['opencode.json', 'opencode.jsonc'], jsonPath: 'mcp' },
+    };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'oc-both'));
+
+    expect(summary.serverNames).toEqual(['fromJson']);
+  });
+
+  it('skips an unparseable candidate and keeps going', async () => {
+    const config: AgentMCPConfig = {
+      project: { path: ['opencode.jsonc', 'opencode.json'], jsonPath: 'mcp' },
+    };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'oc-comments'));
+
+    expect(summary.serverNames).toEqual(['recovered']);
+  });
+
+  it('counts scopes independently and de-duplicates the combined name list', async () => {
+    const config: AgentMCPConfig = {
+      project: { path: 'opencode.json', jsonPath: 'mcp' },
+      user: { path: ['opencode.json'], jsonPath: 'mcp' },
+    };
+
+    const summary = await getMCPConfigSummary(config, join(root, 'oc-json'));
+
+    expect(summary.projectServers).toBe(2);
+    expect(summary.userServers).toBe(2);
+    expect(summary.totalServers).toBe(4);
+    // serverNames is the unique union across scopes.
+    expect(summary.serverNames).toEqual(['fetch', 'sonar']);
+  });
+});

--- a/src/utils/extensions-scan.ts
+++ b/src/utils/extensions-scan.ts
@@ -104,23 +104,69 @@ async function listScriptFiles(dirPath: string): Promise<string[]> {
 // Directory Scanning
 // ============================================================================
 
+/** Subdirectory names scanned per category when an agent declares no override. */
+const DEFAULT_DIR_NAMES: Required<NonNullable<AgentExtensionsConfig['dirNames']>> = {
+  agents: ['agents'],
+  commands: ['commands'],
+  skills: ['skills'],
+  hooks: ['hooks'],
+  rules: ['rules'],
+};
+
 /**
- * Scan an agent's extension base directory and return counts and names per category.
- * Each subdirectory (agents/, commands/, skills/, hooks/, rules/) is scanned independently.
+ * Merge per-directory results, dropping a name only when an EARLIER directory
+ * already supplied it.
  *
- * @param baseDir - Resolved absolute path to the agent's extensions base directory
- * @param skillsEntryFile - If set, only count/name skills files with this exact name (e.g. 'SKILL.md')
+ * De-duplication is deliberately across directories, never within one. A single
+ * directory is listed recursively, so `commands/a/build.md` and
+ * `commands/b/build.md` are two distinct extensions that both must count —
+ * flattening into one Set collapsed them and silently shrank commands_count /
+ * agents_count for every agent that uses namespaced subdirectories. Only the
+ * cross-directory case (the same extension found under two spellings, e.g.
+ * `agent/` and `agents/`) is a genuine duplicate.
  */
-async function scanExtensionsDir(
-  baseDir: string,
-  skillsEntryFile?: string
+function mergeNames(results: string[][]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const names of results) {
+    merged.push(...names.filter(name => !seen.has(name)));
+    for (const name of names) {
+      seen.add(name);
+    }
+  }
+
+  return merged.sort();
+}
+
+/**
+ * Scan an agent's extension base directories and return counts and names per category.
+ *
+ * Each category may map to several subdirectory names (see
+ * AgentExtensionsConfig.dirNames) and each scope may span several base
+ * directories; everything is scanned and merged, with names de-duplicated so an
+ * extension present under two spellings is not counted twice.
+ *
+ * @param baseDirs - Resolved absolute paths to scan for this scope
+ * @param config - The agent's extensions config (dirNames, skillsEntryFile)
+ */
+async function scanExtensionsDirs(
+  baseDirs: string[],
+  config: AgentExtensionsConfig
 ): Promise<{ counts: ExtensionsCount; names: ExtensionsNames }> {
+  const dirNames = { ...DEFAULT_DIR_NAMES, ...config.dirNames };
+  const { skillsEntryFile } = config;
+
+  /** Every (baseDir, subdirectory) pair to scan for one category. */
+  const targets = (category: keyof typeof dirNames): string[] =>
+    baseDirs.flatMap(baseDir => dirNames[category].map(name => path.join(baseDir, name)));
+
   const [agents, commands, skills, hooks, rules] = await Promise.all([
-    listMdFiles(path.join(baseDir, 'agents')),
-    listMdFiles(path.join(baseDir, 'commands')),
-    listMdFiles(path.join(baseDir, 'skills'), skillsEntryFile),
-    listScriptFiles(path.join(baseDir, 'hooks')),
-    listMdFiles(path.join(baseDir, 'rules')),
+    Promise.all(targets('agents').map(dir => listMdFiles(dir))).then(mergeNames),
+    Promise.all(targets('commands').map(dir => listMdFiles(dir))).then(mergeNames),
+    Promise.all(targets('skills').map(dir => listMdFiles(dir, skillsEntryFile))).then(mergeNames),
+    Promise.all(targets('hooks').map(dir => listScriptFiles(dir))).then(mergeNames),
+    Promise.all(targets('rules').map(dir => listMdFiles(dir))).then(mergeNames),
   ]);
 
   return {
@@ -131,13 +177,7 @@ async function scanExtensionsDir(
       hooks: hooks.length,
       rules: rules.length,
     },
-    names: {
-      agents: agents.sort(),
-      commands: commands.sort(),
-      skills: skills.sort(),
-      hooks: hooks.sort(),
-      rules: rules.sort(),
-    },
+    names: { agents, commands, skills, hooks, rules },
   };
 }
 
@@ -173,14 +213,20 @@ export async function getExtensionsScanSummary(
   }
 
   try {
-    const { skillsEntryFile } = extensionsConfig;
+    const resolveScope = (primary: string | undefined, extras: string[] | undefined): string[] =>
+      [primary, ...(extras ?? [])]
+        .filter((dir): dir is string => Boolean(dir))
+        .map(dir => resolveExtensionsPath(dir, cwd));
+
+    const projectDirs = resolveScope(extensionsConfig.project, extensionsConfig.extraProjectDirs);
+    const globalDirs = resolveScope(extensionsConfig.global, extensionsConfig.extraGlobalDirs);
 
     const [projectResult, globalResult] = await Promise.all([
-      extensionsConfig.project
-        ? scanExtensionsDir(resolveExtensionsPath(extensionsConfig.project, cwd), skillsEntryFile)
+      projectDirs.length > 0
+        ? scanExtensionsDirs(projectDirs, extensionsConfig)
         : Promise.resolve({ counts: { ...emptyCount }, names: { ...emptyNames } }),
-      extensionsConfig.global
-        ? scanExtensionsDir(resolveExtensionsPath(extensionsConfig.global, cwd), skillsEntryFile)
+      globalDirs.length > 0
+        ? scanExtensionsDirs(globalDirs, extensionsConfig)
         : Promise.resolve({ counts: { ...emptyCount }, names: { ...emptyNames } }),
     ]);
 

--- a/src/utils/mcp-config.ts
+++ b/src/utils/mcp-config.ts
@@ -150,15 +150,20 @@ async function readMCPFromSource(
     return [];
   }
 
-  const filePath = resolveConfigPath(source.path, cwd);
-  const config = await readJsonFile(filePath);
+  // Candidates are tried in order; the first file that exists AND parses wins.
+  // Note readJsonFile uses JSON.parse, so a .jsonc file carrying comments will
+  // not parse and is skipped like any other unreadable config.
+  const candidates = Array.isArray(source.path) ? source.path : [source.path];
 
-  if (!config) {
-    return [];
+  for (const candidate of candidates) {
+    const config = await readJsonFile(resolveConfigPath(candidate, cwd));
+    if (!config) continue;
+
+    const mcpServers = navigateJsonPath(config, source.jsonPath, cwd);
+    return extractServerNames(mcpServers);
   }
 
-  const mcpServers = navigateJsonPath(config, source.jsonPath, cwd);
-  return extractServerNames(mcpServers);
+  return [];
 }
 
 /**

--- a/tests/integration/metrics/fixtures/opencode/storage/part/msg-assistant-1/part-txt-reply.json
+++ b/tests/integration/metrics/fixtures/opencode/storage/part/msg-assistant-1/part-txt-reply.json
@@ -1,0 +1,7 @@
+{
+  "id": "part-txt-reply",
+  "sessionID": "test-session-1",
+  "messageID": "msg-assistant-1",
+  "type": "text",
+  "text": "Created src/test.ts with three console.log statements and read src/existing.ts."
+}

--- a/tests/integration/session/opencode-metrics-basic.test.ts
+++ b/tests/integration/session/opencode-metrics-basic.test.ts
@@ -22,7 +22,6 @@ import { fileURLToPath } from 'url';
 import { AgentRegistry } from '../../../src/agents/registry.js';
 import { SessionStore } from '../../../src/agents/core/session/SessionStore.js';
 import { getSessionMetricsPath } from '../../../src/agents/core/session/session-config.js';
-import { getCodemiePath } from '../../../src/utils/paths.js';
 import type { MetricDelta } from '../../../src/agents/core/metrics/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -52,6 +51,7 @@ async function processSessionViaAdapter(
     sessionId,
     agentSessionId: 'test-session-1',
     agentSessionFile: sessionFilePath,
+    gitBranch: 'feature/test-branch',
     provider: 'test-provider',
     apiBaseUrl: 'http://localhost:3000',
     cookies: {},
@@ -93,9 +93,7 @@ describe('OpenCode Metrics Processor - Basic Validation', () => {
   });
 
   afterAll(() => {
-    // Cleanup test files and cache
-    const cacheFile = join(getCodemiePath('cache', 'opencode'), `${TEST_SESSION_ID}_last_processed`);
-    [metricsFilePath, sessionFilePath, conversationFilePath, cacheFile].forEach(file => {
+    [metricsFilePath, sessionFilePath, conversationFilePath].forEach(file => {
       if (existsSync(file)) {
         try {
           unlinkSync(file);
@@ -213,14 +211,65 @@ describe('OpenCode Metrics Processor - Basic Validation', () => {
     }
   });
 
-  it('should have correct model information', () => {
+  it('should report the bare model id, matching codemie-claude', () => {
     const deltas = readMetricsFile(TEST_SESSION_ID);
 
-    for (const delta of deltas) {
-      expect(delta.models).toBeDefined();
-      expect(delta.models.length).toBeGreaterThan(0);
-      expect(delta.models[0]).toBe('anthropic/claude-sonnet-4-6');
+    // Only assistant-derived deltas carry a model; user-prompt deltas do not.
+    const withModels = deltas.filter(d => d.models && d.models.length > 0);
+    expect(withModels.length).toBeGreaterThan(0);
+
+    for (const delta of withModels) {
+      // No `anthropic/` provider prefix — codemie-claude sends a bare model id,
+      // and a prefix would split the same model across two analytics buckets.
+      expect(delta.models![0]).toBe('claude-sonnet-4-6');
     }
+  });
+
+  it('should attribute every delta to the branch from the processing context', () => {
+    const deltas = readMetricsFile(TEST_SESSION_ID);
+
+    expect(deltas.length).toBeGreaterThan(0);
+    for (const delta of deltas) {
+      // The aggregator groups on gitBranch; an empty value collapses every
+      // session into one nameless branch bucket.
+      expect(delta.gitBranch).toBe('feature/test-branch');
+    }
+  });
+
+  it('should give each tool call and prompt its own recordId', () => {
+    const deltas = readMetricsFile(TEST_SESSION_ID);
+
+    const recordIds = deltas.map(d => d.recordId);
+    expect(new Set(recordIds).size).toBe(recordIds.length);
+
+    // Tool deltas are keyed {messageId}:{callID}; prompts {messageId}:prompt.
+    expect(recordIds.some(id => id.endsWith(':prompt'))).toBe(true);
+    expect(recordIds.some(id => !id.endsWith(':prompt'))).toBe(true);
+  });
+
+  it('should aggregate into a tool-usage metric with a real session id and branch', async () => {
+    const { aggregateDeltas } = await import(
+      '../../../src/providers/plugins/sso/session/processors/metrics/metrics-aggregator.js'
+    );
+    const session = await sessionStore.loadSession(TEST_SESSION_ID);
+    const deltas = readMetricsFile(TEST_SESSION_ID);
+
+    const metrics = aggregateDeltas(deltas, session!, '1.0.0', 'codemie-opencode');
+
+    expect(metrics.length).toBe(1);
+    const attrs = metrics[0].attributes;
+
+    // The two headline regressions this work fixes.
+    expect(attrs.session_id).not.toBe('unknown');
+    expect(attrs.branch).toBe('feature/test-branch');
+
+    expect(attrs.llm_model).toBe('claude-sonnet-4-6');
+    expect(attrs.total_tool_calls).toBeGreaterThan(0);
+    expect(attrs.total_user_prompts).toBe(1);
+    expect(attrs.files_created).toBeGreaterThan(0);
+    // Parity guard: codemie-claude sends no token or cost fields anywhere.
+    expect(attrs).not.toHaveProperty('total_tokens');
+    expect(attrs).not.toHaveProperty('total_cost');
   });
 
   it('should have user prompts associated with deltas', () => {
@@ -256,29 +305,45 @@ describe('OpenCode Metrics Processor - Basic Validation', () => {
     }
   });
 
-  it.skip('should generate conversation JSONL', async () => {
-    // TODO: OpenCode conversations processor doesn't write JSONL yet (unlike Claude)
-    // This is a future enhancement - for now we're focused on metrics sync
-    // Once implemented, this test should verify:
-    // - Conversation file exists
-    // - Contains payload records with status 'pending'
-    // - Has correct structure (conversationId, history array)
+  it('should be idempotent when reprocessed by the incremental sync timer', async () => {
+    const before = readMetricsFile(TEST_SESSION_ID);
+
+    // The timer re-parses the same session every tick. Without stable per-record
+    // recordIds this would append the whole session again on every pass.
+    await processSessionViaAdapter(SESSION_FILE, TEST_SESSION_ID);
+
+    const after = readMetricsFile(TEST_SESSION_ID);
+    expect(after.length).toBe(before.length);
+    expect(after.map(d => d.recordId)).toEqual(before.map(d => d.recordId));
+  });
+
+  it('should queue a conversation payload for the sync processor', () => {
     expect(existsSync(conversationFilePath)).toBe(true);
 
-    const content = readFileSync(conversationFilePath, 'utf-8');
-    const lines = content.trim().split('\n').filter(line => line.length > 0);
-    expect(lines.length).toBeGreaterThan(0);
+    const lines = readFileSync(conversationFilePath, 'utf-8')
+      .trim().split('\n').filter(line => line.length > 0);
+    // Exactly one: the session was processed twice (see the idempotency test
+    // above) and the checkpoint sentinel must suppress the second queueing.
+    expect(lines.length).toBe(1);
 
-    // Parse conversation payloads
-    const payloads = lines.map(line => JSON.parse(line));
+    const record = JSON.parse(lines[0]);
 
-    // Verify structure
-    for (const payload of payloads) {
-      expect(payload).toHaveProperty('sessionId');
-      expect(payload).toHaveProperty('conversationHistory');
-      expect(payload).toHaveProperty('syncStatus');
-      expect(payload.sessionId).toBe(TEST_SESSION_ID);
-      expect(Array.isArray(payload.conversationHistory)).toBe(true);
-    }
+    expect(record.status).toBe('pending');
+    expect(record.payloadId).toContain('test-session-1@');
+    // Set explicitly so it never falls back to the 'Claude Desktop' default.
+    expect(record.payload.folder).toBe('opencode');
+    expect(record.payload.conversationId).toBe('test-session-1');
+    expect(record.payload.llmModel).toBe('claude-sonnet-4-6');
+
+    const history = record.payload.history;
+    expect(Array.isArray(history)).toBe(true);
+    expect(history.some((entry: any) => entry.role === 'User')).toBe(true);
+
+    const assistant = history.find((entry: any) => entry.role === 'Assistant');
+    expect(assistant).toBeDefined();
+    // Tool calls ride along as thoughts, not as visible history entries.
+    const toolThoughts = (assistant.thoughts ?? []).filter((t: any) => t.author_type === 'Tool');
+    expect(toolThoughts.length).toBe(2);
+    expect(toolThoughts.map((t: any) => t.author_name).sort()).toEqual(['Read', 'Write']);
   });
 });


### PR DESCRIPTION
## Summary

`codemie-opencode` sessions were largely invisible in CodeMie analytics: no `codemie_cli_session_total` rows at all, every tool-usage row shipped `session_id: "unknown"` with an empty `branch`, no conversation pipeline, and `active_duration_ms` / file line counts / `files_deleted` permanently `0`.

This routes the OpenCode session lifecycle through the same in-process `processEvent` path `codemie-claude` already uses, and adds an incremental sync that reads OpenCode's SQLite store read-only. All of the above now report real values through the existing upload machinery.

## Changes

- **Session lifecycle parity** — OpenCode sessions now emit `codemie_cli_session_total` `started`/`completed` pairs with a real `session_id`, `branch`, and `active_duration_ms`.
- **Incremental SQLite sync** — reads the live `opencode.db` read-only (`node:sqlite` `DatabaseSync`, `sqlite3 -readonly` fallback), checkpointing on a positional `sourceIndex` sentinel so a resumed session does not re-upload history.
- **Conversation pipeline** — OpenCode transcripts now flow into the conversations processor; conversations key on OpenCode's `ses_*` session id.
- **Real tool/file metrics** — tool-usage rows carry correct session correlation; diff line counts and `files_deleted` are computed instead of hardcoded `0`.
- **Hook merging** — a user profile defining its own `Stop` or `UserPromptSubmit` hook now merges with the telemetry hook instead of replacing it.

## Impact

**Behaviour change (user-visible): `codemie-opencode` now creates `.claude/skills/` in your project directory.**

One step of the shared `processEvent` path (`syncSkillsToClaude`) copies CodeMie-managed skills into `{cwd}/.claude/skills/`. OpenCode reads those skills, so this is intentional — but a project where you previously only ran `codemie-opencode` will now gain a `.claude/` directory it did not have before. Nothing is deleted or overwritten outside `.claude/skills/`.

**Deliberate non-parity** (documented, not oversights):

- No token or cost fields are captured anywhere, matching `codemie-claude`.
- `rules_*` is always `0` — OpenCode has no `rules/` concept.
- `hooks_*` counts OpenCode **plugins**, the closest equivalent extension point.
- Tool names stay lowercase (`read`) where Claude reports `Read` — normalize backend-side rather than renaming, which would destroy provenance.
- The lifecycle metric's `session_id` is the CodeMie session UUID, so the `started`/`completed` pair stays correlatable.

**Fixed while reviewing this change:**

- Extension scanning de-duplicated by filename across a single recursive listing, which **reduced `agents_count` / `commands_count` for claude, codex, gemini and kimi** when namespaced subdirectories held same-named files. De-duplication now applies only across directories.
- A detached hook child process had no `error` listener, so a failed spawn could raise an unhandled error event inside the host OpenCode process.
- Conversation payloads could be filed under two different conversation ids within one run, splitting history.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented) — see the `.claude/skills/` behaviour change under **Impact**

---

**Gates**: `typecheck` pass · `lint` 0 errors / 0 warnings · `build` pass · unit 2482 passed / 1 skipped · integration 210 passed / 1 skipped.

> Note: `npm run build` must precede `npm run test:integration` — a stale `dist/` produces 36 spurious `|cli|` subprocess failures.
