### PR TITLE
fix(proxy): forward Responses reasoning state, strip only after upstream rejects a replay

### DIFF
--- a/docs/ARCHITECTURE-PROXY.md
+++ b/docs/ARCHITECTURE-PROXY.md
@@ -724,11 +724,22 @@ function-call-output items. This keeps LiteLLM free to load-balance each request
 deployments.
 
 The proxy performs only bounded compatibility normalization for `vscode-byok`: it constrains the
-Responses `user` identifier and removes deployment-bound encrypted reasoning state. It preserves
-the selected `reasoning.effort`, visible messages, assistant phases, tools, call IDs, and tool
-outputs. The proxy does not persist conversation content, add session affinity, buffer Responses
-events, or transform the SSE stream. Removing encrypted state trades hidden-reasoning continuity
-for deployment-independent follow-ups, matching the established Codex compatibility behavior.
+Responses `user` identifier and forwards reasoning state untouched. It preserves the selected
+`reasoning.effort`, visible messages, assistant phases, tools, call IDs, and tool outputs. The
+proxy does not persist conversation content, add session affinity, buffer Responses events, or
+transform the SSE stream.
+
+Deployment-bound reasoning state is now handled server-side: the gateway runs LiteLLM
+`encrypted_content_affinity`, which routes a follow-up carrying encrypted content back to the
+deployment that produced it. Follow-ups therefore keep full cross-turn reasoning continuity.
+
+The proxy retains a self-healing fallback for the case where an affinity pin has expired
+(`deployment_affinity_ttl_seconds`). It watches upstream responses for `invalid_encrypted_content`
+and for bare-reasoning-id rejections; on the first sighting it strips reasoning state from every
+later request for the life of that proxy. The failing turn surfaces its error, then the session
+continues with degraded hidden-reasoning continuity rather than replaying unusable state forever.
+This applies uniformly to `codemie-codex`, `codemie-code`, `codemie-opencode`, `codemie-pi`, and
+`vscode-byok`.
 
 ```mermaid
 sequenceDiagram
@@ -741,7 +752,7 @@ sequenceDiagram
     PX->>PX: Validate and strip local key
     PX->>PX: Inject CodeMie SSO cookies
     PX->>PX: Inject profile/project context headers
-    PX->>PX: Normalize user and strip encrypted reasoning state
+    PX->>PX: Normalize user; forward reasoning state as-is
     PX->>GW: Forward stateless request
     GW->>LM: Invoke configured model
     LM-->>GW: Streaming events / tool calls

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -152,11 +152,15 @@ Use `medium` as the initial baseline; `none`, lower efforts, and `xhigh`/`max` r
 according to each model's advertised capability list.
 
 The proxy does not cache conversation state or rewrite response streams. Its bounded compatibility
-layer adds a safe `user` value when needed, limits long identifiers to 32 characters, and removes
-deployment-bound encrypted reasoning content for `vscode-byok`. This preserves the selected
-`reasoning.effort`, visible assistant history, and tool-call history, at the cost of cross-turn
-hidden-reasoning continuity. Prefer a current VS Code release (1.122 or newer) so the stateless
-flag and marker suppression are honored.
+layer adds a safe `user` value when needed and limits long identifiers to 32 characters.
+
+Encrypted reasoning content is forwarded unchanged: the gateway runs LiteLLM
+`encrypted_content_affinity`, so a follow-up carrying encrypted state is routed back to the
+deployment that produced it and cross-turn reasoning continuity is preserved. If an affinity pin
+expires and upstream rejects the replayed state, the proxy strips reasoning state for the
+remainder of that proxy's lifetime — that turn reports an error, then the session self-heals with
+reduced hidden-reasoning continuity. Prefer a current VS Code release (1.122 or newer) so the
+stateless flag and marker suppression are honored.
 
 Check the daemon context with `codemie proxy status`. Automated VS Code BYOK configuration
 and routing coverage runs as part of `npm run test:all`.
@@ -175,7 +179,7 @@ and routing coverage runs as part of `npm run test:all`.
 | Active profile changed but model did not | VS Code configuration still contains the previous profile model | Re-run `codemie proxy connect vscode` |
 | `previous_response_id` appears in a VS Code request | VS Code is older than the stateless Responses implementation or has stale model metadata | Upgrade to a current VS Code release, re-run the connector, reload VS Code, and verify `store: false` plus no `previous_response_id` in Chat Debug logs |
 | `previous_response_not_found` occurs on a follow-up | The client is still using stateful Responses replay | Complete the compatibility check above; do not add proxy-side response caching or deployment affinity |
-| `invalid_encrypted_content` occurs on a follow-up | Encrypted reasoning state reached a different deployment or the sanitizer is not active | Use the current proxy, confirm the `vscode-byok` sanitizer is enabled, and retry without sharing encrypted reasoning content in logs |
+| `invalid_encrypted_content` occurs on a follow-up | The affinity pin expired, or `encrypted_content_affinity` is not configured on the gateway | Retry the turn — the proxy strips reasoning state after the first rejection and the session continues. If it recurs on every session, verify the gateway's `optional_pre_call_checks` and `deployment_affinity_ttl_seconds`. Never share encrypted reasoning content in logs |
 | An effort value is rejected | The selected effort is not supported by that model/deployment | Choose an advertised effort (`none`, `low`, `medium`, `high`, `xhigh`, or `max` as listed for the model) and certify the deployment before broad rollout |
 | Inline suggestions still use Copilot | Expected limitation | BYOK covers chat/agent workflows, not inline completion |
 

--- a/docs/superpowers/plans/2026-08-09-encrypted-content-affinity-rollback.md
+++ b/docs/superpowers/plans/2026-08-09-encrypted-content-affinity-rollback.md
@@ -1,0 +1,230 @@
+# Retiring the Encrypted Content Sanitizer after `encrypted_content_affinity` lands
+
+**Status:** DONE (2026-08-10) — affinity verified live on `preview`; proxy switched to pass-through
+with a self-healing fallback. Remaining: update the two test files listed in §5.
+**Owner:** codemie-code proxy
+**Trigger:** CodeMie LiteLLM enables `encrypted_content_affinity` on the Responses-API model groups
+
+> **Implementation note.** §4 proposed a transparent retry. Inspecting the interceptor contract
+> showed no retry primitive exists — `streamResponse` pipes the upstream response straight through,
+> so retrying would mean buffering every 400 body in `sso.proxy.ts`, the shared path for all
+> clients. Because interceptors are constructed once per proxy (`sso.proxy.ts:123`) they can hold
+> state, so the shipped design latches a flag on first rejection instead: pass-through by default,
+> strip for the rest of the proxy's life once upstream rejects a replay. Same self-healing outcome,
+> zero changes to the proxy core, at the cost of one visible error per occurrence.
+>
+> **Verified on preview (2026-08-10):** reasoning item ids now arrive as
+> `encitem_<base64>` decoding to
+> `litellm:model_id:gpt-5-6-terra-2026-07-09-swedencentral-1;item_id:rs_...`, a two-turn encrypted
+> replay returns HTTP 200 with context carried, and a multi-turn `codemie-pi` tool-calling session
+> completed with the interceptor active and never triggering a strip.
+
+---
+
+## 1. Why this document exists
+
+The local CodeMie proxy currently deletes reasoning state from every Responses-API request
+before forwarding it to the CodeMie gateway. This is a deliberate workaround for a LiteLLM
+routing gap, and it costs real answer quality. Once DevOps enables server-side
+`encrypted_content_affinity`, the workaround becomes both unnecessary and actively harmful —
+it prevents the affinity check from ever engaging.
+
+This document records exactly what is being stripped today, what to change once the server
+config is live, and how to verify the change.
+
+---
+
+## 2. What the sanitizer removes today — and what it costs
+
+`src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts`
+runs at priority 16 on outbound requests for `codemie-codex`, `codemie-code`,
+`codemie-opencode`, `codemie-pi`, and `vscode-byok`. It rewrites the JSON body and performs
+three deletions:
+
+| # | What is deleted | Where |
+|---|---|---|
+| 1 | Every array element whose `type` is `"reasoning"` — the whole item, including its `summary` and `content` | `input[]` |
+| 2 | Every object key named `encrypted_content`, at any nesting depth | anywhere in the body |
+| 3 | The string `"reasoning.encrypted_content"` | `include[]` |
+
+### What this means for the model
+
+Yes — data is being removed from the agent↔LLM interaction, and it is not a trivial slice.
+
+A reasoning item is the container for the model's own prior thinking. Deleting the item
+removes **both** the encrypted chain-of-thought blob and the human-readable `summary` that
+travels inside it. Deletion #3 goes further and stops the gateway from producing encrypted
+reasoning at all, so there is nothing to carry forward even in principle.
+
+Net effect on every turn after the first:
+
+| Preserved | Discarded |
+|---|---|
+| `reasoning: { effort, summary }` request parameter — the model still thinks at the selected effort | All reasoning the model produced on previous turns |
+| Visible assistant messages | Encrypted chain-of-thought (`encrypted_content`) |
+| Tool calls, call IDs, tool outputs | Reasoning summaries attached to prior turns |
+| User messages, instructions, tools | — |
+
+The model re-derives its reasoning from visible history on each turn instead of resuming it.
+For single-shot questions this is close to invisible. For long multi-step agent loops —
+extended debugging, refactors spanning many tool calls — it degrades continuity and burns
+extra reasoning tokens re-establishing context the model had already worked out.
+
+This is a fidelity-for-availability trade. Without it, sessions fail hard.
+
+### Why it is currently unavoidable
+
+Two distinct upstream failures, both observed on `gpt-5.6-terra-2026-07-09`:
+
+1. **`invalid_encrypted_content`** — the client replays an encrypted reasoning item; LiteLLM
+   load-balances the follow-up to a deployment with a different API key, which cannot decrypt
+   it. This is what `encrypted_content_affinity` fixes.
+2. **`Item with id 'rs_...' not found`** — with deletion #3 in place the upstream returns
+   reasoning items with no `encrypted_content`; pi persists and replays the bare `rs_...` id,
+   and a `store: false` request cannot resolve an id the server never persisted. This is a
+   direct consequence of deletion #3 and disappears with it.
+
+Failure 2 is self-inflicted by the workaround. Failure 1 is the actual upstream gap.
+
+---
+
+## 3. Precondition — do not start until this is confirmed
+
+The LiteLLM proxy config must contain:
+
+```yaml
+router_settings:
+  enable_pre_call_checks: true
+  optional_pre_call_checks:
+    - encrypted_content_affinity
+  deployment_affinity_ttl_seconds: 86400
+```
+
+and every deployment in each affected model group must carry a unique, stable
+`model_info.id`. Affinity is tracked per deployment id; without stable ids the check cannot
+pin anything.
+
+**Verify against the live gateway before touching this repository.** Run the two-turn probe
+in §6 with the sanitizer bypassed (a local build with the plugin unregistered is enough). If
+turn 2 returns 200, the server side is ready. If it returns `invalid_encrypted_content`, it is
+not — stop and go back to DevOps.
+
+---
+
+## 4. Recommended design: fallback, not deletion
+
+Do **not** simply delete the plugin.
+
+`deployment_affinity_ttl_seconds` means the affinity pin expires. A pi or codex session
+resumed after the TTL window replays encrypted content whose pin is gone, and
+`invalid_encrypted_content` returns. Deleting the sanitizer outright trades a permanent
+degradation for an intermittent hard failure, which is worse for users because it is
+unpredictable.
+
+Target behavior:
+
+1. **Default path** — forward reasoning state untouched. Affinity routes the follow-up to the
+   originating deployment. Full reasoning continuity, which is the entire point of the DevOps
+   change.
+2. **Fallback path** — on an upstream `400` whose body matches `invalid_encrypted_content`,
+   strip reasoning state from that request and replay it once. The turn succeeds with degraded
+   continuity instead of surfacing an error to the user.
+3. **Observability** — `logger.warn` on every fallback trigger. A rising rate means the TTL is
+   too short for real session lengths, or affinity has regressed.
+
+The existing `sanitizeValue()` function is reusable as-is for the fallback path; only the
+trigger changes from unconditional to error-driven.
+
+If the fallback proves more complexity than it is worth, the acceptable simpler option is a
+config flag defaulting to *off*, so the strip can be re-enabled without a release. A plain
+deletion is the option to avoid.
+
+---
+
+## 5. Change inventory
+
+| File | Change |
+|---|---|
+| `src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts` | Convert `onRequest` unconditional strip into the error-triggered fallback of §4. Keep `sanitizeValue()`, `isReasoningInputItem()`, `isPlainObject()` unchanged. Rewrite the file docstring — it currently states the strip is unconditional. |
+| `src/providers/plugins/sso/proxy/plugins/index.ts` | Update the priority-16 registration comment (line ~39). Registration itself stays if the fallback is retained. |
+| `src/providers/plugins/sso/proxy/plugins/__tests__/codex-encrypted-content-sanitizer.plugin.test.ts` | Existing cases assert unconditional stripping and must be re-scoped to the fallback path. Add: reasoning state passes through untouched on the happy path. |
+| `tests/integration/vscode-byok.test.ts` (~lines 27, 280-327) | `strips encrypted Responses state while preserving stateless reasoning and tool history` asserts the old behavior. Update to expect pass-through, and add a fallback-path case. |
+| `docs/COMMANDS.md` (lines ~153-159, ~178) | Prose claims the proxy "removes deployment-bound encrypted reasoning content for `vscode-byok`". Replace with the fallback description. Rewrite the `invalid_encrypted_content` troubleshooting row — the remedy becomes "verify affinity is configured and the session is within the TTL". |
+| `docs/ARCHITECTURE-PROXY.md` (lines ~726-731, ~744) | Same claim in prose plus the `PX->>PX: Normalize user and strip encrypted reasoning state` step in the Mermaid sequence diagram. |
+| `src/cli/commands/proxy/connectors/vscode-models.ts` (line ~121) | Comment only. |
+
+### Explicitly out of scope
+
+- `src/agents/plugins/pi/pi.models.ts` — the `openai-responses` classification for
+  `gpt-5.6-*` is correct and stays.
+- All agent plugins — pi, codex, and opencode already replay reasoning items correctly. That
+  replay is precisely what starts working. No client change is required.
+- `request-sanitizer.plugin.ts` — unrelated concern (reasoning parameter shape), leave alone.
+
+---
+
+## 6. Verification
+
+### 6.1 Gateway probe — before and after
+
+```bash
+# Turn 1 — capture a response carrying encrypted reasoning
+curl -s "$LITELLM_URL/v1/responses" \
+  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-5.6-terra-2026-07-09","store":false,
+       "reasoning":{"effort":"medium","summary":"auto"},
+       "include":["reasoning.encrypted_content"],
+       "input":[{"role":"user","content":[{"type":"input_text","text":"What is 17*23?"}]}]}' \
+  | tee turn1.json
+
+# Confirm encrypted content is actually present — if absent, affinity has nothing to key on
+jq '[.output[] | select(.type=="reasoning") | .encrypted_content] | length' turn1.json
+
+# Turn 2 — replay turn 1's output verbatim. Must return 200.
+jq '{model:"gpt-5.6-terra-2026-07-09",store:false,
+     reasoning:{effort:"medium",summary:"auto"},
+     include:["reasoning.encrypted_content"],
+     input:(.output + [{role:"user",content:[{type:"input_text",text:"And times 2?"}]}])}' turn1.json \
+  | curl -s "$LITELLM_URL/v1/responses" -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -d @-
+```
+
+### 6.2 End-to-end through the agents
+
+```bash
+node ./bin/codemie-pi.js --model "gpt-5.6-terra-2026-07-09"
+```
+
+Run a conversation of at least four turns including tool calls. Success criteria:
+
+- No `invalid_encrypted_content` and no `Item with id 'rs_...' not found`.
+- With `CODEMIE_DEBUG=true`, the proxy logs show reasoning items **present** in forwarded
+  request bodies — that is the observable difference from today.
+- No fallback warnings during a normal session.
+
+Repeat for `codemie-codex`, `codemie-opencode`, and VS Code BYOK. All four share this plugin,
+so all four change behavior together.
+
+### 6.3 TTL behavior
+
+Start a session, leave it idle past `deployment_affinity_ttl_seconds`, then continue it. The
+expected outcome is a single fallback warning and a successful turn — not a user-visible
+error. This is the case that justifies keeping the fallback.
+
+---
+
+## 7. Rollback
+
+Re-enable the unconditional strip (revert the plugin to its current `onRequest`) and rebuild.
+No data migration, no coordination with the gateway. Sessions in flight recover on their next
+turn.
+
+---
+
+## 8. Reference
+
+- LiteLLM encrypted content affinity: https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing
+- LiteLLM load balancing config: https://docs.litellm.ai/docs/proxy/load_balancing
+- LiteLLM incident write-up: https://docs.litellm.ai/blog/responses-api-encrypted-content-incident
+- pi reasoning replay: `packages/ai/src/api/openai-responses-shared.ts:221-224` (replay),
+  `packages/ai/src/api/openai-responses.ts:293,328` (`store: false`, `include`)

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/codex-encrypted-content-sanitizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/codex-encrypted-content-sanitizer.plugin.test.ts
@@ -1,8 +1,14 @@
 /**
  * Codex Encrypted Content Sanitizer Plugin Tests
  *
- * Tests agent-scoping and functional encrypted-content removal for
- * codemie-codex, codemie-code, codemie-opencode, and vscode-byok agents.
+ * The gateway runs LiteLLM `encrypted_content_affinity`, so reasoning state is
+ * forwarded untouched by default. Stripping is a self-healing fallback that
+ * engages only after upstream rejects a replay (expired affinity pin, or a bare
+ * reasoning id under `store: false`).
+ *
+ * Covers agent scoping, default pass-through, latch detection, and the strip
+ * behavior once latched, for codemie-codex, codemie-code, codemie-opencode,
+ * codemie-pi, and vscode-byok agents.
  *
  * @group unit
  */
@@ -12,6 +18,13 @@ import { CodexEncryptedContentSanitizerPlugin } from '../codex-encrypted-content
 import { PluginContext, ProxyInterceptor } from '../types.js';
 import { ProxyContext } from '../../proxy-types.js';
 import { logger } from '../../../../../../utils/logger.js';
+
+const AFFINITY_REJECTION = JSON.stringify({
+  error: { code: 'invalid_encrypted_content', message: 'could not be verified' },
+});
+const BARE_ITEM_REJECTION = JSON.stringify({
+  error: { message: "Item with id 'rs_abc' not found. Items are not persisted when `store` is set to false." },
+});
 
 function createPluginContext(clientType?: string): PluginContext {
   return {
@@ -25,14 +38,14 @@ function createPluginContext(clientType?: string): PluginContext {
   };
 }
 
-function createProxyContext(body: unknown): ProxyContext {
+function createProxyContext(body: unknown, url = '/v1/responses'): ProxyContext {
   const requestBody = Buffer.from(JSON.stringify(body), 'utf-8');
   return {
     requestId: 'test-req',
     sessionId: 'test-session',
     agentName: 'test-agent',
     method: 'POST',
-    url: '/v1/responses',
+    url,
     headers: {
       'content-type': 'application/json',
       'content-length': String(requestBody.length),
@@ -41,6 +54,11 @@ function createProxyContext(body: unknown): ProxyContext {
     requestStartTime: Date.now(),
     metadata: {},
   };
+}
+
+/** Drive the interceptor through an upstream rejection so the fallback engages. */
+async function latchFallback(interceptor: ProxyInterceptor, body = AFFINITY_REJECTION): Promise<void> {
+  await interceptor.onResponseChunk!(createProxyContext({}), Buffer.from(body, 'utf-8'));
 }
 
 describe('CodexEncryptedContentSanitizerPlugin', () => {
@@ -62,23 +80,14 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
   });
 
   describe('createInterceptor — Agent Scoping', () => {
-    it('creates interceptor for codemie-codex', async () => {
-      const interceptor = await plugin.createInterceptor(createPluginContext('codemie-codex'));
-      expect(interceptor).toBeDefined();
-    });
-
-    it('creates interceptor for codemie-code', async () => {
-      const interceptor = await plugin.createInterceptor(createPluginContext('codemie-code'));
-      expect(interceptor).toBeDefined();
-    });
-
-    it('creates interceptor for codemie-opencode', async () => {
-      const interceptor = await plugin.createInterceptor(createPluginContext('codemie-opencode'));
-      expect(interceptor).toBeDefined();
-    });
-
-    it('creates interceptor for vscode-byok', async () => {
-      const interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
+    it.each([
+      'codemie-codex',
+      'codemie-code',
+      'codemie-opencode',
+      'codemie-pi',
+      'vscode-byok',
+    ])('creates interceptor for %s', async clientType => {
+      const interceptor = await plugin.createInterceptor(createPluginContext(clientType));
       expect(interceptor).toBeDefined();
     });
 
@@ -93,11 +102,122 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
     });
   });
 
-  describe('Encrypted content removal — codemie-code', () => {
+  describe('Default pass-through (affinity healthy)', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-pi'));
+    });
+
+    it('forwards encrypted reasoning items untouched', async () => {
+      const body = {
+        model: 'gpt-5.6-terra-2026-07-09',
+        include: ['reasoning.encrypted_content'],
+        input: [
+          { type: 'message', role: 'user', content: 'hello' },
+          { type: 'reasoning', id: 'rs_1', encrypted_content: 'abc123==' },
+        ],
+      };
+      const context = createProxyContext(body);
+      const originalStr = context.requestBody!.toString('utf-8');
+      const originalLength = context.headers['content-length'];
+
+      await interceptor.onRequest!(context);
+
+      expect(context.requestBody!.toString('utf-8')).toBe(originalStr);
+      expect(context.headers['content-length']).toBe(originalLength);
+    });
+
+    it('leaves the include array intact so upstream keeps returning encrypted content', async () => {
+      const body = {
+        model: 'gpt-5.6-terra-2026-07-09',
+        include: ['reasoning.encrypted_content', 'usage'],
+      };
+      const context = createProxyContext(body);
+
+      await interceptor.onRequest!(context);
+
+      const result = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(result.include).toEqual(['reasoning.encrypted_content', 'usage']);
+    });
+  });
+
+  describe('Latch detection via onResponseChunk', () => {
+    let interceptor: ProxyInterceptor;
+
+    beforeEach(async () => {
+      interceptor = await plugin.createInterceptor(createPluginContext('codemie-pi'));
+    });
+
+    it('returns the chunk unmodified (read-only scan)', async () => {
+      const chunk = Buffer.from(AFFINITY_REJECTION, 'utf-8');
+
+      const result = await interceptor.onResponseChunk!(createProxyContext({}), chunk);
+
+      expect(result).toBe(chunk);
+    });
+
+    it.each([
+      ['invalid_encrypted_content', AFFINITY_REJECTION],
+      ['bare reasoning id under store:false', BARE_ITEM_REJECTION],
+    ])('engages the fallback on %s', async (_label, rejection) => {
+      const body = { input: [{ type: 'reasoning', id: 'rs_1', encrypted_content: 'abc==' }] };
+      const before = createProxyContext(body);
+      await interceptor.onRequest!(before);
+      expect(JSON.parse(before.requestBody!.toString('utf-8')).input).toHaveLength(1);
+
+      await latchFallback(interceptor, rejection);
+
+      const after = createProxyContext(body);
+      await interceptor.onRequest!(after);
+      expect(JSON.parse(after.requestBody!.toString('utf-8')).input).toHaveLength(0);
+    });
+
+    it('matches a marker split across two chunks', async () => {
+      const context = createProxyContext({});
+      await interceptor.onResponseChunk!(context, Buffer.from('{"code":"invalid_encry', 'utf-8'));
+      await interceptor.onResponseChunk!(context, Buffer.from('pted_content"}', 'utf-8'));
+
+      const request = createProxyContext({ input: [{ type: 'reasoning', id: 'rs_1' }] });
+      await interceptor.onRequest!(request);
+
+      expect(JSON.parse(request.requestBody!.toString('utf-8')).input).toHaveLength(0);
+    });
+
+    it('ignores non-Responses traffic', async () => {
+      await interceptor.onResponseChunk!(
+        createProxyContext({}, '/v1/chat/completions'),
+        Buffer.from(AFFINITY_REJECTION, 'utf-8')
+      );
+
+      const request = createProxyContext({
+        input: [{ type: 'reasoning', id: 'rs_1', encrypted_content: 'abc==' }],
+      });
+      await interceptor.onRequest!(request);
+
+      expect(JSON.parse(request.requestBody!.toString('utf-8')).input).toHaveLength(1);
+    });
+
+    it('does not latch on a clean stream', async () => {
+      const context = createProxyContext({});
+      await interceptor.onResponseChunk!(context, Buffer.from('data: {"type":"response.created"}', 'utf-8'));
+      await interceptor.onResponseChunk!(context, Buffer.from('data: {"type":"response.completed"}', 'utf-8'));
+
+      const request = createProxyContext({
+        input: [{ type: 'reasoning', id: 'rs_1', encrypted_content: 'abc==' }],
+      });
+      await interceptor.onRequest!(request);
+
+      expect(JSON.parse(request.requestBody!.toString('utf-8')).input).toHaveLength(1);
+    });
+  });
+
+  describe('Reasoning state removal once latched — codemie-code', () => {
     let interceptor: ProxyInterceptor;
 
     beforeEach(async () => {
       interceptor = await plugin.createInterceptor(createPluginContext('codemie-code'));
+      await latchFallback(interceptor);
     });
 
     it('removes encrypted reasoning items from input array', async () => {
@@ -115,6 +235,22 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
       const result = JSON.parse(context.requestBody!.toString('utf-8'));
       expect(result.input).toHaveLength(1);
       expect(result.input[0].type).toBe('message');
+    });
+
+    it('removes bare reasoning items that carry no encrypted content', async () => {
+      const body = {
+        model: 'gpt-5.6-terra-2026-07-09',
+        input: [
+          { type: 'message', role: 'user', content: 'hello' },
+          { type: 'reasoning', id: 'rs_06547a8c', summary: [] },
+        ],
+      };
+      const context = createProxyContext(body);
+
+      await interceptor.onRequest!(context);
+
+      const result = JSON.parse(context.requestBody!.toString('utf-8'));
+      expect(result.input).toEqual([{ type: 'message', role: 'user', content: 'hello' }]);
     });
 
     it('removes reasoning.encrypted_content from include array', async () => {
@@ -145,7 +281,7 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
       expect(Number(context.headers['content-length'])).toBe(context.requestBody!.length);
     });
 
-    it('passes through body with no encrypted content unchanged', async () => {
+    it('passes through body with no reasoning state unchanged', async () => {
       const body = { model: 'gpt-5.5-2026-04-24', input: [{ type: 'message', content: 'hi' }] };
       const context = createProxyContext(body);
       const originalStr = context.requestBody!.toString('utf-8');
@@ -156,9 +292,10 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
     });
   });
 
-  describe('Encrypted content removal — codemie-codex (regression)', () => {
+  describe('Reasoning state removal once latched — codemie-codex (regression)', () => {
     it('still removes encrypted items for codemie-codex', async () => {
       const interceptor = await plugin.createInterceptor(createPluginContext('codemie-codex'));
+      await latchFallback(interceptor);
       const body = {
         model: 'gpt-5.3-codex',
         input: [{ type: 'reasoning', encrypted_content: 'xyz==' }],
@@ -172,9 +309,10 @@ describe('CodexEncryptedContentSanitizerPlugin', () => {
     });
   });
 
-  describe('Encrypted content removal — vscode-byok', () => {
+  describe('Reasoning state removal once latched — vscode-byok', () => {
     it('removes encrypted state while preserving reasoning effort and visible tool history', async () => {
       const interceptor = await plugin.createInterceptor(createPluginContext('vscode-byok'));
+      await latchFallback(interceptor);
       const visibleItems = [
         { type: 'message', role: 'user', content: 'hello' },
         {

--- a/src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/codex-encrypted-content-sanitizer.plugin.ts
@@ -2,22 +2,30 @@
  * Encrypted Content Sanitizer
  * Priority: 16 (after generic request sanitizer, before header injection)
  *
- * LiteLLM/Azure can reject Responses API follow-up requests when encrypted
- * reasoning content is load-balanced to a different deployment/API key than
- * the one that created it. Server-side encrypted_content_affinity is the
- * correct fix. This client-side sanitizer is a defensive fallback:
- * it removes replayed reasoning state so the session can continue instead of
- * failing with invalid_encrypted_content (encrypted item routed to the wrong
- * deployment) or "Item with id 'rs_...' not found" (bare item under store:false).
+ * Responses API reasoning items are bound to the deployment that produced them:
+ * `encrypted_content` is decryptable only by the API key that created it, and a
+ * bare `rs_...` id is unresolvable under `store: false`. Replaying either one
+ * against the wrong deployment fails the turn.
+ *
+ * The gateway now runs LiteLLM `encrypted_content_affinity`, which routes a
+ * follow-up carrying encrypted content back to its originating deployment. So
+ * the default path is pass-through: reasoning state is forwarded untouched and
+ * agents keep full cross-turn reasoning continuity.
+ *
+ * Affinity pins expire (`deployment_affinity_ttl_seconds`), and a session
+ * resumed after expiry replays state no deployment can resolve. Because clients
+ * replay their whole history every turn, that first failure would otherwise
+ * repeat forever. This interceptor therefore watches upstream responses for the
+ * two failure signatures and, once either is seen, strips reasoning state from
+ * every subsequent request for the life of the proxy. The failing turn surfaces
+ * its error; the session then self-heals with degraded continuity instead of
+ * staying stuck.
+ *
+ * Stripping is the same trade as before: reasoning effort, visible messages,
+ * tool calls, and tool outputs survive; prior hidden reasoning does not.
  *
  * Scope: codemie-codex, codemie-code, codemie-opencode, codemie-pi, and
- * vscode-byok. This
- * cross-client fallback covers Responses-API sessions when load balancing can
- * send encrypted state to a different deployment/API key. Tradeoff: drops
- * cross-turn hidden-reasoning continuity to avoid hard invalid_encrypted_content
- * failures while preserving effort, visible messages, and tool history. If
- * server-side encrypted_content_affinity becomes available, this client strip
- * becomes redundant.
+ * vscode-byok.
  */
 
 import { ProxyPlugin, PluginContext, ProxyInterceptor } from './types.js';
@@ -32,6 +40,19 @@ const ALLOWED_AGENTS = [
   'vscode-byok',
 ];
 const ENCRYPTED_CONTENT_INCLUDE = 'reasoning.encrypted_content';
+const RESPONSES_PATH_SUFFIX = '/responses';
+
+/**
+ * Upstream signatures that mean replayed reasoning state was rejected:
+ * affinity miss or expired pin, and a bare reasoning id under `store: false`.
+ * Kept short so LiteLLM's nested JSON escaping cannot break the match.
+ */
+const UNUSABLE_REASONING_STATE_MARKERS = [
+  'invalid_encrypted_content',
+  'Items are not persisted when',
+];
+const MARKER_OVERLAP_BYTES = Math.max(...UNUSABLE_REASONING_STATE_MARKERS.map(m => m.length)) - 1;
+const MARKER_CARRY_KEY = 'encryptedContentSanitizerMarkerCarry';
 
 interface SanitizeResult {
   value: unknown;
@@ -58,9 +79,16 @@ export class CodexEncryptedContentSanitizerPlugin implements ProxyPlugin {
 class CodexEncryptedContentSanitizerInterceptor implements ProxyInterceptor {
   name = 'codex-encrypted-content-sanitizer';
 
+  /** Set once upstream rejects replayed reasoning state; never cleared for this proxy. */
+  private reasoningStateUnusable = false;
+
   constructor(private readonly clientType: string) {}
 
   async onRequest(context: ProxyContext): Promise<void> {
+    if (!this.reasoningStateUnusable) {
+      return;
+    }
+
     if (!context.requestBody || !context.headers['content-type']?.includes('application/json')) {
       return;
     }
@@ -83,6 +111,38 @@ class CodexEncryptedContentSanitizerInterceptor implements ProxyInterceptor {
     } catch {
       // Not valid JSON or unexpected structure — pass through unchanged.
     }
+  }
+
+  /**
+   * Read-only scan of the upstream stream. Returns the chunk untouched; the only
+   * effect is latching `reasoningStateUnusable` so later requests get stripped.
+   */
+  async onResponseChunk(context: ProxyContext, chunk: Buffer): Promise<Buffer | null> {
+    if (this.reasoningStateUnusable || !context.url.includes(RESPONSES_PATH_SUFFIX)) {
+      return chunk;
+    }
+
+    // Carry lives on the per-request context: concurrent streams must not share it.
+    const carry = context.metadata[MARKER_CARRY_KEY];
+    const searchable = Buffer.isBuffer(carry) ? Buffer.concat([carry, chunk]) : chunk;
+    const marker = UNUSABLE_REASONING_STATE_MARKERS.find(m => searchable.includes(m));
+
+    if (marker) {
+      this.reasoningStateUnusable = true;
+      delete context.metadata[MARKER_CARRY_KEY];
+      logger.warn(
+        `[${this.name}] Upstream rejected replayed reasoning state for ${this.clientType} ("${marker}"). ` +
+        'Stripping reasoning state from subsequent requests — cross-turn reasoning continuity is degraded ' +
+        'for the rest of this session. Expected after an encrypted_content_affinity pin expires; ' +
+        'a rising rate means deployment_affinity_ttl_seconds is too short.'
+      );
+      return chunk;
+    }
+
+    context.metadata[MARKER_CARRY_KEY] = searchable.subarray(
+      Math.max(0, searchable.length - MARKER_OVERLAP_BYTES)
+    );
+    return chunk;
   }
 }
 

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -36,7 +36,7 @@ export function registerCorePlugins(): void {
   registry.register(new ClaudeRequestNormalizerPlugin()); // Priority 14 - normalizes thinking params for claude models
   registry.register(new KimiRequestNormalizerPlugin()); // Priority 14 - caps Kimi output token requests for upstream limits
   registry.register(new RequestSanitizerPlugin()); // Priority 15 - strips unsupported reasoning params
-  registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - strips deployment-bound encrypted Responses reasoning state
+  registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - forwards Responses reasoning state; strips it only after upstream rejects a replay
   registry.register(new VsCodeRequestNormalizerPlugin()); // Priority 17 - constrains VS Code user identifiers
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level

--- a/tests/integration/vscode-byok.test.ts
+++ b/tests/integration/vscode-byok.test.ts
@@ -277,7 +277,7 @@ describe('VS Code BYOK model matrix', () => {
     }
   });
 
-  it('strips encrypted Responses state while preserving stateless reasoning and tool history', async () => {
+  it('forwards encrypted Responses state untouched while affinity is healthy', async () => {
     const captured: CapturedRequest[] = [];
     const upstream = await listen(createServer((req, res) => {
       void readRequestBody(req).then((body) => {
@@ -343,14 +343,87 @@ describe('VS Code BYOK model matrix', () => {
 
     const expectedBody = {
       ...requestBody,
-      include: ['usage'],
-      input: input.filter(item => item.type !== 'reasoning'),
       user: 'vscode-byok',
     };
     expect(captured[0]?.body).toEqual(expectedBody);
     expect(captured[0]?.body).not.toHaveProperty('previous_response_id');
     expect(captured[0]?.headers['content-length']).toBe(
       String(Buffer.byteLength(JSON.stringify(expectedBody), 'utf-8'))
+    );
+  });
+
+  it('strips reasoning state on later requests once upstream rejects a replay', async () => {
+    const captured: CapturedRequest[] = [];
+    const upstream = await listen(createServer((req, res) => {
+      void readRequestBody(req).then((body) => {
+        captured.push({ url: req.url ?? '/', headers: req.headers, body });
+        res.setHeader('content-type', 'application/json');
+        // First response mimics an expired affinity pin; later ones succeed.
+        if (captured.length === 1) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({
+            error: { code: 'invalid_encrypted_content', message: 'could not be verified' },
+          }));
+          return;
+        }
+        res.end(JSON.stringify({ ok: true }));
+      });
+    }));
+    servers.push(upstream.server);
+
+    const startedProxy = await startVsCodeProxy(upstream.url);
+    proxies.push(startedProxy.proxy);
+
+    const input = [
+      { type: 'message', role: 'user', content: 'Call the test tool.' },
+      { type: 'reasoning', summary: [], encrypted_content: 'deployment-bound-state' },
+      {
+        type: 'function_call',
+        call_id: 'call-1',
+        name: 'get_test_value',
+        arguments: '{}',
+      },
+    ];
+    const requestBody = {
+      model: 'gpt-5.6-sol-2026-07-09',
+      store: false,
+      stream: false,
+      reasoning: { effort: 'medium' },
+      include: ['reasoning.encrypted_content', 'usage'],
+      input,
+      tools: [{ type: 'function', name: 'get_test_value' }],
+    };
+    const send = () => fetch(`${startedProxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${GATEWAY_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const rejected = await send();
+    expect(rejected.status).toBe(400);
+    // Rejection is surfaced, not swallowed: that turn fails, the session recovers.
+    expect(captured[0]?.body).toMatchObject({
+      include: ['reasoning.encrypted_content', 'usage'],
+    });
+    expect(captured[0]?.body.input).toContainEqual(
+      expect.objectContaining({ type: 'reasoning' })
+    );
+
+    const recovered = await send();
+    expect(recovered.status).toBe(200);
+
+    const strippedBody = {
+      ...requestBody,
+      include: ['usage'],
+      input: input.filter(item => item.type !== 'reasoning'),
+      user: 'vscode-byok',
+    };
+    expect(captured[1]?.body).toEqual(strippedBody);
+    expect(captured[1]?.headers['content-length']).toBe(
+      String(Buffer.byteLength(JSON.stringify(strippedBody), 'utf-8'))
     );
   });
 });


### PR DESCRIPTION
## Summary

The CodeMie gateway now runs LiteLLM `encrypted_content_affinity`, which routes a Responses-API follow-up carrying encrypted reasoning content back to the deployment that produced it. The proxy therefore no longer needs to strip that state pre-emptively.

Until now the proxy removed **all** reasoning items from every Responses request. That kept sessions alive while the gateway load-balanced blindly, but it discarded the model's prior reasoning — both the encrypted chain-of-thought and the summary carried inside the item — on every turn after the first, for `codemie-codex`, `codemie-code`, `codemie-opencode`, `codemie-pi`, and `vscode-byok`.

This flips the sanitizer to pass-through by default and keeps a self-healing fallback for the case where an affinity pin has expired.

## Changes

- **Pass-through by default** — `onRequest` returns immediately unless the fallback has engaged, so reasoning state reaches the gateway untouched and agents keep cross-turn reasoning continuity.
- **Self-healing fallback** — a new read-only `onResponseChunk` scan watches upstream for `invalid_encrypted_content` (expired/missing affinity pin) and `Items are not persisted when` (bare reasoning id under `store: false`). The first sighting latches and strips reasoning state from every later request for the life of that proxy. The failing turn surfaces its error; the session then continues with degraded continuity instead of replaying unusable state forever. A `warn` names the matched marker and points at `deployment_affinity_ttl_seconds`.
- **State scoping** — the latch is interceptor state (interceptors are constructed once per proxy, `sso.proxy.ts:123`), while the chunk-boundary carry buffer lives on the per-request `context.metadata` so concurrent streams never share it.
- **`codemie-pi` added to the allowed-agent list** — missing since the pi plugin landed, which is why pi sessions failed on their second turn.
- **Bare reasoning items are now stripped too** — a reasoning id is deployment-bound whether or not it carries a payload, so both shapes are unusable on a stateless follow-up.
- Docs updated (`ARCHITECTURE-PROXY.md` prose + sequence diagram, `COMMANDS.md` prose + troubleshooting row) and a plan/rollback doc added.

## Impact

**Before** — every Responses turn after the first lost all prior reasoning; long agent loops re-derived context and burned extra reasoning tokens.
**After** — full reasoning continuity on the happy path; one visible error then automatic recovery if an affinity pin expires.

Requires `encrypted_content_affinity` on the gateway. If it is ever disabled, the fallback engages on the first turn and behavior returns to today's strip-everything baseline — no hard failure.

## Verification

- **Live against preview** — reasoning ids now arrive as `encitem_<base64>` decoding to `litellm:model_id:gpt-5-6-terra-2026-07-09-swedencentral-1;item_id:rs_...`; a two-turn encrypted replay returned HTTP 200 with context correctly carried.
- **End-to-end** — `node ./bin/codemie-pi.js --profile preview --model gpt-5.6-terra-2026-07-09 -p "<multi-tool prompt>"` completed a multi-turn tool-calling session with the interceptor active and no strip triggered (verified in debug logs).
- **Tests** — 147 passed / 8 files (proxy suite, `vscode-byok`, `transparent-vscode-proxy`). Unit tests restructured around pass-through / latch-detection / strip-once-latched; the vscode-byok integration test now drives the latch through the real proxy pipeline.
- `tsc --noEmit`, eslint, and gitleaks clean.

## Checklist

- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated
- [x] No breaking changes
