### PR TITLE
fix(cli): reuse CodeMie session in setup to avoid double SSO authentication

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -24,7 +24,12 @@ import {
   selectCodeMieProject
 } from '../../providers/core/codemie-auth-helpers.js';
 import { fetchCodeMieIntegrations } from '../../providers/plugins/sso/sso.http-client.js';
-import type { CodeMieIntegration, SSOAuthResult, SetupContext } from '../../providers/core/types.js';
+import type {
+  CodeMieIntegration,
+  CodeMieSetupSession,
+  SSOAuthResult,
+  SetupContext
+} from '../../providers/core/types.js';
 
 interface LiteLLMEnforcementContext {
   integration: CodeMieIntegration;
@@ -34,26 +39,34 @@ interface LiteLLMEnforcementContext {
 }
 
 export type EnforcementGateResult =
-  | { enforced: false }
-  | (LiteLLMEnforcementContext & { enforced: true });
+  | { enforced: false; session?: CodeMieSetupSession }
+  | (LiteLLMEnforcementContext & { enforced: true; session: CodeMieSetupSession });
 
 export async function detectLiteLLMEnforcement(existingCodeMieUrl?: string): Promise<EnforcementGateResult> {
+  let session: CodeMieSetupSession | undefined;
+
   try {
     const codeMieUrl = await promptForCodeMieUrl(existingCodeMieUrl || DEFAULT_CODEMIE_BASE_URL);
     const authResult = await authenticateWithCodeMie(codeMieUrl);
     if (!authResult.success || !authResult.apiUrl || !authResult.cookies) {
       throw new Error(authResult.error || 'SSO authentication failed');
     }
-    const { project } = await selectCodeMieProject(authResult);
+    const { project, userEmail } = await selectCodeMieProject(authResult);
+
+    // The gate has now completed a full CodeMie handshake (URL + browser SSO +
+    // project). Carry it out of the gate on EVERY exit path so provider setup
+    // steps can reuse it instead of authenticating a second time.
+    session = { codeMieUrl, authResult, project, userEmail };
+
     const allIntegrations = await fetchCodeMieIntegrations(authResult.apiUrl, authResult.cookies);
     const projectIntegrations = allIntegrations.filter(
       i => i.project_name === project && i.credential_type === 'LiteLLM'
     );
-    if (projectIntegrations.length === 0) return { enforced: false };
+    if (projectIntegrations.length === 0) return { enforced: false, session };
     if (projectIntegrations.length > 1) {
       logger.warn(`Multiple LiteLLM integrations found for project "${project}". Using "${projectIntegrations[0].alias}".`);
     }
-    return { enforced: true, integration: projectIntegrations[0], project, authResult, codeMieUrl };
+    return { enforced: true, integration: projectIntegrations[0], project, authResult, codeMieUrl, session };
   } catch (error) {
     if (isPromptAbortError(error)) {
       throw error;
@@ -61,7 +74,8 @@ export async function detectLiteLLMEnforcement(existingCodeMieUrl?: string): Pro
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.warn(`Could not check for mandatory integrations: ${errorMessage}`);
     console.log(chalk.yellow(`\n⚠️  Could not check for mandatory integrations (${errorMessage}). Continuing with normal provider setup.\n`));
-    return { enforced: false };
+
+    return { enforced: false, session };
   }
 }
 
@@ -283,6 +297,7 @@ async function runSetupWizard(force?: boolean): Promise<void> {
 
   let provider: string;
   let enforcementContext: LiteLLMEnforcementContext | undefined;
+  const codeMieSession = enforcementResult.session;
 
   if (enforcementResult.enforced) {
     const litellmSteps = ProviderRegistry.getSetupSteps('litellm');
@@ -323,7 +338,7 @@ async function runSetupWizard(force?: boolean): Promise<void> {
   }
 
   // Use plugin-based setup flow
-  await handlePluginSetup(provider, setupSteps, profileName, isUpdate, storageLocation, enforcementContext);
+  await handlePluginSetup(provider, setupSteps, profileName, isUpdate, storageLocation, enforcementContext, codeMieSession);
 }
 
 /**
@@ -337,7 +352,8 @@ async function handlePluginSetup(
   profileName: string | null,
   isUpdate: boolean,
   storageLocation: 'global' | 'local' = 'global',
-  enforcementContext?: LiteLLMEnforcementContext
+  enforcementContext?: LiteLLMEnforcementContext,
+  codeMieSession?: CodeMieSetupSession
 ): Promise<void> {
   try {
     const providerTemplate = ProviderRegistry.getProvider(providerName);
@@ -347,16 +363,23 @@ async function handlePluginSetup(
       displaySetupInstructions(providerTemplate);
     }
 
-    // Step 1: Get credentials — pass SetupContext when LiteLLM enforcement is active
-    const setupContext: SetupContext | undefined = enforcementContext
-      ? {
-          enforcedIntegration: {
-            id: enforcementContext.integration.id,
-            alias: enforcementContext.integration.alias,
-            codeMieUrl: enforcementContext.codeMieUrl
-          }
-        }
-      : undefined;
+    // Step 1: Get credentials — pass SetupContext when LiteLLM enforcement is
+    // active and/or when the wizard already established a CodeMie session, so
+    // SSO-based providers reuse that session rather than re-authenticating.
+    let setupContext: SetupContext | undefined;
+    if (enforcementContext || codeMieSession) {
+      setupContext = {};
+      if (enforcementContext) {
+        setupContext.enforcedIntegration = {
+          id: enforcementContext.integration.id,
+          alias: enforcementContext.integration.alias,
+          codeMieUrl: enforcementContext.codeMieUrl
+        };
+      }
+      if (codeMieSession) {
+        setupContext.codeMieSession = codeMieSession;
+      }
+    }
     const credentials = await setupSteps.getCredentials(isUpdate, setupContext);
 
     // Step 2: Fetch models

--- a/src/providers/core/types.ts
+++ b/src/providers/core/types.ts
@@ -272,6 +272,21 @@ export interface ProviderCredentials {
 }
 
 /**
+ * CodeMie session already established by the setup wizard before provider
+ * setup steps run (during the mandatory-integration gate).
+ *
+ * Provider setup steps that would otherwise prompt for the portal URL,
+ * open a browser for SSO, and ask for a project must reuse this instead,
+ * so the user authenticates exactly once per `codemie setup` run.
+ */
+export interface CodeMieSetupSession {
+  codeMieUrl: string;
+  authResult: SSOAuthResult;
+  project: string;
+  userEmail: string;
+}
+
+/**
  * Context passed from the setup wizard into provider setup steps.
  * When enforcedIntegration is set, the provider must enforce API key entry.
  */
@@ -281,6 +296,8 @@ export interface SetupContext {
     alias: string;
     codeMieUrl: string;
   };
+  /** Reusable CodeMie session; present only when the wizard already authenticated. */
+  codeMieSession?: CodeMieSetupSession;
 }
 
 /**

--- a/src/providers/plugins/sso/sso.setup-steps.ts
+++ b/src/providers/plugins/sso/sso.setup-steps.ts
@@ -16,7 +16,9 @@ import type {
   ProviderSetupSteps,
   ProviderCredentials,
   AuthValidationResult,
-  AuthStatus
+  AuthStatus,
+  SetupContext,
+  SSOAuthResult
 } from '../../core/types.js';
 import type { CodeMieConfigOptions, CodeMieIntegrationInfo } from '../../../env/types.js';
 import { ProviderRegistry } from '../../core/registry.js';
@@ -40,40 +42,58 @@ export const SSOSetupSteps: ProviderSetupSteps = {
   /**
    * Step 1: Gather credentials/configuration
    *
-   * Prompts for CodeMie URL and performs browser-based authentication
+   * Prompts for CodeMie URL and performs browser-based authentication.
+   *
+   * When the setup wizard already completed a CodeMie handshake (its
+   * mandatory-integration gate authenticates before provider selection), that
+   * session is reused so the user is not prompted for the portal URL and sent
+   * through the browser a second time in one `codemie setup` run.
    */
-  async getCredentials(): Promise<ProviderCredentials> {
-    const codeMieUrl = await promptForCodeMieUrl(DEFAULT_CODEMIE_BASE_URL);
+  async getCredentials(_isUpdate = false, context?: SetupContext): Promise<ProviderCredentials> {
+    const session = context?.codeMieSession;
 
-    // Authenticate via browser
-    console.log(chalk.cyan('\n🔐 Authenticating via browser...\n'));
-    const authResult = await authenticateWithCodeMie(codeMieUrl, 120000);
-
-    if (!authResult.success) {
-      throw new Error(`SSO authentication failed: ${authResult.error || 'Unknown error'}`);
-    }
-
-    console.log(chalk.green('✓ Authentication successful!\n'));
-
-    // === NEW STEP: Fetch applications and select project ===
+    let codeMieUrl: string;
+    let authResult: SSOAuthResult;
     let selectedProject: string | undefined;
     let selectedUserEmail: string | undefined;
 
-    try {
-      console.log(chalk.cyan('📂 Fetching available projects...\n'));
+    if (session) {
+      codeMieUrl = session.codeMieUrl;
+      authResult = session.authResult;
+      selectedProject = session.project;
+      selectedUserEmail = session.userEmail;
 
-      // Ensure API URL and cookies are available
-      if (!authResult.apiUrl || !authResult.cookies) {
-        throw new Error('API URL or cookies not found in authentication result');
+      console.log(chalk.green(`✓ Using existing authenticated session for ${codeMieUrl}`));
+      console.log(chalk.dim(`  Project: ${selectedProject}\n`));
+    } else {
+      codeMieUrl = await promptForCodeMieUrl(DEFAULT_CODEMIE_BASE_URL);
+
+      // Authenticate via browser
+      console.log(chalk.cyan('\n🔐 Authenticating via browser...\n'));
+      authResult = await authenticateWithCodeMie(codeMieUrl, 120000);
+
+      if (!authResult.success) {
+        throw new Error(`SSO authentication failed: ${authResult.error || 'Unknown error'}`);
       }
 
-      ({ project: selectedProject, userEmail: selectedUserEmail } = await selectCodeMieProject(authResult));
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      console.log(chalk.red(`✗ Project selection failed: ${errorMsg}\n`));
+      console.log(chalk.green('✓ Authentication successful!\n'));
 
-      // Fail fast - project selection is required
-      throw new Error(`Project selection required: ${errorMsg}`);
+      // === NEW STEP: Fetch applications and select project ===
+      try {
+        console.log(chalk.cyan('📂 Fetching available projects...\n'));
+
+        ({ project: selectedProject, userEmail: selectedUserEmail } = await selectCodeMieProject(authResult));
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        console.log(chalk.red(`✗ Project selection failed: ${errorMsg}\n`));
+
+        // Fail fast - project selection is required
+        throw new Error(`Project selection required: ${errorMsg}`);
+      }
+    }
+
+    if (!authResult.apiUrl || !authResult.cookies) {
+      throw new Error('API URL or cookies not found in authentication result');
     }
 
     // Check for LiteLLM integrations


### PR DESCRIPTION
## Summary

`codemie setup` asked the user to authenticate twice in a single run: portal URL prompt → browser SSO → project selection, then the exact same sequence again after choosing the CodeMie SSO provider.

The mandatory-LiteLLM-integration gate (added in #429) performs a full CodeMie handshake before provider selection to decide whether LiteLLM is enforced, then throws the result away. `SSOSetupSteps.getCredentials()` ignored its `context` argument entirely and repeated the whole handshake from scratch.

This threads the already-established session through to the provider setup step instead of discarding it, so the user logs in exactly once per run.

## Changes

- `SetupContext` gains an optional `codeMieSession` (`CodeMieSetupSession`: portal URL, auth result, project, user email).
- `detectLiteLLMEnforcement` returns that session on **every** exit path — enforced, not-enforced, and the degraded `catch` path where the integrations fetch fails after a successful login (that path would otherwise still force a second browser login).
- `runSetupWizard` / `handlePluginSetup` pass the session into the `SetupContext` handed to `getCredentials`.
- `SSOSetupSteps.getCredentials(isUpdate, context)` reuses the session when present, printing `✓ Using existing authenticated session for <url>` instead of re-prompting. With no session the original prompt-and-authenticate flow is unchanged, so the graceful fallback when the gate fails still works.
- Dropped a redundant `apiUrl`/`cookies` guard in the SSO branch — `selectCodeMieProject` already validates both, and a single guard now covers both branches.

Change is additive: the new context field and function parameters are optional, and providers that do not consume the session (LiteLLM, Bedrock, Ollama, …) are unaffected.

## Impact

Before — one `codemie setup` run:

```
? CodeMie organization URL: https://codemie.lab.epam.com
Opening browser for authentication...
? Select your project: <user>@epam.com
? Choose your LLM provider: CodeMie SSO
? CodeMie organization URL: https://codemie.lab.epam.com   <-- again
Opening browser for authentication...                       <-- again
? Select your project: <user>@epam.com                      <-- again
```

After:

```
? CodeMie organization URL: https://codemie.lab.epam.com
Opening browser for authentication...
? Select your project: <user>@epam.com
? Choose your LLM provider: CodeMie SSO
✓ Using existing authenticated session for https://codemie.lab.epam.com
  Project: <user>@epam.com
```

## Testing

- [ ] Tests added/updated — no existing test needed changing (the change is additive and no test exercises `SSOSetupSteps.getCredentials`); a regression test asserting the reuse path is worth a follow-up.
- [x] Manual testing done — `npm run test:unit` (176 files, 2542 passed / 1 skipped), `npm run typecheck`, `npx eslint` on the changed files, all clean. The existing `setup.enforcement.test.ts` suite (12 cases) still passes unchanged.

## Checklist

- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`
