### PR TITLE
docs: refresh README and AGENTS.md for current agent and provider roster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,11 +122,13 @@ Ask the user when:
 | Keywords | P0 Guide | P1 Guide |
 |---|---|---|
 | `plugin`, `registry`, `agent`, `adapter` | architecture | external-integrations |
+| `claude`, `codex`, `gemini`, `opencode`, `pi`, `kimi`, `copilot`, `acp` | architecture | external-integrations |
+| `session`, `metrics`, `analytics`, `transcript`, `sync` | architecture | external-integrations |
 | `architecture`, `layer`, `structure`, `pattern` | architecture | development-practices |
 | `test`, `vitest`, `mock`, `coverage` | testing-patterns | development-practices |
 | `error`, `exception`, `validation` | development-practices | security-practices |
 | `security`, `sanitize`, `credential` | security-practices | development-practices |
-| `provider`, `sso`, `bedrock`, `litellm`, `langgraph`, `kimi` | external-integrations | architecture |
+| `provider`, `sso`, `bedrock`, `litellm`, `langgraph`, `ollama`, `subscription` | external-integrations | architecture |
 | `cli`, `command`, `commander` | architecture | development-practices |
 | `workflow`, `ci/cd`, `github`, `gitlab` | git-workflow | quality-gates |
 | `lint`, `eslint`, `format`, `code quality` | code-quality | quality-gates |
@@ -166,7 +168,7 @@ Detailed patterns for architecture, error handling, logging, security, project c
 | Imports without `.js` | Always include `.js` extension |
 | Deep relative imports (`../../..`) | `@/` alias (e.g. `@/env/types.js`) |
 | Writing tests by default | Tests only on explicit request |
-| `child_process.exec` directly | `exec()` from `src/utils/processes.ts` |
+| `child_process.exec` directly | `exec()` from `src/utils/exec.ts`; npm/spawn helpers in `src/utils/processes.ts` |
 | `console.log()` debug output | `logger.debug()` |
 | Logging raw secrets or tokens | `sanitizeLogArgs()` |
 | Throwing generic `Error` | Specific project error classes |
@@ -196,11 +198,34 @@ Project defaults:
 - Package manager: npm
 - Test framework: Vitest
 - Build output: `dist/`
-- Entry points: `bin/codemie.js`, `bin/agent-executor.js`
+- Entry points: `bin/codemie.js` (CLI), `bin/agent-executor.js` (built-in agent), `bin/codemie-<agent>.js` (per-agent shortcuts), `bin/codemie-mcp-proxy.js`, `bin/proxy-daemon.js`. All declared in `package.json:bin`.
 
 ## Project Context
 
 See `package.json` for exact dependency versions and `.ai-run/guides/architecture/architecture.md` for the plugin-based 5-layer architecture, layer responsibilities, and `src/` directory roles.
+
+### Agent Plugins (`src/agents/plugins/`, registered in `src/agents/registry.ts`)
+
+| Plugin | Dir | Upstream | Notes |
+|---|---|---|---|
+| `codemie-code` | `codemie-code.plugin.ts` | `@codemieai/codemie-opencode` | Built-in (`isBuiltIn`); native binary resolved by `codemie-code-binary.ts`, OpenCode-derived (`.opencode` home, `run`/`chat`/`config`/`init` subcommands). **Not** LangGraph — LangGraph now only backs LLM hooks (`src/hooks/prompt-executor.ts`) |
+| `claude` / `claude-acp` | `claude/` | `@anthropic-ai/claude-code`, `@zed-industries/claude-code-acp` | Ships the CodeMie Claude plugin (`claude/plugin/`) |
+| `codex` | `codex/` | `@openai/codex` | Responses API; reasoning state handled by proxy plugins |
+| `gemini` | `gemini/` | `@google/gemini-cli` | |
+| `opencode` | `opencode/` | `opencode-ai` | Session metrics via `codemie opencode-metrics` |
+| `pi` | `pi/` | `@earendil-works/pi-coding-agent` | Redirects `PI_CODING_AGENT_DIR` to `<cwd>/.pi/codemie/agent`; metrics via injected extension + run ledger |
+| `kimi` / `kimi-acp` | `kimi/` | `@moonshot-ai/kimi-code` | ACP variant prepends `acp` to argv |
+| `copilot-cli` | `copilot-cli/` | none | Analytics ingestion only — never installed or launched by CodeMie |
+
+Not agent adapters, but injected runtime plugins under the same tree: `codemie-code-hooks/` (injected into `codemie-code` and `opencode`) and `reasoning-sanitizer/` (injected into `codemie-code`).
+
+### Provider Plugins (`src/providers/plugins/`, auto-register via `registerProvider()`)
+
+`sso` (CodeMie SSO — default, owns the local proxy), `jwt` (Bearer Authorization), `litellm`, `bedrock`, `ollama`, `anthropic-subscription`, `moonshot-subscription`.
+
+Proxy plugins live under `src/providers/plugins/sso/proxy/plugins/` — see `.ai-run/guides/` and `docs/ARCHITECTURE-PROXY.md`.
+
+> Neither `.ai-run/guides/integration/external-integrations.md` nor `docs/AGENTS.md` covers Pi yet. For Pi work, read `src/agents/plugins/pi/` directly plus the design docs under `docs/superpowers/specs/`.
 
 ## Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3%2B-blue.svg)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-> **Unified AI Coding Assistant CLI** - Manage Claude Code, OpenAI Codex, Google Gemini, OpenCode, and custom AI agents from one powerful command-line interface. Multi-provider support (OpenAI, Azure OpenAI, AWS Bedrock, LiteLLM, Ollama, Enterprise SSO, JWT Bearer Auth). Built-in LangGraph agent with file operations, command execution, and planning tools. Cross-platform support for Windows, Linux, and macOS.
+> **Unified AI Coding Assistant CLI** - Manage Claude Code, OpenAI Codex, Google Gemini, OpenCode, Pi, Kimi Code, and custom AI agents from one powerful command-line interface. Multi-provider support (CodeMie SSO, Bearer Auth, LiteLLM, AWS Bedrock, Ollama, Anthropic Subscription, Moonshot Subscription). Built-in native agent with file operations, command execution, planning mode, and plugins. Cross-platform support for Windows, Linux, and macOS.
 
 ---
 
@@ -22,9 +22,9 @@
 
 CodeMie CLI is the all-in-one AI coding assistant for developers.
 
-- ✨ **One CLI, Multiple AI Agents** - Switch between Claude Code, OpenAI Codex, Gemini, OpenCode, and built-in agent.
-- 🔄 **Multi-Provider Support** - OpenAI, Azure OpenAI, AWS Bedrock, LiteLLM, Ollama, Enterprise SSO, and JWT Bearer Auth.
-- 🚀 **Built-in Agent** - A powerful LangGraph-based assistant with file operations, command execution, and planning tools.
+- ✨ **One CLI, Multiple AI Agents** - Switch between Claude Code, OpenAI Codex, Gemini, OpenCode, Pi, Kimi Code, and built-in agent.
+- 🔄 **Multi-Provider Support** - CodeMie SSO, Bearer Authorization, LiteLLM, AWS Bedrock, Ollama, Anthropic Subscription, and Moonshot Subscription.
+- 🚀 **Built-in Agent** - `codemie-code` ships with the CLI: file operations, command execution, planning mode, and native plugins.
 - 🖥️ **Cross-Platform** - Full support for Windows, Linux, and macOS with platform-specific optimizations.
 - 🔗 **MCP Proxy** - Connect to remote MCP servers with automatic OAuth authorization.
 - 🔐 **Enterprise Ready** - SSO and JWT authentication, audit logging, and role-based access.
@@ -149,7 +149,7 @@ npm install @codemieai/code
 npx @codemieai/code --help
 ```
 
-**Note:** Agent shortcuts (`codemie-claude`, `codemie-codex`, `codemie-code`, `codemie-opencode`, etc.) require global installation.
+**Note:** Agent shortcuts (`codemie-claude`, `codemie-codex`, `codemie-code`, `codemie-opencode`, `codemie-pi`, `codemie-kimi`, etc.) require global installation.
 
 ### Installation Troubleshooting
 
@@ -183,55 +183,43 @@ The CodeMie CLI provides two ways to interact with AI agents:
 
 ### Built-in Agent (CodeMie Native)
 
-The built-in agent is ready to use immediately and is great for a wide range of coding tasks.
-
-**Available Tools:**
-- `read_file` - Read file contents
-- `write_file` - Write content to files
-- `list_directory` - List files with intelligent filtering (auto-filters node_modules, .git, etc.)
-- `execute_command` - Execute shell commands with progress tracking
-- `write_todos` / `update_todo_status` / `append_todo` / `clear_todos` / `show_todos` - Planning and progress tracking tools
+`codemie-code` ships with the CLI — no separate install. It is a native CodeMie binary (`@codemieai/codemie-opencode`, platform-specific), pre-wired to the CodeMie proxy, with file/shell tools, planning mode, and native plugin support.
 
 ```bash
-# Start an interactive conversation
-codemie-code
-
-# Start with an initial message
+codemie-code                                  # interactive session
 codemie-code "Help me refactor this component"
+codemie-code --task "Generate unit tests"     # run once and exit
+codemie-code --plan                           # planning mode
+codemie-code --plan-only                      # plan without executing
+codemie-code --plugin-dir ./my-plugins        # load native plugins
+codemie-code --debug                          # debug logging
 ```
+
+Providers: CodeMie SSO, Bearer Auth, LiteLLM, AWS Bedrock, Ollama.
 
 ### External Agents
 
-You can also install and use external agents like Claude Code, OpenAI Codex, Gemini, and OpenCode.
+CodeMie installs external agents, routes them through the CodeMie proxy, and tracks their sessions.
 
-**Available Agents:**
-- **Claude Code** (`codemie-claude`) - Anthropic's official CLI with advanced code understanding
-- **OpenAI Codex** (`codemie-codex`) - OpenAI's coding agent CLI with CodeMie-managed model/provider configuration
-- **Claude Code ACP** (`codemie-claude-acp`) - Claude Code for IDE integration via ACP protocol (Zed, JetBrains, Emacs)
-- **Gemini CLI** (`codemie-gemini`) - Google's Gemini for coding tasks
-- **OpenCode** (`codemie-opencode`) - Open-source AI coding assistant with session analytics
+| Agent | Install | Shortcut | Upstream package |
+|---|---|---|---|
+| Claude Code | `codemie install claude --supported` | `codemie-claude` | `@anthropic-ai/claude-code` |
+| Claude Code ACP | `codemie install claude-acp` | `codemie-claude-acp` | `@zed-industries/claude-code-acp` |
+| OpenAI Codex | `codemie install codex --supported` | `codemie-codex` | `@openai/codex` |
+| Gemini CLI | `codemie install gemini` | `codemie-gemini` | `@google/gemini-cli` |
+| OpenCode | `codemie install opencode` | `codemie-opencode` | `opencode-ai` |
+| Pi | `codemie install pi` | `codemie-pi` | `@earendil-works/pi-coding-agent` |
+| Kimi Code | `codemie install kimi` | `codemie-kimi` | `@moonshot-ai/kimi-code` |
+| Kimi Code ACP | `codemie install kimi-acp` | `codemie-kimi-acp` | `@moonshot-ai/kimi-code` (`acp` mode) |
+| GitHub Copilot CLI | — | — | analytics ingestion only; CodeMie never installs or launches it |
+
+ACP agents are launched by your IDE, not directly — see [ACP Agent usage](#acp-agent-usage-in-ides-and-editors) below.
 
 ```bash
-# Install an agent (latest supported version)
-codemie install claude --supported
-
-# Use the agent
-codemie-claude "Review my API code"
-
-# Install Codex
-codemie install codex --supported
-codemie-codex "Refactor this authentication flow"
-
-# Install Gemini
-codemie install gemini
-codemie-gemini "Implement a REST API"
-
-# Install OpenCode
-codemie install opencode
-
-# Install Claude Code ACP (for IDE integration)
-codemie install claude-acp
-# Configure in your IDE (see docs/AGENTS.md for details)
+codemie install claude --supported             # install
+codemie-claude "Review my API code"            # one-shot task
+codemie-claude                                 # interactive session
+codemie-codex --task "Refactor this auth flow" # same shape for every agent
 ```
 
 #### ACP Agent usage in IDEs and Editors
@@ -269,27 +257,33 @@ codemie install claude-acp
 
 **Version Management:**
 
-CodeMie manages agent versions to ensure compatibility. For example, with Claude Code or OpenAI Codex:
+CodeMie manages agent versions to ensure compatibility:
 
 ```bash
-# Install latest supported version (recommended)
-codemie install claude --supported
-
-# Install latest supported Codex version (recommended)
-codemie install codex --supported
-
-# Install specific version
-codemie install claude 2.1.22
-codemie install codex 0.129.0
-
-# Install latest available version
-codemie install claude
-codemie install codex
+codemie install claude --supported   # latest supported version (recommended)
+codemie install claude 2.1.22        # pin a specific version
+codemie install claude               # latest available version
 ```
 
 Auto-updates are automatically disabled to maintain version control. CodeMie notifies you when running a different version than supported.
 
 For more detailed information on the available agents, see the [Agents Documentation](docs/AGENTS.md).
+
+### Providers
+
+A profile binds an agent to a provider. Run `codemie setup` to create one, or `codemie profile` to manage several (work, personal, team).
+
+| Provider | Auth | Use case |
+|---|---|---|
+| CodeMie SSO | enterprise SSO | Enterprise default — centralized model management, proxy routing, analytics |
+| Bearer Authorization | JWT via CLI or env var | CI, service accounts, self-hosted gateways |
+| LiteLLM | API key | Universal gateway to 100+ LLM providers (OpenAI, Azure, Vertex, …) |
+| AWS Bedrock | AWS access key + secret | Claude, Llama, Mistral & more via Amazon Bedrock |
+| Ollama | none | Local open-source models, offline work |
+| Anthropic Subscription | native Claude Code login | Bring your own Claude subscription |
+| Moonshot Subscription | native Kimi Code login | Bring your own Moonshot subscription (Kimi Code) |
+
+See [Authentication](docs/AUTHENTICATION.md) and [Configuration](docs/CONFIGURATION.md) for setup details.
 
 ### CodeMie Assistants as Claude Skills or Subagents
 
@@ -411,6 +405,29 @@ codemie opencode-metrics --discover --verbose
 
 Metrics are automatically extracted at session end and synced to the analytics system. Use `codemie analytics` to view comprehensive usage statistics across all agents.
 
+### Pi (`codemie-pi`)
+
+Pi is an open-source coding agent harness ([`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)).
+
+```bash
+codemie install pi                            # also installs the required Pi packages
+codemie-pi "Add retry logic to the HTTP client"
+codemie-pi                                    # interactive session
+codemie-pi --continue                         # continue the latest session
+codemie-pi --resume <session-id>              # open a specific session
+```
+
+**What CodeMie configures for you:**
+
+| What | How |
+|---|---|
+| **Managed agent dir** | `~/.pi/agent` is copied once to `<project>/.pi/codemie/agent`; Pi runs against the copy via `PI_CODING_AGENT_DIR`. Your skills, prompts, and extensions carry over — your Pi home is never modified. |
+| **Live model catalogue** | `models.json` is regenerated each run with providers `codemie-proxy` (OpenAI-compatible) and `codemie-anthropic` (Claude). Model/provider come from your active profile. |
+| **Required packages** | `pi-mcp-adapter` (Pi ships without built-in MCP), `pi-subagents`, `superpowers` — installed at setup. |
+| **Session analytics** | An injected extension records tokens, tools, and models per session and syncs at session end; visible in `codemie analytics`. |
+
+Providers: CodeMie SSO, Bearer Auth, LiteLLM.
+
 ## Claude Code Statusline
 
 The CodeMie Statusline displays live budget usage, project name, git branch, model, context window percentage, and token counts at the bottom of every Claude Code session.
@@ -439,16 +456,24 @@ The CodeMie CLI has a rich set of commands for managing agents, configuration, a
 codemie setup            # Interactive configuration wizard
 codemie list             # List all available agents
 codemie install <name>   # Install an agent or add-on (e.g. statusline)
+codemie uninstall <name> # Remove an agent or add-on
 codemie update <agent>   # Update installed agents
 codemie self-update      # Update CodeMie CLI itself
 codemie profile          # Manage provider profiles
+codemie models list      # List models available for the current provider
 codemie analytics        # View usage analytics (sessions, tokens, costs, tools)
 codemie analytics --report --open   # Self-contained HTML dashboard (7 views, cost, date range, light/dark, no server)
 codemie analytics --report --report-format json  # Same priced report data as JSON (--report-format html | json | both)
 codemie workflow <cmd>   # Manage CI/CD workflows
-codemie doctor           # Health check and diagnostics
+codemie sdk <resource>   # Manage CodeMie platform assets (assistants, workflows, datasources, integrations, skills, users)
+codemie skill <cmd>      # Manage skills for CodeMie agents (list, validate, reload)
+codemie skills <cmd>     # Discover/install agent skills via skills.sh + EPAM catalog
+codemie plugin <cmd>     # Manage native plugins (Anthropic format)
+codemie mcp add          # Add an MCP server to an agent config
 codemie mcp-proxy <url>  # Stdio-to-HTTP MCP proxy with OAuth
+codemie proxy <cmd>      # Manage the local CodeMie proxy and its integrations
 codemie codebase ui      # Start and open Codebase Memory graph UI
+codemie doctor           # Health check and diagnostics
 ```
 
 For a full command reference, see the [Commands Documentation](docs/COMMANDS.md).
@@ -524,8 +549,11 @@ Comprehensive guides are available in the `docs/` directory:
   - `CODEMIE_INSECURE=1` — disable SSL verification for self-signed certs or local dev environments (SSL is on by default)
 - **[Commands](docs/COMMANDS.md)** - Complete command reference including analytics and workflow commands
 - **[Analytics Report](docs/ANALYTICS-REPORT.md)** - HTML dashboard: all 8 views, filters, session drill-down, cost and efficiency metrics
-- **[Agents](docs/AGENTS.md)** - Detailed information about each agent (Claude Code, Gemini, built-in)
+- **[Agents](docs/AGENTS.md)** - Per-agent detail (built-in, Claude Code, Claude Code ACP, Gemini, OpenCode; Pi and Kimi are documented in this README)
 - **[Authentication](docs/AUTHENTICATION.md)** - SSO setup, token management, enterprise authentication
+- **[Plugins](docs/PLUGINS.md)** - Reusable packages of skills, commands, agents, hooks, and MCP servers (`.claude-plugin/plugin.json` format)
+- **[Skills](docs/SKILLS.md)** - Injecting custom knowledge into agents via markdown + YAML frontmatter
+- **[Hooks](docs/HOOKS.md)** - Shell and LLM-based hooks at agent lifecycle points
 - **[Examples](docs/EXAMPLES.md)** - Common workflows, multi-provider examples, CI/CD integration
 - **[Configuration Architecture](docs/ARCHITECTURE-CONFIGURATION.md)** - How configuration flows through the system from CLI to proxy plugins
 - **[Proxy Architecture](docs/ARCHITECTURE-PROXY.md)** - Proxy plugin system, MCP authorization flow


### PR DESCRIPTION
## Summary

Documents Pi / `codemie-pi` in the README, and brings `README.md` and `AGENTS.md` back in line with the code. Two descriptions had drifted far enough to actively mislead: the built-in agent was documented as a LangGraph assistant it no longer is, and the provider list advertised two providers that are not registered plugins. Docs-only — no source changes.

## Changes

**Corrections (were wrong, not just stale)**

- **Built-in agent is not LangGraph-based.** `codemie-code` is a native platform-specific binary (`@codemieai/codemie-opencode`, resolved by `codemie-code-binary.ts`, `.opencode` home, OpenCode subcommands). The documented tool list (`read_file`, `write_todos`, …) came from the retired implementation. LangGraph now only backs LLM hooks (`src/hooks/prompt-executor.ts`).
- **Provider list was fictional.** README listed "OpenAI, Azure OpenAI" as providers; the registered plugins are `sso`, `jwt`, `litellm`, `bedrock`, `ollama`, `anthropic-subscription`, `moonshot-subscription`.
- **`AGENTS.md` pointed at the wrong module.** `exec()` is exported from `src/utils/exec.ts`; `src/utils/processes.ts` holds the npm/spawn helpers.

**README.md**

- New **Pi** section: install, run, resume, and what CodeMie configures (managed agent dir via `PI_CODING_AGENT_DIR`, regenerated `models.json`, required Pi packages, session analytics).
- External agents: bullet list → table with install command, shortcut, and upstream package. Added **Kimi Code**, **Kimi Code ACP**, and **GitHub Copilot CLI** (analytics ingestion only).
- New **Providers** section covering all seven with auth type and use case.
- Commands: added the six that were missing — `uninstall`, `models list`, `sdk`, `skill`, `plugin`, `mcp add`, `proxy`.
- Docs index: added `PLUGINS.md`, `SKILLS.md`, `HOOKS.md`.

**AGENTS.md**

- Added agent-plugin and provider-plugin rosters to Project Context (previously only a pointer to the architecture guide).
- Task Classifier: added agent-name and session/metrics keyword rows.
- Entry points: all `bin/` families instead of two.
- Noted that `.ai-run/guides/integration/external-integrations.md` and `docs/AGENTS.md` do not cover Pi yet.

## Impact

Net +116/−63 lines, but denser — four repetitive install code blocks collapsed into tables.

Known gap, deliberately left for a follow-up: `docs/AGENTS.md` still has no Pi or Kimi section. `AGENTS.md` now says so explicitly rather than implying coverage that does not exist.

## Checklist

- [x] Self-reviewed
- [x] Every claim verified against source (plugin metadata, registry, `package.json:bin`, provider templates, commitlint config)
- [x] All `docs/*.md` links in README resolve
- [x] Pre-commit gates passed (typecheck, gitleaks, commitlint)
- [x] Documentation updated (this PR is the documentation)
- [x] No breaking changes — docs only
