### PR TITLE
feat(proxy): add Claude Opus 5 to VS Code BYOK

### DIFF
--- a/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/vscode.test.ts
@@ -33,6 +33,7 @@ const EXPECTED_MODEL_IDS = [
   'claude-opus-4-6-20260205',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-haiku-4-5-20251001',
   'qwen.qwen3-coder-30b-a3b-v1',
   'qwen.qwen3-coder-480b-a35b-v1',

--- a/src/cli/commands/proxy/connectors/vscode-models.ts
+++ b/src/cli/commands/proxy/connectors/vscode-models.ts
@@ -269,6 +269,17 @@ export const VS_CODE_SUPPORTED_MODELS: readonly VsCodeModelDefinition[] = [
     maxOutputTokens: 128000,
   },
   {
+    id: 'claude-opus-5',
+    apiType: 'messages',
+    vision: true,
+    thinking: true,
+    adaptiveThinking: true,
+    requestHeaders: MESSAGE_AUTH_HEADERS,
+    supportsReasoningEffort: CLAUDE_XHIGH_EFFORTS,
+    maxInputTokens: 872000,
+    maxOutputTokens: 128000,
+  },
+  {
     id: 'claude-haiku-4-5-20251001',
     apiType: 'chat-completions',
     vision: true,


### PR DESCRIPTION
## Summary

Adds Claude Opus 5 support to the VS Code BYOK connector, enabling users to select and use the model through the existing proxy flow.

## Changes

1. Added claude-opus-5 using the Messages API.
2. Enabled vision, adaptive thinking, and xhigh reasoning effort support.
3. Added model coverage to the VS Code connector tests.

## Impact

Before: Claude Opus 5 was unavailable in the VS Code BYOK model list.
After: Users can select Claude Opus 5 with the same token limits and advanced reasoning capabilities as other recent Opus models.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
