### PR TITLE
feat(analytics): prompt for user email when absent during report generation

### DIFF
--- a/src/cli/commands/analytics/index.ts
+++ b/src/cli/commands/analytics/index.ts
@@ -4,6 +4,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import inquirer from 'inquirer';
 import { AnalyticsAggregator } from './aggregator.js';
 import { AnalyticsFormatter } from './formatter.js';
 import { AnalyticsExporter } from './exporter.js';
@@ -148,6 +149,26 @@ export async function runAnalytics(options: AnalyticsOptions, source: AnalyticsS
         userEmail = cfg.userEmail || undefined;
       } catch {
         // omit email gracefully
+      }
+
+      if (userEmail === undefined && process.stdout.isTTY) {
+        console.log(chalk.yellow('\n  Warning: your email is not configured. It will be included in the report metadata and saved for future runs.'));
+        try {
+          const { email } = await inquirer.prompt<{ email: string }>([{
+            type: 'input',
+            name: 'email',
+            message: 'Enter your email address:',
+            validate: (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim()) || 'Please enter a valid email address',
+          }]);
+          userEmail = email.trim();
+          await ConfigLoader.saveUserEmail(userEmail).catch(() => { /* non-fatal */ });
+        } catch (err) {
+          if (err instanceof Error && (err.name === 'ExitPromptError' || err.name === 'AbortPromptError')) {
+            console.log(chalk.dim('\n  Report generation cancelled.'));
+            return;
+          }
+          throw err;
+        }
       }
 
       const { index: costIndex, summary } = costResult;


### PR DESCRIPTION
## Summary

When generating an analytics report and no email is stored in config, prompt the user to enter it interactively, then persist it to config for future runs. Ctrl+C cancels report generation entirely. Non-TTY environments (CI, pipes) skip the prompt silently.

## Changes

- Added interactive email prompt in `runAnalytics` before building the report payload, guarded by `process.stdout.isTTY`
- Persists entered email via `ConfigLoader.saveUserEmail` (non-fatal if save fails)
- Ctrl+C / ESC on the prompt cancels report generation with a clear message (`ExitPromptError` / `AbortPromptError` handling matches the pattern used in `setup.ts`)

## Impact

Before: report generated without `userEmail` in metadata when user was not authenticated via SSO or used bedrock/jwt/litellm/ollama provider.
After: user is prompted once; email is saved and reused on subsequent runs.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)