### PR TITLE
fix(agents): stop the ownership marker from breaking Pi session resume

### DIFF
--- a/src/agents/core/session/session-origin-audit.ts
+++ b/src/agents/core/session/session-origin-audit.ts
@@ -26,6 +26,19 @@ export function appendAuditEvent(
   }
 }
 
+/**
+ * Agents whose transcript is a parent-linked entry tree rather than a flat log.
+ *
+ * Pi rebuilds its session from the file on every open: `_buildIndex()` takes the last
+ * non-header line as the tree leaf and `buildSessionPath()` walks `parentId` upwards from
+ * it to assemble the model context. A marker line carries neither `id` nor `parentId`, so
+ * appending one leaves the leaf undefined, ends the walk on its first step, and every later
+ * `--resume` of that transcript opens with an empty conversation — indistinguishable from a
+ * new session. Ownership for these agents is carried entirely outside the transcript, by the
+ * sidecar written above and by `correlation.agentSessionFile` on the session record.
+ */
+const TREE_STRUCTURED_TRANSCRIPT_AGENTS = new Set(['pi']);
+
 export function appendTranscriptMarker(
   transcriptPath: string,
   codemieSessionId: string,
@@ -60,6 +73,13 @@ export function appendTranscriptMarker(
     }
   } catch (err) {
     logger.debug(`[session-origin] Failed to write sidecar marker (non-fatal): ${err}`);
+  }
+
+  if (TREE_STRUCTURED_TRANSCRIPT_AGENTS.has(codemieAgent)) {
+    logger.debug(
+      `[session-origin] Skipping in-transcript marker for ${codemieAgent}: the line would become the session's tree leaf and break resume`,
+    );
+    return;
   }
 
   // CR-007: spec says "skip and emit debug log if transcript not yet present" (non-fatal).

--- a/src/agents/plugins/pi/__tests__/pi.conversations-processor.test.ts
+++ b/src/agents/plugins/pi/__tests__/pi.conversations-processor.test.ts
@@ -190,11 +190,11 @@ function writeSessionRecord(sync?: Record<string, unknown>): void {
 }
 
 describe('PiConversationsProcessor', () => {
-  it('still reads the conversation when CodeMie has appended its ownership marker', async () => {
-    // `appendTranscriptMarker` appends a `codemie_session_start` line to the live transcript,
-    // and `correlateRunToSession` does so before the processors run. The marker is not a tree
-    // node — no `id`, no `parentId` — so treating "last line written" as the leaf ended the
-    // parent walk immediately and every real pi session normalised to zero events.
+  it('still reads the conversation when a transcript ends with an ownership marker', async () => {
+    // Transcripts recorded before `appendTranscriptMarker` stopped writing this line for pi
+    // still end with a `codemie_session_start`, and foreign tooling may append one. The marker
+    // is not a tree node — no `id`, no `parentId` — so treating "last line written" as the leaf
+    // ended the parent walk immediately and every such pi session normalised to zero events.
     const processor = await createProcessor();
     const session = buildSession([
       userEntry('add a health endpoint'),

--- a/src/agents/plugins/pi/session/processors/pi.conversations-processor.ts
+++ b/src/agents/plugins/pi/session/processors/pi.conversations-processor.ts
@@ -392,8 +392,8 @@ function selectActiveBranch(entries: PiEntry[]): PiActiveEntry[] {
   for (const [sourceIndex, entry] of entries.entries()) {
     // The `session` header line is not part of the tree — upstream drops it too.
     if (!entry || typeof entry !== 'object' || entry.type === 'session') continue;
-    // Only tree nodes may become the leaf. CodeMie appends its own `codemie_session_start`
-    // ownership marker to the end of the transcript (`appendTranscriptMarker`), and foreign
+    // Only tree nodes may become the leaf. Transcripts written before CodeMie stopped
+    // appending its `codemie_session_start` ownership marker still end with one, and foreign
     // tooling may append too. Such a line carries no `id`, so taking it as the leaf ended the
     // parent walk on its first step and normalised the whole conversation down to nothing.
     if (typeof entry.id !== 'string' || !entry.id) continue;


### PR DESCRIPTION
## Summary

`codemie-pi --resume <session-id>` opened the correct Pi transcript but the model saw an empty conversation, so every resume behaved like a brand-new session. The cause was CodeMie's own ownership marker, written into the transcript at SessionEnd. This drops the in-transcript write for Pi and keeps the sidecar, which is what attribution actually reads.

## Root cause

At SessionEnd, `appendTranscriptMarker()` appended a raw line to the Pi transcript:

```json
{"type":"codemie_session_start","uuid":"…","codemie_session_id":"…","codemie_agent":"pi"}
```

Pi's session file is an `id`/`parentId` tree. `SessionManager._buildIndex()` takes the **last** non-header line as the tree leaf, and `buildSessionPath()` walks `parentId` upwards from it to assemble the model context. The marker carries neither `id` nor `parentId`, so:

1. `leafId` became `undefined`;
2. `buildSessionPath` fell back to the last entry — the marker — whose walk ended immediately;
3. the model context collapsed to zero messages;
4. the next turn was written with `parentId: undefined`, starting a second root inside the same file.

Measured directly against Pi's own `SessionManager`:

| transcript | `leafId` | context entries |
|---|---|---|
| without marker line | `"ad517436"` | 4 |
| with marker line | `undefined` | **1** |

Every `codemie-pi` run poisoned its own transcript on exit, so any later resume was empty — including bare `pi --session <id>`, `pi -c`, and Pi's own `--resume` picker.

## Changes

- `session-origin-audit.ts`: `appendTranscriptMarker()` still writes the `~/.codemie/sessions/<name>-codemie-marker.json` sidecar for every agent, but returns before the in-transcript append for agents whose transcript is a parent-linked tree (`TREE_STRUCTURED_TRANSCRIPT_AGENTS = {'pi'}`).
- Updated two comments the change made factually false (`pi.conversations-processor.ts` and its test). The id-less-entry guard in `selectActiveBranch` stays — transcripts recorded before this change still carry markers, and foreign tooling may append too.

## Why attribution is unaffected

`native-loader`'s ownership index unions sidecar `transcriptPath` values with `correlation.agentSessionFile` from session records; `correlateRunToSession` writes a sidecar for **every** transcript in the run ledger, and the primary transcript is additionally covered by the correlation record. The in-transcript fallback scan reads only the first 10 lines / 4 KB while the marker was appended last, so it could never have classified a real Pi transcript.

The guard key holds on every Pi path: `BaseAgentAdapter` sets `CODEMIE_AGENT` to `metadata.name` (`'pi'`) *after* spreading `process.env`, so a user-set value cannot leak past it, and Pi's `SessionStart` passes an empty `transcript_path`, short-circuiting the `hook.ts` marker call sites.

## Testing

- [ ] Tests added/updated — no new tests (per repo policy, tests only on explicit request); the existing `pi.conversations-processor` marker-tolerance test still passes as a regression guard for legacy transcripts.
- [x] Manual testing done — end to end on a rebuilt `dist`: turn 1 replies `OMEGA`, then `codemie-pi --resume <id>` recalls `OMEGA`. Transcript afterwards: one file, one root, unbroken `parentId` chain, zero marker lines. Sidecar still written with the correct `transcriptPath` and `codemieAgent: "pi"`.

## Checklist

- [x] Code follows project standards
- [x] Lint clean (`--max-warnings=0`), `tsc --noEmit` clean, gitleaks clean, related vitest suites pass (all via pre-commit)
- [x] No merge conflicts with `main`