### PR TITLE
feat(proxy): enable stateless VS Code Responses

### DIFF
--- a/docs/ARCHITECTURE-PROXY.md
+++ b/docs/ARCHITECTURE-PROXY.md
@@ -716,12 +716,19 @@ The command reuses a healthy daemon when its profile, project, provider, target 
 
 The connector merges one managed model into VS Code's `chatLanguageModels.json` and preserves unrelated models plus an existing `${input:chat.lm.secret.*}` reference as `apiKey`. If no valid reference exists, it omits `apiKey` rather than generating a placeholder and directs the user to open `Chat: Manage Language Models`, right-click **CodeMie Profile Model**, and choose **Update API Key**. VS Code then stores the local `codemie-proxy` key in secret storage; CodeMie SSO credentials never enter VS Code configuration.
 
-GPT-5.5 and GPT-5.6 are routed through Chat Completions with `thinking: false` and no
-reasoning-effort metadata. This is an explicit compatibility tradeoff: the current
-CodeMie/LiteLLM Chat route rejects requests that combine tools with reasoning, while the
-Responses route can lose `previous_response_id` state across load-balanced follow-up requests.
-The models must remain non-reasoning in the VS Code catalog until one of those upstream
-limitations is resolved.
+GPT-5.5 and all three GPT-5.6 entries use `/v1/responses` with
+`zeroDataRetentionEnabled: true`, `thinking: true`, and Responses-format reasoning efforts. VS
+Code owns the complete conversation history for these entries and sends stateless requests with
+`store: false`, no `previous_response_id`, and replayed assistant, function-call, and
+function-call-output items. This keeps LiteLLM free to load-balance each request across Azure
+deployments.
+
+The proxy performs only bounded compatibility normalization for `vscode-byok`: it constrains the
+Responses `user` identifier and removes deployment-bound encrypted reasoning state. It preserves
+the selected `reasoning.effort`, visible messages, assistant phases, tools, call IDs, and tool
+outputs. The proxy does not persist conversation content, add session affinity, buffer Responses
+events, or transform the SSE stream. Removing encrypted state trades hidden-reasoning continuity
+for deployment-independent follow-ups, matching the established Codex compatibility behavior.
 
 ```mermaid
 sequenceDiagram
@@ -730,11 +737,12 @@ sequenceDiagram
     participant GW as CodeMie Gateway
     participant LM as Profile Model
 
-    VS->>PX: POST /v1/chat/completions<br/>model=&lt;selected-profile-model&gt;<br/>Bearer local gateway key
+    VS->>PX: POST /v1/responses<br/>store=false<br/>input=full local history<br/>Bearer local gateway key
     PX->>PX: Validate and strip local key
     PX->>PX: Inject CodeMie SSO cookies
     PX->>PX: Inject profile/project context headers
-    PX->>GW: Forward request body unchanged
+    PX->>PX: Normalize user and strip encrypted reasoning state
+    PX->>GW: Forward stateless request
     GW->>LM: Invoke configured model
     LM-->>GW: Streaming events / tool calls
     GW-->>PX: SSE stream

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -82,7 +82,7 @@ codemie proxy connect vscode --profile work
 codemie proxy connect vscode --insiders
 ```
 
-The connector resolves the selected profile once, synchronizes skills, and merges that profile's real model ID into VS Code's `User/chatLanguageModels.json`. VS Code sends the configured model ID directly; the proxy authenticates the request, adds CodeMie context headers, and forwards the request body unchanged.
+The connector resolves the selected profile once, synchronizes skills, and writes the managed CodeMie model catalog into VS Code's `User/chatLanguageModels.json`. VS Code sends the configured model ID directly; the proxy authenticates the request, adds CodeMie context headers, and applies only the documented compatibility normalization before forwarding.
 
 `--profile <name>` is a one-command override and does not change the active CodeMie profile. Model and project remain independent: the model is written into VS Code configuration, while `codeMieProject` is passed to the daemon and emitted as `X-CodeMie-Project`. When a selected profile has no project of its own, compatible repository-local project context continues to apply through the standard profile merge rules.
 
@@ -101,7 +101,7 @@ Reload VS Code, then select a CodeMie model from the model picker
 
 VS Code stores that local key in its secret storage and adds the reference to the configuration. The CLI cannot inspect whether an existing secret reference still resolves; if VS Code reports a missing or invalid key, use **Update API Key** again.
 
-The managed provider has this effective structure. The port is taken from the running daemon, including a fallback port:
+The managed provider has this effective structure for a GPT-5.6 Responses entry. The port is taken from the running daemon, including a fallback port; other catalog entries retain their model-specific API type and capabilities:
 
 ```json
 [
@@ -111,22 +111,26 @@ The managed provider has this effective structure. The port is taken from the ru
     "apiType": "chat-completions",
     "models": [
       {
-        "id": "<selected-profile-model>",
-        "name": "CodeMie Profile Model",
-        "url": "http://127.0.0.1:4001/v1/chat/completions",
+        "id": "gpt-5.6-sol-2026-07-09",
+        "name": "gpt-5.6-sol-2026-07-09",
+        "url": "http://127.0.0.1:4001/v1/responses",
+        "apiType": "responses",
         "toolCalling": true,
         "vision": true,
         "streaming": true,
         "thinking": true,
+        "zeroDataRetentionEnabled": true,
         "supportsReasoningEffort": [
-          "minimal",
+          "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh",
+          "max"
         ],
-        "reasoningEffortFormat": "chat-completions",
-        "maxInputTokens": 224000,
-        "maxOutputTokens": 32000
+        "reasoningEffortFormat": "responses",
+        "maxInputTokens": 922000,
+        "maxOutputTokens": 128000
       }
     ]
   }
@@ -140,13 +144,19 @@ unrelated providers, models, settings, and unknown provider properties. It rejec
 or a non-array root without overwriting the file. Re-running the command with another profile
 replaces the previous CodeMie-managed model without changing unrelated entries.
 
-GPT-5.5 and GPT-5.6 are deliberate exceptions: the connector routes them through Chat Completions
-but publishes `thinking: false` and omits reasoning-effort metadata. The current CodeMie/LiteLLM
-route rejects Chat Completions requests that combine tool calling with reasoning. Responses API
-reasoning is not used as a fallback because load-balanced follow-up requests can fail when the
-referenced `previous_response_id` is unavailable. Keep thinking disabled for these models until
-the upstream Chat route accepts tools with reasoning or the Responses route provides reliable
-response-state continuity.
+GPT-5.5 and all three GPT-5.6 entries use the Responses API with
+`zeroDataRetentionEnabled: true` and Responses-format reasoning. Current VS Code builds use this
+flag to construct each request from the complete conversation held locally, send `store: false`,
+omit `previous_response_id`, and replay assistant, function-call, and function-call-output items.
+Use `medium` as the initial baseline; `none`, lower efforts, and `xhigh`/`max` remain selectable
+according to each model's advertised capability list.
+
+The proxy does not cache conversation state or rewrite response streams. Its bounded compatibility
+layer adds a safe `user` value when needed, limits long identifiers to 32 characters, and removes
+deployment-bound encrypted reasoning content for `vscode-byok`. This preserves the selected
+`reasoning.effort`, visible assistant history, and tool-call history, at the cost of cross-turn
+hidden-reasoning continuity. Prefer a current VS Code release (1.122 or newer) so the stateless
+flag and marker suppression are honored.
 
 Check the daemon context with `codemie proxy status`. Automated VS Code BYOK configuration
 and routing coverage runs as part of `npm run test:all`.
@@ -163,7 +173,10 @@ and routing coverage runs as part of `npm run test:all`.
 | Configuration is rejected | `chatLanguageModels.json` is malformed or not an array | Repair the file; the connector leaves invalid content unchanged |
 | VS Code still uses old settings | Model configuration was not reloaded | Reload VS Code |
 | Active profile changed but model did not | VS Code configuration still contains the previous profile model | Re-run `codemie proxy connect vscode` |
-| GPT-5.5 or GPT-5.6 fails when thinking is enabled | Current Chat route rejects tools combined with reasoning | Keep thinking disabled; the managed catalog intentionally omits reasoning controls |
+| `previous_response_id` appears in a VS Code request | VS Code is older than the stateless Responses implementation or has stale model metadata | Upgrade to a current VS Code release, re-run the connector, reload VS Code, and verify `store: false` plus no `previous_response_id` in Chat Debug logs |
+| `previous_response_not_found` occurs on a follow-up | The client is still using stateful Responses replay | Complete the compatibility check above; do not add proxy-side response caching or deployment affinity |
+| `invalid_encrypted_content` occurs on a follow-up | Encrypted reasoning state reached a different deployment or the sanitizer is not active | Use the current proxy, confirm the `vscode-byok` sanitizer is enabled, and retry without sharing encrypted reasoning content in logs |
+| An effort value is rejected | The selected effort is not supported by that model/deployment | Choose an advertised effort (`none`, `low`, `medium`, `high`, `xhigh`, or `max` as listed for the model) and certify the deployment before broad rollout |
 | Inline suggestions still use Copilot | Expected limitation | BYOK covers chat/agent workflows, not inline completion |
 
 ### Claude Desktop 3P

--- a/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
@@ -98,11 +98,14 @@ describe('writeVsCodeLanguageModelsConfigAtPath', () => {
         apiType: definition.apiType,
         toolCalling: true,
         vision: definition.vision,
-        streaming: true,
-        thinking: definition.thinking,
-        maxInputTokens: definition.maxInputTokens,
-        maxOutputTokens: definition.maxOutputTokens,
-      };
+      streaming: true,
+      thinking: definition.thinking,
+      maxInputTokens: definition.maxInputTokens,
+      maxOutputTokens: definition.maxOutputTokens,
+    };
+      if (definition.zeroDataRetentionEnabled !== undefined) {
+        expected.zeroDataRetentionEnabled = definition.zeroDataRetentionEnabled;
+      }
       if (definition.adaptiveThinking) expected.adaptiveThinking = true;
       if (definition.modelOptions) expected.modelOptions = definition.modelOptions;
       if (definition.requestHeaders) expected.requestHeaders = definition.requestHeaders;
@@ -135,26 +138,51 @@ describe('writeVsCodeLanguageModelsConfigAtPath', () => {
     }
   });
 
-  it('disables thinking for GPT-5.5 and GPT-5.6 Chat Completions models', async () => {
+  it('renders stateless Responses reasoning capabilities for GPT-5.5 and GPT-5.6', async () => {
     await writeVsCodeLanguageModelsConfigAtPath(configPath, 'http://127.0.0.1:4001');
 
     const providers = await readProviders();
     const models = providers[0].models as Array<Record<string, unknown>>;
-    const affectedIds = [
-      'gpt-5.5-2026-04-24',
-      'gpt-5.6-luna-2026-07-09',
-      'gpt-5.6-sol-2026-07-09',
-      'gpt-5.6-terra-2026-07-09',
-    ];
+    const expectedEfforts = new Map([
+      ['gpt-5.5-2026-04-24', ['none', 'low', 'medium', 'high', 'xhigh']],
+      ['gpt-5.6-luna-2026-07-09', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+      ['gpt-5.6-sol-2026-07-09', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+      ['gpt-5.6-terra-2026-07-09', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+    ]);
 
-    for (const id of affectedIds) {
+    for (const [id, efforts] of expectedEfforts) {
       const model = models.find(candidate => candidate.id === id);
       expect(model).toMatchObject({
-        apiType: 'chat-completions',
-        thinking: false,
+        apiType: 'responses',
+        url: 'http://127.0.0.1:4001/v1/responses',
+        zeroDataRetentionEnabled: true,
+        thinking: true,
+        supportsReasoningEffort: efforts,
+        reasoningEffortFormat: 'responses',
       });
-      expect(model).not.toHaveProperty('supportsReasoningEffort');
-      expect(model).not.toHaveProperty('reasoningEffortFormat');
+    }
+  });
+
+  it('requires every Responses catalog entry to enable stateless mode', () => {
+    const responsesModels = VS_CODE_SUPPORTED_MODELS.filter(
+      definition => definition.apiType === 'responses'
+    );
+
+    expect(responsesModels.length).toBeGreaterThan(0);
+    for (const definition of responsesModels) {
+      expect(definition.zeroDataRetentionEnabled).toBe(true);
+    }
+  });
+
+  it('requires effort metadata for every thinking-enabled Responses entry', () => {
+    const responsesModels = VS_CODE_SUPPORTED_MODELS.filter(
+      definition => definition.apiType === 'responses' && definition.thinking
+    );
+
+    expect(responsesModels.length).toBeGreaterThan(0);
+    for (const definition of responsesModels) {
+      expect(definition.supportsReasoningEffort?.length).toBeGreaterThan(0);
+      expect(definition.reasoningEffortFormat).toBe('responses');
     }
   });
 

--- a/src/cli/commands/proxy/connectors/vscode-models.ts
+++ b/src/cli/commands/proxy/connectors/vscode-models.ts
@@ -14,6 +14,7 @@ export interface VsCodeModelDefinition {
   apiType: VsCodeApiType;
   vision: boolean;
   thinking: boolean;
+  zeroDataRetentionEnabled?: boolean;
   adaptiveThinking?: true;
   modelOptions?: Readonly<{
     temperature?: number | null;
@@ -29,6 +30,7 @@ export interface VsCodeModelDefinition {
 const GPT_5_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
 const GPT_5_2_EFFORTS = ['none', 'low', 'medium', 'high'] as const;
 const GPT_5_XHIGH_EFFORTS = ['none', 'low', 'medium', 'high', 'xhigh'] as const;
+const GPT_5_6_EFFORTS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 const GEMINI_FLASH_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
 const GEMINI_PRO_EFFORTS = ['low', 'medium', 'high'] as const;
 const CLAUDE_EFFORTS = ['low', 'medium', 'high'] as const;
@@ -114,39 +116,51 @@ export const VS_CODE_SUPPORTED_MODELS: readonly VsCodeModelDefinition[] = [
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
-  // GPT-5.5/5.6 use Chat Completions to avoid Responses API follow-up failures
-  // caused by missing previous_response_id state. The current CodeMie/LiteLLM
-  // route rejects Chat requests that combine tools with reasoning, so thinking
-  // stays disabled and reasoning-effort metadata is intentionally omitted.
+  // VS Code's zero-data-retention Responses mode replays the complete local
+  // conversation with store=false and without previous_response_id. The proxy
+  // strips deployment-bound encrypted reasoning state while preserving the
+  // selected effort and visible/tool history for load-balanced continuations.
   {
     id: 'gpt-5.5-2026-04-24',
-    apiType: 'chat-completions',
+    apiType: 'responses',
     vision: true,
-    thinking: false,
+    thinking: true,
+    zeroDataRetentionEnabled: true,
+    supportsReasoningEffort: GPT_5_XHIGH_EFFORTS,
+    reasoningEffortFormat: 'responses',
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
   {
     id: 'gpt-5.6-luna-2026-07-09',
-    apiType: 'chat-completions',
+    apiType: 'responses',
     vision: true,
-    thinking: false,
+    thinking: true,
+    zeroDataRetentionEnabled: true,
+    supportsReasoningEffort: GPT_5_6_EFFORTS,
+    reasoningEffortFormat: 'responses',
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
   {
     id: 'gpt-5.6-sol-2026-07-09',
-    apiType: 'chat-completions',
+    apiType: 'responses',
     vision: true,
-    thinking: false,
+    thinking: true,
+    zeroDataRetentionEnabled: true,
+    supportsReasoningEffort: GPT_5_6_EFFORTS,
+    reasoningEffortFormat: 'responses',
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },
   {
     id: 'gpt-5.6-terra-2026-07-09',
-    apiType: 'chat-completions',
+    apiType: 'responses',
     vision: true,
-    thinking: false,
+    thinking: true,
+    zeroDataRetentionEnabled: true,
+    supportsReasoningEffort: GPT_5_6_EFFORTS,
+    reasoningEffortFormat: 'responses',
     maxInputTokens: 922000,
     maxOutputTokens: 128000,
   },

--- a/src/cli/commands/proxy/connectors/vscode.ts
+++ b/src/cli/commands/proxy/connectors/vscode.ts
@@ -30,6 +30,7 @@ interface VsCodeManagedModel {
   vision: boolean;
   streaming: true;
   thinking: boolean;
+  zeroDataRetentionEnabled?: boolean;
   adaptiveThinking?: true;
   modelOptions?: Readonly<{
     temperature?: number | null;
@@ -119,6 +120,9 @@ function buildManagedModels(proxyUrl: string): VsCodeManagedModel[] {
     };
 
     if (definition.adaptiveThinking) model.adaptiveThinking = true;
+    if (definition.zeroDataRetentionEnabled !== undefined) {
+      model.zeroDataRetentionEnabled = definition.zeroDataRetentionEnabled;
+    }
     if (definition.modelOptions) model.modelOptions = definition.modelOptions;
     if (definition.requestHeaders) model.requestHeaders = definition.requestHeaders;
     if (definition.supportsReasoningEffort) {

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/codex-encrypted-content-sanitizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/codex-encrypted-content-sanitizer.plugin.test.ts
@@ -2,7 +2,7 @@
  * Codex Encrypted Content Sanitizer Plugin Tests
  *
  * Tests agent-scoping and functional encrypted-content removal for
- * codemie-codex, codemie-code, and codemie-opencode agents.
+ * codemie-codex, codemie-code, codemie-opencode, and vscode-byok agents.
  *
  * @group unit
  */
@@ -74,6 +74,11 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
 
     it('creates interceptor for codemie-opencode', async () => {
       const interceptor = await plugin.createInterceptor(createPluginContext('codemie-opencode'));
+      expect(interceptor).toBeDefined();
+    });
+
+    it('creates interceptor for vscode-byok', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
       expect(interceptor).toBeDefined();
     });
 
@@ -164,6 +169,68 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
 
       const result = JSON.parse(context.requestBody!.toString('utf-8'));
       expect(result.input).toHaveLength(0);
+    });
+  });
+
+  describe('Encrypted content removal — vscode-byok', () => {
+    it('removes encrypted state while preserving reasoning effort and visible tool history', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
+      const visibleItems = [
+        { type: 'message', role: 'user', content: 'hello' },
+        {
+          type: 'message',
+          role: 'assistant',
+          phase: 'commentary',
+          content: [{ type: 'output_text', text: 'I will call the tool.' }],
+        },
+        {
+          type: 'function_call',
+          call_id: 'call-1',
+          name: 'get_test_value',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call-1',
+          output: 'ready',
+        },
+      ];
+      const body = {
+        model: 'gpt-5.6-sol-2026-07-09',
+        reasoning: { effort: 'medium' },
+        include: ['reasoning.encrypted_content', 'usage'],
+        input: [
+          visibleItems[0],
+          { type: 'reasoning', summary: [], encrypted_content: 'deployment-bound-state' },
+          ...visibleItems.slice(1),
+        ],
+      };
+      const context = createProxyContext(body);
+      const originalLength = Number(context.headers['content-length']);
+
+      await interceptor.onRequest!(context);
+
+      const result = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(result.reasoning).toEqual({ effort: 'medium' });
+      expect(result.include).toEqual(['usage']);
+      expect(result.input).toEqual(visibleItems);
+      expect(result.input).not.toContainEqual(
+        expect.objectContaining({ type: 'reasoning', encrypted_content: expect.any(String) })
+      );
+      expect(result.input[1]).toMatchObject({
+        role: 'assistant',
+        phase: 'commentary',
+      });
+      expect(result.input[2]).toMatchObject({
+        type: 'function_call',
+        call_id: 'call-1',
+      });
+      expect(result.input[3]).toMatchObject({
+        type: 'function_call_output',
+        call_id: 'call-1',
+      });
+      expect(Number(context.headers['content-length'])).toBe(context.requestBody!.length);
+      expect(Number(context.headers['content-length'])).toBeLessThan(originalLength);
     });
   });
 });

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/vscode-request-normalizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/vscode-request-normalizer.plugin.test.ts
@@ -1,0 +1,202 @@
+/**
+ * VS Code request normalizer plugin tests
+ *
+ * @group unit
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { VsCodeRequestNormalizerPlugin } from '../vscode-request-normalizer.plugin.js';
+import type { PluginContext, ProxyInterceptor } from '../types.js';
+import type { ProxyContext } from '../../proxy-types.js';
+import { logger } from '../../../../../../utils/logger.js';
+
+interface ProxyContextOptions {
+  body?: unknown;
+  rawBody?: Buffer | null;
+  contentType?: string;
+  url?: string;
+}
+
+function createPluginContext(clientType?: string): PluginContext {
+  return {
+    config: {
+      targetApiUrl: 'https://api.example.com',
+      provider: 'test',
+      sessionId: 'test-session',
+      clientType,
+    },
+    logger,
+  };
+}
+
+function createProxyContext(options: ProxyContextOptions = {}): ProxyContext {
+  const requestBody = options.rawBody !== undefined
+    ? options.rawBody
+    : options.body === undefined
+      ? null
+      : Buffer.from(JSON.stringify(options.body), 'utf-8');
+  const headers: Record<string, string> = {
+    'content-type': options.contentType ?? 'application/json',
+  };
+  if (requestBody) headers['content-length'] = String(requestBody.length);
+
+  return {
+    requestId: 'test-req',
+    sessionId: 'test-session',
+    agentName: 'test-agent',
+    method: 'POST',
+    url: options.url ?? '/v1/responses',
+    headers,
+    requestBody,
+    requestStartTime: Date.now(),
+    metadata: {},
+  };
+}
+
+function readBody(context: ProxyContext): Record<string, unknown> {
+  return JSON.parse(context.requestBody!.toString('utf-8')) as Record<string, unknown>;
+}
+
+describe('VsCodeRequestNormalizerPlugin', () => {
+  let plugin: VsCodeRequestNormalizerPlugin;
+
+  beforeEach(() => {
+    plugin = new VsCodeRequestNormalizerPlugin();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createInterceptor — client scoping', () => {
+    it('creates an interceptor only for vscode-byok', async () => {
+      const interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
+
+      expect(interceptor.name).toBe('vscode-request-normalizer');
+    });
+
+    it.each(['codemie-code', 'codemie-codex', undefined])(
+      'rejects non-VS Code client type %s',
+      async clientType => {
+        await expect(plugin.createInterceptor(createPluginContext(clientType)))
+          .rejects.toThrow(`Plugin disabled for agent: ${clientType}`);
+      }
+    );
+  });
+
+  describe('request normalization', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
+    });
+
+    it('ignores non-Responses URLs, non-JSON bodies, missing bodies, and invalid JSON', async () => {
+      const cases: ProxyContextOptions[] = [
+        { url: '/v1/chat/completions', body: {} },
+        { contentType: 'text/plain', body: '{}' },
+        { rawBody: null },
+        { rawBody: Buffer.from('{invalid-json', 'utf-8') },
+      ];
+
+      for (const options of cases) {
+        const context = createProxyContext(options);
+        const originalBody = context.requestBody;
+        const originalLength = context.headers['content-length'];
+
+        await interceptor.onRequest!(context);
+
+        expect(context.requestBody).toBe(originalBody);
+        expect(context.headers['content-length']).toBe(originalLength);
+      }
+    });
+
+    it.each([
+      ['absent', {}],
+      ['empty', { user: '' }],
+      ['non-string', { user: 42 }],
+    ])('adds the fallback user for an %s field', async (_label, body) => {
+      const context = createProxyContext({ body });
+
+      await interceptor.onRequest!(context);
+
+      expect(readBody(context).user).toBe('vscode-byok');
+    });
+
+    it.each([
+      'short-user',
+      'x'.repeat(32),
+    ])('preserves an existing user identifier of 32 characters or fewer', async user => {
+      const context = createProxyContext({ body: { user } });
+      const originalBody = context.requestBody;
+      const originalLength = context.headers['content-length'];
+
+      await interceptor.onRequest!(context);
+
+      expect(readBody(context).user).toBe(user);
+      expect(context.requestBody).toBe(originalBody);
+      expect(context.headers['content-length']).toBe(originalLength);
+    });
+
+    it('hashes an overlength identifier to a stable lowercase 32-character digest', async () => {
+      const user = 'user-with-more-than-thirty-two-characters';
+      const expected = createHash('sha256')
+        .update(user, 'utf-8')
+        .digest('hex')
+        .slice(0, 32);
+      const firstContext = createProxyContext({ body: { user } });
+      const secondContext = createProxyContext({ body: { user } });
+
+      await interceptor.onRequest!(firstContext);
+      await interceptor.onRequest!(secondContext);
+
+      const firstHash = String(readBody(firstContext).user);
+      const secondHash = String(readBody(secondContext).user);
+      expect(firstHash).toBe(expected);
+      expect(firstHash).toBe(secondHash);
+      expect(firstHash).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('produces different hashes without logging overlength identifiers', async () => {
+      const firstUser = 'first-user-with-more-than-thirty-two-characters';
+      const secondUser = 'second-user-with-more-than-thirty-two-characters';
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const firstContext = createProxyContext({ body: { user: firstUser } });
+      const secondContext = createProxyContext({ body: { user: secondUser } });
+
+      await interceptor.onRequest!(firstContext);
+      await interceptor.onRequest!(secondContext);
+
+      expect(readBody(firstContext).user).not.toBe(readBody(secondContext).user);
+      const logText = debugSpy.mock.calls
+        .flatMap(call => call.map(argument => String(argument)))
+        .join(' ');
+      expect(logText).not.toContain(firstUser);
+      expect(logText).not.toContain(secondUser);
+    });
+
+    it.each([
+      '/v1/responses',
+      '/proxy/v1/responses?trace=test',
+      '/proxy/v1/responses/',
+    ])('normalizes Responses URL variants consistently: %s', async url => {
+      const context = createProxyContext({ url, body: { model: 'test-model' } });
+
+      await interceptor.onRequest!(context);
+
+      expect(readBody(context).user).toBe('vscode-byok');
+    });
+
+    it('updates content-length exactly when the request body changes', async () => {
+      const context = createProxyContext({ body: { model: 'test-model', user: '' } });
+
+      await interceptor.onRequest!(context);
+
+      expect(context.headers['content-length']).toBe(String(context.requestBody!.length));
+      expect(context.headers['content-length']).toBe(
+        String(Buffer.byteLength(context.requestBody!.toString('utf-8'), 'utf-8'))
+      );
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts
@@ -9,19 +9,25 @@
  * it removes encrypted reasoning state so the session can continue instead of
  * failing with invalid_encrypted_content.
  *
- * Scope: codemie-codex, codemie-code, codemie-opencode. Widened from codex-only
- * to cover all Responses-API sessions — affects gpt-5.2, gpt-5.3-codex, gpt-5.5,
- * and any other Responses-path models. Tradeoff: drops cross-turn reasoning
- * continuity (encrypted state stripped) to avoid hard invalid_encrypted_content
- * failures — the same tradeoff already accepted for Codex. If server-side
- * encrypted_content_affinity becomes available, this client strip becomes redundant.
+ * Scope: codemie-codex, codemie-code, codemie-opencode, and vscode-byok. This
+ * cross-client fallback covers Responses-API sessions when load balancing can
+ * send encrypted state to a different deployment/API key. Tradeoff: drops
+ * cross-turn hidden-reasoning continuity to avoid hard invalid_encrypted_content
+ * failures while preserving effort, visible messages, and tool history. If
+ * server-side encrypted_content_affinity becomes available, this client strip
+ * becomes redundant.
  */
 
 import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
 import { ProxyContext } from '../proxy-types.js';
 import { logger } from '../../../../../utils/logger.js';
 
-const ALLOWED_AGENTS = ['codemie-codex', 'codemie-code', 'codemie-opencode'];
+const ALLOWED_AGENTS = [
+  'codemie-codex',
+  'codemie-code',
+  'codemie-opencode',
+  'vscode-byok',
+];
 const ENCRYPTED_CONTENT_INCLUDE = 'reasoning.encrypted_content';
 
 interface SanitizeResult {

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -36,7 +36,7 @@ export function registerCorePlugins(): void {
   registry.register(new ClaudeRequestNormalizerPlugin()); // Priority 14 - normalizes thinking params for claude models
   registry.register(new KimiRequestNormalizerPlugin()); // Priority 14 - caps Kimi output token requests for upstream limits
   registry.register(new RequestSanitizerPlugin()); // Priority 15 - strips unsupported reasoning params
-  registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - strips encrypted reasoning state for Codex
+  registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - strips deployment-bound encrypted Responses reasoning state
   registry.register(new VsCodeRequestNormalizerPlugin()); // Priority 17 - constrains VS Code user identifiers
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level

--- a/tests/integration/vscode-byok.test.ts
+++ b/tests/integration/vscode-byok.test.ts
@@ -23,6 +23,12 @@ import {
   HeaderInjectionPlugin,
 } from '../../src/providers/plugins/sso/proxy/plugins/header-injection.plugin.js';
 import {
+  CodexEncryptedContentSanitizerPlugin,
+} from '../../src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.js';
+import {
+  VsCodeRequestNormalizerPlugin,
+} from '../../src/providers/plugins/sso/proxy/plugins/vscode-request-normalizer.plugin.js';
+import {
   getPluginRegistry,
   resetPluginRegistry,
 } from '../../src/providers/plugins/sso/proxy/plugins/registry.js';
@@ -46,6 +52,10 @@ interface LanguageModel {
   name: string;
   url: string;
   apiType: string;
+  thinking?: boolean;
+  zeroDataRetentionEnabled?: boolean;
+  supportsReasoningEffort?: readonly string[];
+  reasoningEffortFormat?: string;
 }
 
 interface LanguageModelProvider {
@@ -81,6 +91,7 @@ function buildRequestBody(
   if (definition.apiType === 'responses') {
     return {
       model: definition.id,
+      store: false,
       stream: false,
       input: [{ role: 'user', content: 'Call get_test_value.' }],
       tools: [{
@@ -145,6 +156,32 @@ function buildVsCodeAuthHeaders(
   return { authorization: `Bearer ${GATEWAY_KEY}` };
 }
 
+function registerVsCodePipeline(): void {
+  const registry = getPluginRegistry();
+  registry.register(new GatewayKeyPlugin());
+  registry.register(new HeaderInjectionPlugin());
+  registry.register(new CodexEncryptedContentSanitizerPlugin());
+  registry.register(new VsCodeRequestNormalizerPlugin());
+}
+
+async function startVsCodeProxy(targetApiUrl: string): Promise<{
+  proxy: CodeMieProxy;
+  url: string;
+}> {
+  registerVsCodePipeline();
+  const proxy = new CodeMieProxy({
+    targetApiUrl,
+    host: '127.0.0.1',
+    port: 0,
+    provider: 'test-provider',
+    gatewayKey: GATEWAY_KEY,
+    clientType: 'vscode-byok',
+    project: 'test-project',
+  });
+  const started = await proxy.start();
+  return { proxy, url: started.url };
+}
+
 describe('VS Code BYOK model matrix', () => {
   const proxies: CodeMieProxy[] = [];
   const servers: Server[] = [];
@@ -178,20 +215,8 @@ describe('VS Code BYOK model matrix', () => {
     }));
     servers.push(upstream.server);
 
-    const registry = getPluginRegistry();
-    registry.register(new GatewayKeyPlugin());
-    registry.register(new HeaderInjectionPlugin());
-    const proxy = new CodeMieProxy({
-      targetApiUrl: upstream.url,
-      host: '127.0.0.1',
-      port: 0,
-      provider: 'test-provider',
-      gatewayKey: GATEWAY_KEY,
-      clientType: 'vscode-byok',
-      project: 'test-project',
-    });
-    proxies.push(proxy);
-    const startedProxy = await proxy.start();
+    const startedProxy = await startVsCodeProxy(upstream.url);
+    proxies.push(startedProxy.proxy);
 
     const configPath = join(testDir, 'User', 'chatLanguageModels.json');
     await writeVsCodeLanguageModelsConfigAtPath(configPath, startedProxy.url);
@@ -212,6 +237,14 @@ describe('VS Code BYOK model matrix', () => {
         name: definition.id,
         apiType: definition.apiType,
       });
+      if (definition.apiType === 'responses') {
+        expect(configuredModel).toMatchObject({
+          thinking: true,
+          zeroDataRetentionEnabled: true,
+          supportsReasoningEffort: definition.supportsReasoningEffort,
+          reasoningEffortFormat: 'responses',
+        });
+      }
 
       const efforts: ReadonlyArray<VsCodeReasoningEffort | undefined> =
         [undefined, ...(definition.supportsReasoningEffort ?? [])];
@@ -231,7 +264,10 @@ describe('VS Code BYOK model matrix', () => {
 
         const forwarded = captured.at(-1);
         expect(forwarded?.url).toBe(new URL(String(configuredModel?.url)).pathname);
-        expect(forwarded?.body).toEqual(requestBody);
+        const expectedBody = definition.apiType === 'responses'
+          ? { ...requestBody, user: 'vscode-byok' }
+          : requestBody;
+        expect(forwarded?.body).toEqual(expectedBody);
         expect(forwarded?.headers.authorization).toBeUndefined();
         expect(forwarded?.headers['x-api-key']).toBeUndefined();
         expect(forwarded?.headers['x-codemie-client']).toBe('vscode-byok');
@@ -239,5 +275,82 @@ describe('VS Code BYOK model matrix', () => {
         expect(forwarded?.headers['x-codemie-cli-model']).toBeUndefined();
       }
     }
+  });
+
+  it('strips encrypted Responses state while preserving stateless reasoning and tool history', async () => {
+    const captured: CapturedRequest[] = [];
+    const upstream = await listen(createServer((req, res) => {
+      void readRequestBody(req).then((body) => {
+        captured.push({
+          url: req.url ?? '/',
+          headers: req.headers,
+          body,
+        });
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+      });
+    }));
+    servers.push(upstream.server);
+
+    const startedProxy = await startVsCodeProxy(upstream.url);
+    proxies.push(startedProxy.proxy);
+    const input = [
+      { type: 'message', role: 'user', content: 'Call the test tool.' },
+      {
+        type: 'reasoning',
+        summary: [],
+        encrypted_content: 'deployment-bound-state',
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        phase: 'commentary',
+        content: [{ type: 'output_text', text: 'Calling the tool.' }],
+      },
+      {
+        type: 'function_call',
+        call_id: 'call-1',
+        name: 'get_test_value',
+        arguments: '{}',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call-1',
+        output: 'ready',
+      },
+    ];
+    const requestBody = {
+      model: 'gpt-5.6-sol-2026-07-09',
+      store: false,
+      stream: false,
+      reasoning: { effort: 'medium' },
+      include: ['reasoning.encrypted_content', 'usage'],
+      input,
+      tools: [{ type: 'function', name: 'get_test_value' }],
+    };
+
+    const response = await fetch(`${startedProxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${GATEWAY_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+
+    const expectedBody = {
+      ...requestBody,
+      include: ['usage'],
+      input: input.filter(item => item.type !== 'reasoning'),
+      user: 'vscode-byok',
+    };
+    expect(captured[0]?.body).toEqual(expectedBody);
+    expect(captured[0]?.body).not.toHaveProperty('previous_response_id');
+    expect(captured[0]?.headers['content-length']).toBe(
+      String(Buffer.byteLength(JSON.stringify(expectedBody), 'utf-8'))
+    );
   });
 });

--- a/tests/integration/vscode-models.live.test.ts
+++ b/tests/integration/vscode-models.live.test.ts
@@ -43,6 +43,12 @@ const ALL_EFFORTS: readonly VsCodeReasoningEffort[] = [
   'xhigh',
   'max',
 ];
+const STATELESS_RESPONSES_MODEL_IDS = new Set([
+  'gpt-5.5-2026-04-24',
+  'gpt-5.6-luna-2026-07-09',
+  'gpt-5.6-sol-2026-07-09',
+  'gpt-5.6-terra-2026-07-09',
+]);
 const DEFAULT_REPORT_PATH = resolve('reports/vscode-model-certification.md');
 
 interface LiveConfiguration {
@@ -100,7 +106,20 @@ function selectEfforts(
   definition: VsCodeModelDefinition,
   selector: string | undefined
 ): ReadonlyArray<VsCodeReasoningEffort | undefined> {
-  if (!selector) return [undefined];
+  if (!selector) {
+    if (!STATELESS_RESPONSES_MODEL_IDS.has(definition.id)) return [undefined];
+
+    const supported = definition.supportsReasoningEffort ?? [];
+    const candidates: Array<VsCodeReasoningEffort | undefined> = [
+      'none',
+      'medium',
+      supported[supported.length - 1],
+    ];
+    return [...new Set(candidates.filter(
+      (effort): effort is VsCodeReasoningEffort =>
+        effort !== undefined && supported.includes(effort)
+    ))];
+  }
   if (selector === 'all') {
     return [undefined, ...(definition.supportsReasoningEffort ?? [])];
   }
@@ -131,6 +150,7 @@ function buildRequestBody(
   if (definition.apiType === 'responses') {
     return {
       model: definition.id,
+      store: false,
       input: [{ role: 'user', content: 'Call get_test_value with value "ready".' }],
       tools: [{
         type: 'function',
@@ -483,6 +503,17 @@ describe.runIf(LIVE_ENABLED)('VS Code live model certification', () => {
     const configuration = await resolveLiveConfiguration();
     const selectedModels = selectModels(selector);
     expect(selectedModels.length).toBeGreaterThan(0);
+
+    for (const definition of selectedModels) {
+      if (!STATELESS_RESPONSES_MODEL_IDS.has(definition.id)) continue;
+      expect(definition.apiType).toBe('responses');
+      expect(definition.zeroDataRetentionEnabled).toBe(true);
+      expect(definition.thinking).toBe(true);
+      expect(definition.supportsReasoningEffort).toEqual(
+        expect.arrayContaining(['none', 'medium'])
+      );
+      expect(definition.reasoningEffortFormat).toBe('responses');
+    }
 
     const parsedTimeout = Number(process.env.CODEMIE_VSCODE_REQUEST_TIMEOUT_MS ?? '120000');
     if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {


### PR DESCRIPTION
## Summary

Migrates CodeMie-managed GPT-5.5 and GPT-5.6 VS Code models to stateless Responses API mode, preventing load-balanced continuation failures caused by previous_response_id state.

## Changes

1. Enabled zeroDataRetentionEnabled, Responses reasoning, and model-specific effort capabilities.
2. Extended encrypted reasoning sanitization to VS Code BYOK requests.
3. Added request-normalizer, catalog, sanitizer, and integration coverage.
4. Updated VS Code proxy and user-facing architecture documentation.
5. Preserved streaming behavior and avoided proxy-side conversation storage.

## Impact

VS Code now replays conversation and tool history locally with store: false and no previous_response_id. Encrypted hidden reasoning state is removed between deployments while visible history, reasoning effort, and tool calls are preserved.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
