### PR TITLE
fix(agents): stop syncing external Claude sessions on confirmed resume

### DIFF
--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import chalk from 'chalk';
 import type { AgentAdapter, ResumeOwnershipResult } from './types.js';
+import { SESSION_ORIGIN_ENV_KEY, EXTERNAL_RESUME_ORIGIN } from './session/session-origin-audit.js';
 import { ConfigLoader, CodeMieConfigOptions } from '../../utils/config.js';
 import { ensureApiBase, DEFAULT_CODEMIE_BASE_URL } from '../../providers/core/codemie-auth-helpers.js';
 import { AuthMethod, ProviderName } from '../../providers/core/types.js';
@@ -385,12 +386,14 @@ export class AgentCLI {
               process.exit(1);
             }
 
-            // Inject into subprocess env (for lifecycle hook subprocesses that inherit it)
-            // and into the current process env (for same-process consumers such as sso syncProcessor).
+            // Inject into subprocess env — the spawned agent (and, transitively, the
+            // `codemie hook` invocations it shells out to) reads this to persist the
+            // session's origin, which is what actually gates ingestion. No same-process
+            // env write is needed here: origin is persisted to the Session record before
+            // any upload is attempted.
             Object.assign(providerEnv, buildResumeEnvOverride(true));
-            process.env.CODEMIE_CONV_SYNC_DISABLED = '1';
             appendAuditEvent('resume_external_confirmed', auditData);
-            logger.info(`[AgentCLI] External resume confirmed for agent ${this.adapter.name}; conversation sync suppressed`);
+            logger.info(`[AgentCLI] External resume confirmed for agent ${this.adapter.name}; session will not be synced`);
           }
         }
       }
@@ -406,8 +409,6 @@ export class AgentCLI {
 
       // Run the agent (welcome message will be shown inside)
       await this.adapter.run(agentArgs, providerEnv, options.printConfig ? { dryRun: true } : undefined);
-      // Clean up the process-level flag set for same-process conversation sync consumers.
-      delete process.env.CODEMIE_CONV_SYNC_DISABLED;
     } catch (error) {
       // Show user-friendly error message in console first
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -688,7 +689,7 @@ export class AgentCLI {
 }
 
 export function buildResumeEnvOverride(isExternal: boolean): Record<string, string> {
-  return isExternal ? { CODEMIE_CONV_SYNC_DISABLED: '1' } : {};
+  return isExternal ? { [SESSION_ORIGIN_ENV_KEY]: EXTERNAL_RESUME_ORIGIN } : {};
 }
 
 export function shouldBlockNonInteractiveResume(): boolean {

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import chalk from 'chalk';
 import type { AgentAdapter, ResumeOwnershipResult } from './types.js';
-import { SESSION_ORIGIN_ENV_KEY, EXTERNAL_RESUME_ORIGIN } from './session/session-origin-audit.js';
+import { SESSION_ORIGIN, SESSION_ORIGIN_ENV_KEY } from './session/types.js';
 import { ConfigLoader, CodeMieConfigOptions } from '../../utils/config.js';
 import { ensureApiBase, DEFAULT_CODEMIE_BASE_URL } from '../../providers/core/codemie-auth-helpers.js';
 import { AuthMethod, ProviderName } from '../../providers/core/types.js';
@@ -689,7 +689,7 @@ export class AgentCLI {
 }
 
 export function buildResumeEnvOverride(isExternal: boolean): Record<string, string> {
-  return isExternal ? { [SESSION_ORIGIN_ENV_KEY]: EXTERNAL_RESUME_ORIGIN } : {};
+  return isExternal ? { [SESSION_ORIGIN_ENV_KEY]: SESSION_ORIGIN.EXTERNAL_RESUME } : {};
 }
 
 export function shouldBlockNonInteractiveResume(): boolean {

--- a/src/agents/core/__tests__/AgentCLI-resume.test.ts
+++ b/src/agents/core/__tests__/AgentCLI-resume.test.ts
@@ -57,9 +57,9 @@ function mockHandleRunDependencies(overrides: Record<string, unknown> = {}) {
 }
 
 describe('buildResumeEnvOverride', () => {
-  it('returns CODEMIE_CONV_SYNC_DISABLED=1 for an external confirmed resume', () => {
+  it('returns CODEMIE_SESSION_ORIGIN=external-resume for an external confirmed resume', () => {
     const env = buildResumeEnvOverride(true);
-    expect(env).toEqual({ CODEMIE_CONV_SYNC_DISABLED: '1' });
+    expect(env).toEqual({ CODEMIE_SESSION_ORIGIN: 'external-resume' });
   });
 
   it('returns empty object for a CodeMie-owned session', () => {
@@ -149,7 +149,7 @@ describe('handleRun resume ownership flow', () => {
   });
 
   afterEach(() => {
-    delete process.env.CODEMIE_CONV_SYNC_DISABLED;
+    delete process.env.CODEMIE_SESSION_ORIGIN;
     vi.restoreAllMocks();
   });
 
@@ -172,7 +172,7 @@ describe('handleRun resume ownership flow', () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it('prompts, appends audit data, and injects the sync override for confirmed external resumes', async () => {
+  it('prompts, appends audit data, and injects the origin override for confirmed external resumes', async () => {
     mockHandleRunDependencies();
     const resolveResumeOwnership = vi.fn().mockResolvedValue({
       supported: true,
@@ -203,11 +203,13 @@ describe('handleRun resume ownership flow', () => {
     expect(run).toHaveBeenCalledWith(
       ['--resume', 'external-123'],
       expect.objectContaining({
-        CODEMIE_CONV_SYNC_DISABLED: '1',
+        CODEMIE_SESSION_ORIGIN: 'external-resume',
       }),
       undefined,
     );
-    expect(process.env.CODEMIE_CONV_SYNC_DISABLED).toBeUndefined();
+    // No same-process env write is needed — origin is persisted to the Session record
+    // by createSessionRecord() before any upload is attempted, not read from process env here.
+    expect(process.env.CODEMIE_SESSION_ORIGIN).toBeUndefined();
   });
 
   it('blocks unowned external resumes and records the blocked audit payload when confirmation is denied', async () => {
@@ -263,7 +265,7 @@ describe('handleRun resume ownership flow', () => {
     expect(run).toHaveBeenCalledWith(
       ['--resume', 'resume-789'],
       expect.not.objectContaining({
-        CODEMIE_CONV_SYNC_DISABLED: '1',
+        CODEMIE_SESSION_ORIGIN: 'external-resume',
       }),
       undefined,
     );

--- a/src/agents/core/__tests__/session-origin-audit.test.ts
+++ b/src/agents/core/__tests__/session-origin-audit.test.ts
@@ -7,9 +7,8 @@ import {
   appendAuditEvent,
   appendTranscriptMarker,
   isExternalOrigin,
-  SESSION_ORIGIN_ENV_KEY,
-  EXTERNAL_RESUME_ORIGIN,
 } from '../session/session-origin-audit.js';
+import { SESSION_ORIGIN, SESSION_ORIGIN_ENV_KEY } from '../session/types.js';
 
 const TMP = join(tmpdir(), `codemie-audit-test-${process.pid}`);
 const auditFile = join(TMP, 'logs', 'session-origin-audit.jsonl');
@@ -90,7 +89,7 @@ describe('isExternalOrigin', () => {
   });
 
   it('returns true when the session record is flagged external-resume', () => {
-    expect(isExternalOrigin({ origin: EXTERNAL_RESUME_ORIGIN })).toBe(true);
+    expect(isExternalOrigin({ origin: SESSION_ORIGIN.EXTERNAL_RESUME })).toBe(true);
   });
 
   it('returns false when the session record is codemie-owned', () => {
@@ -102,18 +101,18 @@ describe('isExternalOrigin', () => {
   });
 
   it('does not fall back to env when the record explicitly says codemie-owned', () => {
-    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    process.env[SESSION_ORIGIN_ENV_KEY] = SESSION_ORIGIN.EXTERNAL_RESUME;
     expect(isExternalOrigin({ origin: 'codemie' })).toBe(false);
   });
 
   it('falls back to the env var when no record is available (fail-closed)', () => {
-    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    process.env[SESSION_ORIGIN_ENV_KEY] = SESSION_ORIGIN.EXTERNAL_RESUME;
     expect(isExternalOrigin(null)).toBe(true);
     expect(isExternalOrigin(undefined)).toBe(true);
   });
 
   it('falls back to the env var when the record has no origin field (write failure case)', () => {
-    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    process.env[SESSION_ORIGIN_ENV_KEY] = SESSION_ORIGIN.EXTERNAL_RESUME;
     expect(isExternalOrigin({})).toBe(true);
   });
 

--- a/src/agents/core/__tests__/session-origin-audit.test.ts
+++ b/src/agents/core/__tests__/session-origin-audit.test.ts
@@ -6,6 +6,9 @@ import { tmpdir } from 'node:os';
 import {
   appendAuditEvent,
   appendTranscriptMarker,
+  isExternalOrigin,
+  SESSION_ORIGIN_ENV_KEY,
+  EXTERNAL_RESUME_ORIGIN,
 } from '../session/session-origin-audit.js';
 
 const TMP = join(tmpdir(), `codemie-audit-test-${process.pid}`);
@@ -67,5 +70,54 @@ describe('appendTranscriptMarker', () => {
 
   it('is non-fatal when transcript path is empty string', () => {
     expect(() => appendTranscriptMarker('', 'id', 'claude')).not.toThrow();
+  });
+});
+
+describe('isExternalOrigin', () => {
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env[SESSION_ORIGIN_ENV_KEY];
+    delete process.env[SESSION_ORIGIN_ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env[SESSION_ORIGIN_ENV_KEY];
+    } else {
+      process.env[SESSION_ORIGIN_ENV_KEY] = origEnv;
+    }
+  });
+
+  it('returns true when the session record is flagged external-resume', () => {
+    expect(isExternalOrigin({ origin: EXTERNAL_RESUME_ORIGIN })).toBe(true);
+  });
+
+  it('returns false when the session record is codemie-owned', () => {
+    expect(isExternalOrigin({ origin: 'codemie' })).toBe(false);
+  });
+
+  it('returns false for a session record with no origin field when env is unset (back-compat default)', () => {
+    expect(isExternalOrigin({})).toBe(false);
+  });
+
+  it('does not fall back to env when the record explicitly says codemie-owned', () => {
+    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    expect(isExternalOrigin({ origin: 'codemie' })).toBe(false);
+  });
+
+  it('falls back to the env var when no record is available (fail-closed)', () => {
+    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    expect(isExternalOrigin(null)).toBe(true);
+    expect(isExternalOrigin(undefined)).toBe(true);
+  });
+
+  it('falls back to the env var when the record has no origin field (write failure case)', () => {
+    process.env[SESSION_ORIGIN_ENV_KEY] = EXTERNAL_RESUME_ORIGIN;
+    expect(isExternalOrigin({})).toBe(true);
+  });
+
+  it('returns false when neither the record nor env indicate external origin', () => {
+    expect(isExternalOrigin(null)).toBe(false);
   });
 });

--- a/src/agents/core/session/session-origin-audit.ts
+++ b/src/agents/core/session/session-origin-audit.ts
@@ -3,8 +3,30 @@ import { basename, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getCodemiePath } from '../../../utils/paths.js';
 import { logger } from '../../../utils/logger.js';
+import type { Session } from './types.js';
 
 const LOG_FILENAME = 'session-origin-audit.jsonl';
+
+/**
+ * Env var carrying the resume-ownership decision from AgentCLI into the spawned agent
+ * subprocess (and, transitively, into `codemie hook` invocations it shells out to).
+ */
+export const SESSION_ORIGIN_ENV_KEY = 'CODEMIE_SESSION_ORIGIN';
+export const EXTERNAL_RESUME_ORIGIN = 'external-resume' as const;
+
+/**
+ * Whether a session must never be ingested (metrics, conversations, transcript markers).
+ *
+ * Checks the persisted Session record first (authoritative — survives process boundaries
+ * like the proxy timer or DesktopTelemetryRuntime). Falls back to the env var so a session
+ * still fails closed if `createSessionRecord()` silently swallowed a write error before the
+ * origin could be persisted (it deliberately never throws — see hook.ts createSessionRecord).
+ */
+export function isExternalOrigin(session: Pick<Session, 'origin'> | null | undefined): boolean {
+  if (session?.origin === EXTERNAL_RESUME_ORIGIN) return true;
+  if (session?.origin) return false;
+  return process.env[SESSION_ORIGIN_ENV_KEY] === EXTERNAL_RESUME_ORIGIN;
+}
 
 export type AuditEventName =
   | 'transcript_marker_written'

--- a/src/agents/core/session/session-origin-audit.ts
+++ b/src/agents/core/session/session-origin-audit.ts
@@ -3,29 +3,27 @@ import { basename, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getCodemiePath } from '../../../utils/paths.js';
 import { logger } from '../../../utils/logger.js';
+import { SESSION_ORIGIN, SESSION_ORIGIN_ENV_KEY } from './types.js';
 import type { Session } from './types.js';
 
 const LOG_FILENAME = 'session-origin-audit.jsonl';
 
 /**
- * Env var carrying the resume-ownership decision from AgentCLI into the spawned agent
- * subprocess (and, transitively, into `codemie hook` invocations it shells out to).
- */
-export const SESSION_ORIGIN_ENV_KEY = 'CODEMIE_SESSION_ORIGIN';
-export const EXTERNAL_RESUME_ORIGIN = 'external-resume' as const;
-
-/**
  * Whether a session must never be ingested (metrics, conversations, transcript markers).
  *
- * Checks the persisted Session record first (authoritative — survives process boundaries
- * like the proxy timer or DesktopTelemetryRuntime). Falls back to the env var so a session
- * still fails closed if `createSessionRecord()` silently swallowed a write error before the
- * origin could be persisted (it deliberately never throws — see hook.ts createSessionRecord).
+ * The persisted Session record is the single source of truth: once `origin` was written,
+ * it alone decides — a stale env var can never reclassify a session whose record says
+ * 'codemie'. The env var is the same fact held by the original decision-maker (AgentCLI),
+ * consulted only when the record is silent, so the session still fails closed if the
+ * record was never written: `createSessionRecord()` swallows write errors and returns
+ * early when agent/provider config is missing (see hook.ts), and records predating this
+ * field have no origin at all.
  */
 export function isExternalOrigin(session: Pick<Session, 'origin'> | null | undefined): boolean {
-  if (session?.origin === EXTERNAL_RESUME_ORIGIN) return true;
-  if (session?.origin) return false;
-  return process.env[SESSION_ORIGIN_ENV_KEY] === EXTERNAL_RESUME_ORIGIN;
+  if (session?.origin !== undefined) {
+    return session.origin === SESSION_ORIGIN.EXTERNAL_RESUME;
+  }
+  return process.env[SESSION_ORIGIN_ENV_KEY] === SESSION_ORIGIN.EXTERNAL_RESUME;
 }
 
 export type AuditEventName =

--- a/src/agents/core/session/types.ts
+++ b/src/agents/core/session/types.ts
@@ -37,11 +37,24 @@ export type SessionStatus = 'active' | 'completed' | 'recovered' | 'failed';
 
 /**
  * Session origin — whether this session is safe to ingest.
- * 'codemie': created through CodeMie tooling (default when unset, for back-compat with
- * existing session files). 'external-resume': a confirmed resume of a Claude transcript
+ * CODEMIE: created through CodeMie tooling (default when unset, for back-compat with
+ * existing session files). EXTERNAL_RESUME: a confirmed resume of a Claude transcript
  * that was never created through CodeMie — must never be synced (metrics or conversations).
  */
-export type SessionOrigin = 'codemie' | 'external-resume';
+export const SESSION_ORIGIN = {
+  CODEMIE: 'codemie',
+  EXTERNAL_RESUME: 'external-resume',
+} as const;
+
+export type SessionOrigin = (typeof SESSION_ORIGIN)[keyof typeof SESSION_ORIGIN];
+
+/**
+ * Env var carrying the resume-ownership decision from AgentCLI into the spawned agent
+ * subprocess (and, transitively, into `codemie hook` invocations it shells out to).
+ * Holds a SESSION_ORIGIN value; kept separate from the object above because it names
+ * the channel, not an origin.
+ */
+export const SESSION_ORIGIN_ENV_KEY = 'CODEMIE_SESSION_ORIGIN';
 
 /**
  * Sync status (used by all processors)

--- a/src/agents/core/session/types.ts
+++ b/src/agents/core/session/types.ts
@@ -36,6 +36,14 @@ export interface CorrelationResult {
 export type SessionStatus = 'active' | 'completed' | 'recovered' | 'failed';
 
 /**
+ * Session origin — whether this session is safe to ingest.
+ * 'codemie': created through CodeMie tooling (default when unset, for back-compat with
+ * existing session files). 'external-resume': a confirmed resume of a Claude transcript
+ * that was never created through CodeMie — must never be synced (metrics or conversations).
+ */
+export type SessionOrigin = 'codemie' | 'external-resume';
+
+/**
  * Sync status (used by all processors)
  */
 export type SyncStatus = 'pending' | 'syncing' | 'synced' | 'failed';
@@ -124,6 +132,7 @@ export interface Session {
   correlation: CorrelationResult;
   status: SessionStatus;
   reason?: string; // Session end reason (optional, e.g., 'clear', 'logout', 'prompt_input_exit', 'other')
+  origin?: SessionOrigin; // undefined = 'codemie' (back-compat)
 
   // Active duration tracking (excludes idle time)
   activityStartedAt?: number; // Unix ms when current activity began (undefined = idle)

--- a/src/cli/commands/__tests__/hook.session-origin.test.ts
+++ b/src/cli/commands/__tests__/hook.session-origin.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression tests for EPMCDME-12992: a confirmed external-resume session must never
+ * upload anything (lifecycle metrics or conversations), and its transcript must never be
+ * (re-)stamped with a CodeMie ownership marker.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getCodemiePath } from '../../../utils/paths.js';
+import { getSessionPath } from '../../../agents/core/session/session-config.js';
+import type { BaseHookEvent } from '../../../agents/core/types.js';
+import type { HookProcessingConfig } from '../hook.js';
+
+const mockSendSessionStart = vi.fn().mockResolvedValue(undefined);
+const mockSendSessionEnd = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../providers/plugins/sso/index.js', () => ({
+  MetricsSender: vi.fn(function (this: Record<string, unknown>) {
+    this.sendSessionStart = mockSendSessionStart;
+    this.sendSessionEnd = mockSendSessionEnd;
+  })
+}));
+
+vi.mock('../../../providers/plugins/sso/sso.auth.js', () => ({
+  CodeMieSSO: vi.fn(function (this: Record<string, unknown>) {
+    this.getStoredCredentials = vi.fn().mockResolvedValue({ cookies: { session: 'abc123' } });
+  })
+}));
+
+const TMP = join(tmpdir(), `codemie-hook-origin-test-${process.pid}`);
+
+function sessionFilePath(sessionId: string): string {
+  return getSessionPath(sessionId);
+}
+
+function markerFilePath(claudeSessionId: string): string {
+  return getCodemiePath('sessions', `${claudeSessionId}-codemie-marker.json`);
+}
+
+function cleanupSession(sessionId: string, claudeSessionId: string): void {
+  const p = sessionFilePath(sessionId);
+  if (existsSync(p)) rmSync(p, { force: true });
+  const m = markerFilePath(claudeSessionId);
+  if (existsSync(m)) rmSync(m, { force: true });
+}
+
+describe('hook.ts external-resume origin gating', () => {
+  const baseConfig: Omit<HookProcessingConfig, 'sessionId'> = {
+    agentName: 'claude',
+    provider: 'ai-run-sso',
+    ssoUrl: 'https://sso.example.invalid',
+    syncApiUrl: 'https://api.example.invalid',
+  };
+
+  beforeEach(() => {
+    mkdirSync(TMP, { recursive: true });
+    mkdirSync(getCodemiePath('sessions'), { recursive: true });
+    vi.clearAllMocks();
+    delete process.env.CODEMIE_SESSION_ORIGIN;
+  });
+
+  afterEach(() => {
+    delete process.env.CODEMIE_SESSION_ORIGIN;
+    rmSync(TMP, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('persists origin=external-resume and skips start metrics + marker write for a confirmed external resume', async () => {
+    const sessionId = 'test-origin-external-start';
+    const claudeSessionId = 'claude-ext-1';
+    const transcriptPath = join(TMP, `${claudeSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '{"type":"user"}\n');
+    cleanupSession(sessionId, claudeSessionId);
+
+    process.env.CODEMIE_SESSION_ORIGIN = 'external-resume';
+
+    const { processEvent } = await import('../hook.js');
+    const event: BaseHookEvent = {
+      session_id: claudeSessionId,
+      hook_event_name: 'SessionStart',
+      transcript_path: transcriptPath,
+      permission_mode: 'default',
+      cwd: process.cwd(),
+    } as BaseHookEvent & { source: string };
+    (event as unknown as { source: string }).source = 'startup';
+
+    await processEvent(event, { ...baseConfig, sessionId });
+
+    // Origin persisted on the Session record.
+    const saved = JSON.parse(readFileSync(sessionFilePath(sessionId), 'utf-8'));
+    expect(saved.origin).toBe('external-resume');
+
+    // No lifecycle metrics uploaded.
+    expect(mockSendSessionStart).not.toHaveBeenCalled();
+
+    // No ownership marker written (sidecar or in-band) — must not re-adopt the transcript.
+    expect(existsSync(markerFilePath(claudeSessionId))).toBe(false);
+    const transcriptContent = readFileSync(transcriptPath, 'utf-8');
+    expect(transcriptContent).not.toContain('codemie_session_start');
+
+    cleanupSession(sessionId, claudeSessionId);
+  });
+
+  it('persists no origin and uploads start metrics + marker for a normal CodeMie session', async () => {
+    const sessionId = 'test-origin-codemie-start';
+    const claudeSessionId = 'claude-normal-1';
+    const transcriptPath = join(TMP, `${claudeSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '{"type":"user"}\n');
+    cleanupSession(sessionId, claudeSessionId);
+
+    const { processEvent } = await import('../hook.js');
+    const event: BaseHookEvent = {
+      session_id: claudeSessionId,
+      hook_event_name: 'SessionStart',
+      transcript_path: transcriptPath,
+      permission_mode: 'default',
+      cwd: process.cwd(),
+    } as BaseHookEvent & { source: string };
+    (event as unknown as { source: string }).source = 'startup';
+
+    await processEvent(event, { ...baseConfig, sessionId });
+
+    const saved = JSON.parse(readFileSync(sessionFilePath(sessionId), 'utf-8'));
+    expect(saved.origin).toBeUndefined();
+
+    expect(mockSendSessionStart).toHaveBeenCalledTimes(1);
+    expect(existsSync(markerFilePath(claudeSessionId))).toBe(true);
+
+    cleanupSession(sessionId, claudeSessionId);
+  });
+
+  it('skips end metrics for a session already flagged external-resume', async () => {
+    const sessionId = 'test-origin-external-end';
+    const claudeSessionId = 'claude-ext-end-1';
+    cleanupSession(sessionId, claudeSessionId);
+
+    writeFileSync(
+      sessionFilePath(sessionId),
+      JSON.stringify({
+        sessionId,
+        agentName: 'claude',
+        provider: 'ai-run-sso',
+        startTime: Date.now() - 1000,
+        workingDirectory: process.cwd(),
+        status: 'active',
+        activeDurationMs: 0,
+        origin: 'external-resume',
+        correlation: {
+          status: 'matched',
+          agentSessionId: claudeSessionId,
+          agentSessionFile: join(TMP, `${claudeSessionId}.jsonl`),
+          retryCount: 0,
+        },
+      })
+    );
+
+    const { processEvent } = await import('../hook.js');
+    const event = {
+      session_id: claudeSessionId,
+      hook_event_name: 'SessionEnd',
+      transcript_path: join(TMP, `${claudeSessionId}.jsonl`),
+      permission_mode: 'default',
+      cwd: process.cwd(),
+      reason: 'exit',
+    } as unknown as BaseHookEvent;
+
+    await processEvent(event, { ...baseConfig, sessionId });
+
+    expect(mockSendSessionEnd).not.toHaveBeenCalled();
+
+    cleanupSession(sessionId, claudeSessionId);
+  });
+});

--- a/src/cli/commands/analytics/__tests__/native-loader.test.ts
+++ b/src/cli/commands/analytics/__tests__/native-loader.test.ts
@@ -2,8 +2,26 @@
  * Native session discovery + synthesis unit tests (dependency-injected — no fs/registry).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { synthesizeRawSession, loadNativeSessions, type NativeLoaderDeps } from '../native-loader.js';
+
+// Module-level mock (must live at file top level, not inside a describe block, so Vitest's
+// hoisting transform actually lifts it above the static `native-loader.js` import above).
+// Only redirects the 'sessions' subpath used by buildOwnershipIndex(); everything else
+// (getCodemieHome, etc.) falls through to the real implementation.
+const mockSessionsDir = join(tmpdir(), `codemie-native-loader-ownership-test-${process.pid}`);
+
+vi.mock('../../../../utils/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../utils/paths.js')>();
+  return {
+    ...actual,
+    getCodemiePath: (...segments: string[]) =>
+      segments[0] === 'sessions' ? mockSessionsDir : actual.getCodemiePath(...segments),
+  };
+});
 
 const parsed = {
   sessionId: 'sx',
@@ -292,6 +310,49 @@ describe('loadNativeSessions — ownership gate exemption for analytics-only age
 
     expect(results).toHaveLength(1);
     expect(results[0].startEvent!.data.provider).toBe('native-external');
+  });
+});
+
+describe('realNativeDeps.hasOwnershipMarker — ownership index excludes external-resume records (EPMCDME-12992)', () => {
+  const ownedTranscript = join(mockSessionsDir, 'owned.jsonl');
+  const externalTranscript = join(mockSessionsDir, 'external.jsonl');
+
+  beforeEach(() => {
+    vi.resetModules();
+    rmSync(mockSessionsDir, { recursive: true, force: true });
+    mkdirSync(mockSessionsDir, { recursive: true });
+    // Plain transcripts with no in-band marker — so a `false` result only comes from the
+    // ownership index correctly excluding the record, not from the legacy 4KB-scan fallback
+    // hitting a missing file.
+    writeFileSync(ownedTranscript, '{"type":"user"}\n');
+    writeFileSync(externalTranscript, '{"type":"user"}\n');
+  });
+
+  afterEach(() => {
+    rmSync(mockSessionsDir, { recursive: true, force: true });
+  });
+
+  it('adopts the transcript of a normal CodeMie session (origin unset)', async () => {
+    writeFileSync(
+      join(mockSessionsDir, 'codemie-session-1.json'),
+      JSON.stringify({ correlation: { agentSessionFile: ownedTranscript } })
+    );
+
+    const { realNativeDeps } = await import('../native-loader.js');
+    expect(realNativeDeps.hasOwnershipMarker(ownedTranscript)).toBe(true);
+  });
+
+  it('does NOT adopt the transcript of a session flagged origin=external-resume', async () => {
+    writeFileSync(
+      join(mockSessionsDir, 'codemie-session-2.json'),
+      JSON.stringify({
+        origin: 'external-resume',
+        correlation: { agentSessionFile: externalTranscript },
+      })
+    );
+
+    const { realNativeDeps } = await import('../native-loader.js');
+    expect(realNativeDeps.hasOwnershipMarker(externalTranscript)).toBe(false);
   });
 });
 

--- a/src/cli/commands/analytics/native-loader.ts
+++ b/src/cli/commands/analytics/native-loader.ts
@@ -23,7 +23,7 @@ import { AgentRegistry } from '../../../agents/registry.js';
 import { getCodemiePath } from '../../../utils/paths.js';
 import { logger } from '../../../utils/logger.js';
 import { stripClear } from '../../../agents/plugins/claude/session/strip-clear.js';
-import { EXTERNAL_RESUME_ORIGIN } from '../../../agents/core/session/session-origin-audit.js';
+import { SESSION_ORIGIN } from '../../../agents/core/session/types.js';
 import { isCodexFamilyAgent } from './cost/codex-agent.js';
 import { firstCodexUserText } from '../../../agents/plugins/codex/session/codex-user-prompt.js';
 import { collectCodexChildThreadIds } from '../../../agents/plugins/codex/session/codex-collab-links.js';
@@ -150,7 +150,7 @@ function buildOwnershipIndex(): Set<string> {
         // A confirmed external-resume session must never re-adopt its transcript into the
         // ownership index — that would silently exclude it from `native-external` filtering
         // again, undoing the whole point of flagging it. See EPMCDME-12992.
-        if (meta.origin === EXTERNAL_RESUME_ORIGIN) continue;
+        if (meta.origin === SESSION_ORIGIN.EXTERNAL_RESUME) continue;
         const asf = meta.correlation?.agentSessionFile;
         if (asf) out.add(safeRealPath(asf));
       }

--- a/src/cli/commands/analytics/native-loader.ts
+++ b/src/cli/commands/analytics/native-loader.ts
@@ -23,6 +23,7 @@ import { AgentRegistry } from '../../../agents/registry.js';
 import { getCodemiePath } from '../../../utils/paths.js';
 import { logger } from '../../../utils/logger.js';
 import { stripClear } from '../../../agents/plugins/claude/session/strip-clear.js';
+import { EXTERNAL_RESUME_ORIGIN } from '../../../agents/core/session/session-origin-audit.js';
 import { isCodexFamilyAgent } from './cost/codex-agent.js';
 import { firstCodexUserText } from '../../../agents/plugins/codex/session/codex-user-prompt.js';
 import { collectCodexChildThreadIds } from '../../../agents/plugins/codex/session/codex-collab-links.js';
@@ -144,7 +145,12 @@ function buildOwnershipIndex(): Set<string> {
       } else if (!f.endsWith('_metrics.json')) {
         const meta = JSON.parse(readFileSync(join(dir, f), 'utf-8')) as {
           correlation?: { agentSessionFile?: string };
+          origin?: string;
         };
+        // A confirmed external-resume session must never re-adopt its transcript into the
+        // ownership index — that would silently exclude it from `native-external` filtering
+        // again, undoing the whole point of flagging it. See EPMCDME-12992.
+        if (meta.origin === EXTERNAL_RESUME_ORIGIN) continue;
         const asf = meta.correlation?.agentSessionFile;
         if (asf) out.add(safeRealPath(asf));
       }

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { logger } from '@/utils/logger.js';
 import { AgentRegistry } from '@/agents/registry.js';
 import { getSessionPath, getSessionMetricsPath, getSessionConversationPath } from '@/agents/core/session/session-config.js';
+import { SESSION_ORIGIN, SESSION_ORIGIN_ENV_KEY } from '@/agents/core/session/types.js';
 import type { BaseHookEvent, HookTransformer, MCPConfigSummary, ExtensionsScanSummary } from '@/agents/core/types.js';
 import type { ProcessingContext } from '@/agents/core/session/BaseProcessor.js';
 
@@ -724,7 +725,6 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
         appendTranscriptMarker: writeMarker,
         appendAuditEvent: writeAudit,
         isExternalOrigin,
-        EXTERNAL_RESUME_ORIGIN,
       } = await import('../../agents/core/session/session-origin-audit.js');
 
       existing.status = 'active';
@@ -738,8 +738,8 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
       };
       // Preserve an already-set origin; only derive from env for pre-existing records that
       // predate this field. An established origin must never flip on re-entry.
-      if (!existing.origin && getConfigValue('CODEMIE_SESSION_ORIGIN', config) === EXTERNAL_RESUME_ORIGIN) {
-        existing.origin = EXTERNAL_RESUME_ORIGIN;
+      if (!existing.origin && getConfigValue(SESSION_ORIGIN_ENV_KEY, config) === SESSION_ORIGIN.EXTERNAL_RESUME) {
+        existing.origin = SESSION_ORIGIN.EXTERNAL_RESUME;
       }
       await sessionStore.saveSession(existing);
       if (event.transcript_path && !isExternalOrigin(existing)) {
@@ -757,12 +757,12 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
       return;
     }
 
-    const { appendTranscriptMarker, appendAuditEvent, isExternalOrigin, EXTERNAL_RESUME_ORIGIN } = await import(
+    const { appendTranscriptMarker, appendAuditEvent, isExternalOrigin } = await import(
       '../../agents/core/session/session-origin-audit.js'
     );
     const origin =
-      getConfigValue('CODEMIE_SESSION_ORIGIN', config) === EXTERNAL_RESUME_ORIGIN
-        ? EXTERNAL_RESUME_ORIGIN
+      getConfigValue(SESSION_ORIGIN_ENV_KEY, config) === SESSION_ORIGIN.EXTERNAL_RESUME
+        ? SESSION_ORIGIN.EXTERNAL_RESUME
         : undefined;
 
     // Create session record with correlation already matched

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -634,10 +634,16 @@ async function routeHookEvent(event: BaseHookEvent, rawInput: string, sessionId:
       event.transcript_path &&
       (normalizedEventName === 'UserPromptSubmit' || normalizedEventName === 'Stop')
     ) {
-      const { appendTranscriptMarker } = await import(
+      const { appendTranscriptMarker, isExternalOrigin } = await import(
         '../../agents/core/session/session-origin-audit.js'
       );
-      appendTranscriptMarker(event.transcript_path, sessionId, agentName);
+      const { SessionStore } = await import('../../agents/core/session/SessionStore.js');
+      const session = await new SessionStore().loadSession(sessionId);
+      // Never (re-)stamp a transcript that's flagged external-resume — doing so would
+      // re-adopt it into the local analytics ownership index (native-loader.ts).
+      if (!isExternalOrigin(session)) {
+        appendTranscriptMarker(event.transcript_path, sessionId, agentName);
+      }
     }
 
     const duration = Date.now() - startTime;
@@ -714,6 +720,13 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
     // process with a fresh CODEMIE_SESSION_ID, so it never reaches this branch.)
     const existing = await sessionStore.loadSession(sessionId);
     if (existing && existing.status === 'active' && existing.endTime === undefined) {
+      const {
+        appendTranscriptMarker: writeMarker,
+        appendAuditEvent: writeAudit,
+        isExternalOrigin,
+        EXTERNAL_RESUME_ORIGIN,
+      } = await import('../../agents/core/session/session-origin-audit.js');
+
       existing.status = 'active';
       if (gitBranch) existing.gitBranch = gitBranch;
       if (remoteRepository) existing.repository = remoteRepository;
@@ -723,11 +736,13 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
         ...(event.session_id && { agentSessionId: event.session_id }),
         ...(event.transcript_path && { agentSessionFile: event.transcript_path }),
       };
+      // Preserve an already-set origin; only derive from env for pre-existing records that
+      // predate this field. An established origin must never flip on re-entry.
+      if (!existing.origin && getConfigValue('CODEMIE_SESSION_ORIGIN', config) === EXTERNAL_RESUME_ORIGIN) {
+        existing.origin = EXTERNAL_RESUME_ORIGIN;
+      }
       await sessionStore.saveSession(existing);
-      const { appendTranscriptMarker: writeMarker, appendAuditEvent: writeAudit } = await import(
-        '../../agents/core/session/session-origin-audit.js'
-      );
-      if (event.transcript_path) {
+      if (event.transcript_path && !isExternalOrigin(existing)) {
         writeMarker(event.transcript_path, sessionId, agentName);
         writeAudit('transcript_marker_written', {
           codemieSessionId: sessionId,
@@ -742,6 +757,14 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
       return;
     }
 
+    const { appendTranscriptMarker, appendAuditEvent, isExternalOrigin, EXTERNAL_RESUME_ORIGIN } = await import(
+      '../../agents/core/session/session-origin-audit.js'
+    );
+    const origin =
+      getConfigValue('CODEMIE_SESSION_ORIGIN', config) === EXTERNAL_RESUME_ORIGIN
+        ? EXTERNAL_RESUME_ORIGIN
+        : undefined;
+
     // Create session record with correlation already matched
     const session = {
       sessionId,
@@ -754,6 +777,7 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
       ...(gitBranch && { gitBranch }),
       status: 'active' as const,
       activeDurationMs: 0, // Initialize active duration tracking
+      ...(origin && { origin }),
       correlation: {
         status: 'matched' as const,
         agentSessionId: event.session_id,
@@ -765,10 +789,9 @@ async function createSessionRecord(event: SessionStartEvent, sessionId: string, 
     // Save session
     await sessionStore.saveSession(session);
 
-    const { appendTranscriptMarker, appendAuditEvent } = await import(
-      '../../agents/core/session/session-origin-audit.js'
-    );
-    if (session.correlation.agentSessionFile) {
+    // Never stamp a transcript that's flagged external-resume — doing so would re-adopt it
+    // into the local analytics ownership index (native-loader.ts) and undo the exclusion.
+    if (session.correlation.agentSessionFile && !isExternalOrigin(session)) {
       appendTranscriptMarker(
         session.correlation.agentSessionFile,
         sessionId,
@@ -815,6 +838,16 @@ async function sendSessionStartMetrics(event: SessionStartEvent, sessionId: stri
 
     if (!sessionId || !agentName || !ssoUrl || !apiUrl) {
       logger.debug('[hook:SessionStart] Missing required config for metrics');
+      return;
+    }
+
+    // Session record is created (with origin persisted) immediately before this is called —
+    // see handleSessionStart. Never upload lifecycle metrics for a confirmed external resume.
+    const { isExternalOrigin } = await import('../../agents/core/session/session-origin-audit.js');
+    const { SessionStore } = await import('../../agents/core/session/SessionStore.js');
+    const session = await new SessionStore().loadSession(sessionId);
+    if (isExternalOrigin(session)) {
+      logger.debug('[hook:SessionStart] Skipping start metrics for external-resume session');
       return;
     }
 
@@ -1097,6 +1130,12 @@ async function sendSessionEndMetrics(event: SessionEndEvent, sessionId: string, 
 
     if (!session) {
       logger.warn(`[hook:SessionEnd] Session not found for metrics: ${sessionId}`);
+      return;
+    }
+
+    const { isExternalOrigin } = await import('../../agents/core/session/session-origin-audit.js');
+    if (isExternalOrigin(session)) {
+      logger.debug('[hook:SessionEnd] Skipping end metrics for external-resume session');
       return;
     }
 

--- a/src/providers/plugins/sso/session/SessionSyncer.ts
+++ b/src/providers/plugins/sso/session/SessionSyncer.ts
@@ -20,6 +20,7 @@ import { SessionStore } from '../../../../agents/core/session/SessionStore.js';
 import { MetricsSyncProcessor } from './processors/metrics/metrics-sync-processor.js';
 import { createSyncProcessor as createConversationSyncProcessor } from './processors/conversations/syncProcessor.js';
 import { applyProcessingSyncUpdates } from '../../../../agents/core/session/sync-state-utils.js';
+import { isExternalOrigin } from '../../../../agents/core/session/session-origin-audit.js';
 
 export interface SessionSyncResult {
   success: boolean;
@@ -92,6 +93,19 @@ export class SessionSyncer {
         return {
           success: false,
           message: 'Session not found',
+          processorResults: {},
+          failedProcessors: []
+        };
+      }
+
+      // Central ingestion gate: a confirmed external-resume session must never sync anything
+      // (metrics or conversations), regardless of which caller (hook, proxy timer, codex
+      // incremental sync, DesktopTelemetryRuntime) invoked this. See EPMCDME-12992.
+      if (isExternalOrigin(sessionMetadata)) {
+        logger.debug(`[SessionSyncer] Skipping sync for external-resume session ${sessionId}`);
+        return {
+          success: true,
+          message: 'Sync skipped: external-resume session',
           processorResults: {},
           failedProcessors: []
         };

--- a/src/providers/plugins/sso/session/__tests__/SessionSyncer.test.ts
+++ b/src/providers/plugins/sso/session/__tests__/SessionSyncer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Session } from '../../../../../agents/core/session/types.js';
+import type { ProcessingContext } from '../../../../../agents/core/session/BaseProcessor.js';
+
+const mockLoadSession = vi.fn();
+const mockSaveSession = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../../../agents/core/session/SessionStore.js', () => ({
+  SessionStore: vi.fn(function (this: Record<string, unknown>) {
+    this.loadSession = mockLoadSession;
+    this.saveSession = mockSaveSession;
+  })
+}));
+
+const mockMetricsShouldProcess = vi.fn().mockReturnValue(true);
+const mockMetricsProcess = vi.fn().mockResolvedValue({ success: true, message: 'metrics ok' });
+
+vi.mock('../processors/metrics/metrics-sync-processor.js', () => ({
+  MetricsSyncProcessor: vi.fn(function (this: Record<string, unknown>) {
+    this.name = 'metrics-sync';
+    this.priority = 2;
+    this.shouldProcess = mockMetricsShouldProcess;
+    this.process = mockMetricsProcess;
+  })
+}));
+
+const mockConvShouldProcess = vi.fn().mockReturnValue(true);
+const mockConvProcess = vi.fn().mockResolvedValue({ success: true, message: 'conversations ok' });
+
+vi.mock('../processors/conversations/syncProcessor.js', () => ({
+  createSyncProcessor: vi.fn(() => ({
+    name: 'conversation-sync',
+    priority: 3,
+    shouldProcess: mockConvShouldProcess,
+    process: mockConvProcess,
+  }))
+}));
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'session-1',
+    agentName: 'claude',
+    provider: 'ai-run-sso',
+    startTime: Date.now(),
+    workingDirectory: '/tmp/project',
+    status: 'active',
+    activeDurationMs: 0,
+    correlation: {
+      status: 'matched',
+      agentSessionId: 'agent-session-1',
+      agentSessionFile: '/tmp/transcript.jsonl',
+      retryCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+const context: ProcessingContext = {
+  apiBaseUrl: 'https://api.example.com',
+  cookies: 'session=abc',
+  clientType: 'codemie-cli',
+  version: '1.0.0',
+  dryRun: false,
+};
+
+describe('SessionSyncer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips all processors and reports success for an external-resume session', async () => {
+    mockLoadSession.mockResolvedValue(makeSession({ origin: 'external-resume' }));
+
+    const { SessionSyncer } = await import('../SessionSyncer.js');
+    const syncer = new SessionSyncer();
+    const result = await syncer.sync('session-1', context);
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Sync skipped: external-resume session',
+      processorResults: {},
+      failedProcessors: [],
+    });
+    expect(mockMetricsProcess).not.toHaveBeenCalled();
+    expect(mockConvProcess).not.toHaveBeenCalled();
+    expect(mockSaveSession).not.toHaveBeenCalled();
+  });
+
+  it('runs processors normally for a codemie-owned session', async () => {
+    mockLoadSession.mockResolvedValue(makeSession({ origin: 'codemie' }));
+
+    const { SessionSyncer } = await import('../SessionSyncer.js');
+    const syncer = new SessionSyncer();
+    const result = await syncer.sync('session-1', context);
+
+    expect(result.success).toBe(true);
+    expect(mockMetricsProcess).toHaveBeenCalledTimes(1);
+    expect(mockConvProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs processors normally for a legacy session with no origin field (back-compat)', async () => {
+    mockLoadSession.mockResolvedValue(makeSession());
+
+    const { SessionSyncer } = await import('../SessionSyncer.js');
+    const syncer = new SessionSyncer();
+    const result = await syncer.sync('session-1', context);
+
+    expect(result.success).toBe(true);
+    expect(mockMetricsProcess).toHaveBeenCalledTimes(1);
+    expect(mockConvProcess).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
A confirmed external Claude session resume (`codemie-claude --resume <id>` on a session never created through CodeMie) still uploaded lifecycle metrics and could re-adopt the transcript into CodeMie's local analytics ownership index, even though conversation content sync was already suppressed.

## Motivation
EPMCDME-13367 (closed) fixed local `codemie analytics` filtering only. Anton Yeromin's comment on EPMCDME-12992 confirmed the gap: "we do show warning if resume native claude sessions, but we do not exclude them from analytics." The existing `CODEMIE_CONV_SYNC_DISABLED` flag only ever suppressed conversation content, not metrics/lifecycle events, and the ownership marker was written unconditionally on every SessionStart — silently re-adopting a transcript that had just been flagged external.

## Changes
- Added `Session.origin` (`'codemie' | 'external-resume'`), persisted on the Session record instead of relying solely on a process-local env flag.
- Added `isExternalOrigin()` predicate (checks the persisted record, falls back to env for fail-closed behavior if the record write failed).
- `AgentCLI.buildResumeEnvOverride()` now propagates `CODEMIE_SESSION_ORIGIN` instead of `CODEMIE_CONV_SYNC_DISABLED`.
- `hook.ts`: persists origin at SessionStart (including the `compact` re-entry path), skips ownership-marker writes for external-resume sessions at all call sites, and gates the two direct `MetricsSender` calls (`sendSessionStartMetrics` / `sendSessionEndMetrics`).
- `SessionSyncer.sync()`: central gate — an external-resume session skips all processors (metrics + conversations), covering every caller (hook SessionEnd, proxy timer, codex incremental sync, DesktopTelemetryRuntime) in one place.
- `native-loader.ts`: `buildOwnershipIndex()` no longer harvests `correlation.agentSessionFile` from external-resume records, so local analytics exclusion is no longer silently undone.
- `CODEMIE_CONV_SYNC_DISABLED` is left untouched — it's now a genuinely orthogonal, still-supported mechanism, unused by this flow.

## Testing
- [x] Tests added/updated (`isExternalOrigin`, `SessionSyncer.sync()` gating, `AgentCLI` resume env propagation, hook-level origin persistence + marker/metrics suppression, `native-loader` ownership-index exclusion)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean on touched files (repo has pre-existing unrelated `no-undef` errors in `.mjs`/`.cjs` scripts, confirmed present on `main` before this change)
- [x] `npm run build` — clean
- [x] `npm run test:unit` — 198 files, 2925 passed
- [x] `npm run test:integration` — 29 files, 204 passed
- [x] `npm run license-check` — clean
- [x] `npm run validate:secrets` — no leaks found

## Breaking Changes
None. `Session.origin` is optional and back-compat (undefined ⇒ treated as `'codemie'`) for all existing session files.

## Related Issues
Relates to EPMCDME-12992 (Jira — this repo tracks work in EPM-CDME, not GitHub Issues, so no `#NNN` applies here)