### PR TITLE
fix(cli): restore the SSO success message in setup

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -66,6 +66,12 @@ export async function detectLiteLLMEnforcement(existingCodeMieUrl?: string): Pro
     if (!authResult.success || !authResult.apiUrl || !authResult.cookies) {
       throw new Error(authResult.error || 'SSO authentication failed');
     }
+
+    // Announce success here, where the login actually happens. Provider setup
+    // steps reuse this session and so never reach their own success message —
+    // without this the user (and the setup e2e) sees no confirmation at all.
+    console.log(chalk.green('✓ Authentication successful!\n'));
+
     const { project, userEmail } = await selectCodeMieProject(authResult);
 
     // The gate has now completed a full CodeMie handshake (URL + browser SSO +


### PR DESCRIPTION
## Summary

`codemie setup` no longer prints `✓ Authentication successful!` after the browser login.

The message lives in the SSO provider's `getCredentials`, so it only printed when that
step performed the login itself. Since #457 the wizard reuses the session established by
the mandatory-integration gate, so that step is skipped and the login completes with no
confirmation.

## Changes

- Print the message in `detectLiteLLMEnforcement()`, where the login actually happens.

It now appears exactly once on every path: the gate announces it when it authenticates,
and the SSO step still announces its own login when the gate is skipped.

Fixes the 120s timeout in `tests/integration/agent-setup.test.ts` waiting for
`/Authentication successful/i`.

## Checklist

- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [ ] No merge conflicts with `main`
