### PR TITLE
feat(cli): add `codemie-copilot` agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3%2B-blue.svg)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-> **Unified AI Coding Assistant CLI** - Manage Claude Code, OpenAI Codex, Google Gemini, OpenCode, Pi, Kimi Code, and custom AI agents from one powerful command-line interface. Multi-provider support (CodeMie SSO, Bearer Auth, LiteLLM, AWS Bedrock, Ollama, Anthropic Subscription, Moonshot Subscription). Built-in native agent with file operations, command execution, planning mode, and plugins. Cross-platform support for Windows, Linux, and macOS.
+> **Unified AI Coding Assistant CLI** - Manage Claude Code, OpenAI Codex, GitHub Copilot CLI, Google Gemini, OpenCode, Pi, Kimi Code, and custom AI agents from one powerful command-line interface. Multi-provider support (CodeMie SSO, Bearer Auth, LiteLLM, AWS Bedrock, Ollama, Anthropic Subscription, Moonshot Subscription). Built-in native agent with file operations, command execution, planning mode, and plugins. Cross-platform support for Windows, Linux, and macOS.
 
 ---
 
@@ -22,7 +22,7 @@
 
 CodeMie CLI is the all-in-one AI coding assistant for developers.
 
-- ✨ **One CLI, Multiple AI Agents** - Switch between Claude Code, OpenAI Codex, Gemini, OpenCode, Pi, Kimi Code, and built-in agent.
+- ✨ **One CLI, Multiple AI Agents** - Switch between Claude Code, OpenAI Codex, GitHub Copilot CLI, Gemini, OpenCode, Pi, Kimi Code, and built-in agent.
 - 🔄 **Multi-Provider Support** - CodeMie SSO, Bearer Authorization, LiteLLM, AWS Bedrock, Ollama, Anthropic Subscription, and Moonshot Subscription.
 - 🚀 **Built-in Agent** - `codemie-code` ships with the CLI: file operations, command execution, planning mode, and native plugins.
 - 🖥️ **Cross-Platform** - Full support for Windows, Linux, and macOS with platform-specific optimizations.
@@ -46,8 +46,10 @@ codemie setup
 codemie doctor
 codemie install claude --supported
 codemie install codex --supported
+codemie install copilot
 codemie-claude "Review my API code"
 codemie-codex "Refactor this service"
+codemie-copilot --task "Summarize this module"
 codemie --task "Generate unit tests"
 codemie skills find pdf                    # discover agent skills (EPAM internal + skills.sh)
 claude mcp add my-server -- codemie-mcp-proxy "https://mcp-server.example.com/sse"
@@ -211,16 +213,39 @@ CodeMie installs external agents, routes them through the CodeMie proxy, and tra
 | Pi | `codemie install pi` | `codemie-pi` | `@earendil-works/pi-coding-agent` |
 | Kimi Code | `codemie install kimi` | `codemie-kimi` | `@moonshot-ai/kimi-code` |
 | Kimi Code ACP | `codemie install kimi-acp` | `codemie-kimi-acp` | `@moonshot-ai/kimi-code` (`acp` mode) |
-| GitHub Copilot CLI | — | — | analytics ingestion only; CodeMie never installs or launches it |
+| GitHub Copilot CLI | `codemie install copilot` | `codemie-copilot` | `@github/copilot` |
 
 ACP agents are launched by your IDE, not directly — see [ACP Agent usage](#acp-agent-usage-in-ides-and-editors) below.
 
 ```bash
 codemie install claude --supported             # install
+codemie install copilot                        # install GitHub Copilot CLI
 codemie-claude "Review my API code"            # one-shot task
 codemie-claude                                 # interactive session
+codemie-copilot --task "Refactor this auth flow"
+codemie uninstall copilot                      # uninstall GitHub Copilot CLI
 codemie-codex --task "Refactor this auth flow" # same shape for every agent
 ```
+
+#### GitHub Copilot CLI via CodeMie
+
+CodeMie can install and launch GitHub Copilot CLI as a managed agent while keeping the internal registry identity `copilot-cli`.
+
+Supported managed path for this release:
+
+- **Install:** `codemie install copilot`
+- **Uninstall:** `codemie uninstall copilot`
+- **Launch:** `codemie-copilot`
+- **One-shot task:** `codemie-copilot --task "Explain this service"`
+- **Supported providers:** CodeMie SSO and LiteLLM
+
+Requirements and behavior:
+
+- Use an authenticated CodeMie profile (`codemie setup`).
+- Managed Copilot runs are routed through CodeMie's provider/proxy path.
+- The supported managed path does **not** require GitHub login, a GitHub Copilot subscription, or a GitHub personal access token.
+- CodeMie blocks fallback to ambient GitHub credentials for this managed mode.
+- Copilot conversation sync is attributed under `copilot-cli` in CodeMie.
 
 #### ACP Agent usage in IDEs and Editors
 

--- a/bin/codemie-copilot.js
+++ b/bin/codemie-copilot.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+ * GitHub Copilot CLI Agent Entry Point
+ * Direct entry point for codemie-copilot command
+ */
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+import { resolveCopilotModel } from '../dist/agents/plugins/copilot-cli/index.js';
+import { ConfigLoader } from '../dist/utils/config.js';
+import { getCodemiePath } from '../dist/utils/paths.js';
+
+const SAVED_MODEL_PATH = getCodemiePath('agents', 'copilot-cli', 'model.json');
+
+const OPTION_ALIASES = new Map([
+  ['-m', 'model'],
+  ['--model', 'model'],
+  ['--model-list', 'modelList'],
+  ['--profile', 'profile'],
+  ['--provider', 'provider'],
+  ['--api-key', 'apiKey'],
+  ['--base-url', 'baseUrl'],
+  ['--timeout', 'timeout'],
+  ['--jwt-token', 'jwtToken'],
+]);
+
+function parseOptionValue(argv, index) {
+  const arg = argv[index];
+  const equalsIndex = arg.indexOf('=');
+  if (equalsIndex !== -1) {
+    return { value: arg.slice(equalsIndex + 1), consumed: 0 };
+  }
+
+  const next = argv[index + 1];
+  if (!next || next.startsWith('-')) {
+    return { value: true, consumed: 0 };
+  }
+
+  return { value: next, consumed: 1 };
+}
+
+function parseCopilotOptions(argv) {
+  const options = {};
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const optionName = OPTION_ALIASES.get(arg.split('=')[0]);
+    if (!optionName) continue;
+
+    if (optionName === 'modelList') {
+      options.modelList = true;
+      continue;
+    }
+
+    const { value, consumed } = parseOptionValue(argv, i);
+    options[optionName] = value;
+    i += consumed;
+  }
+
+  return options;
+}
+
+function hasEnvModelOverride() {
+  return Boolean(process.env.CODEMIE_MODEL);
+}
+
+async function loadSavedModel() {
+  try {
+    const raw = await readFile(SAVED_MODEL_PATH, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.model === 'string' && parsed.model.trim() ? parsed.model.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function saveSelectedModel(model) {
+  await mkdir(dirname(SAVED_MODEL_PATH), { recursive: true });
+  await writeFile(
+    SAVED_MODEL_PATH,
+    `${JSON.stringify({ model, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    'utf-8'
+  );
+}
+
+function applySavedModelIfNeeded(options, savedModel) {
+  if (typeof options.model === 'string' || options.model === true || hasEnvModelOverride() || !savedModel) {
+    return;
+  }
+
+  process.env.CODEMIE_MODEL = savedModel;
+}
+
+function resolveInitialModelSource(options) {
+  if (typeof options.model === 'string') return 'cli';
+  if (hasEnvModelOverride()) return 'env';
+  return 'default';
+}
+
+function buildConfigOverrides(options) {
+  return {
+    name: typeof options.profile === 'string' ? options.profile : undefined,
+    provider: typeof options.provider === 'string' ? options.provider : undefined,
+    model: typeof options.model === 'string' ? options.model : undefined,
+    apiKey: typeof options.apiKey === 'string' ? options.apiKey : undefined,
+    baseUrl: typeof options.baseUrl === 'string' ? options.baseUrl : undefined,
+    timeout: typeof options.timeout === 'string' ? Number.parseInt(options.timeout, 10) : undefined,
+  };
+}
+
+async function getCopilotModels(options) {
+  const config = await ConfigLoader.load(process.cwd(), buildConfigOverrides(options));
+  if (typeof options.jwtToken === 'string') {
+    process.env.CODEMIE_JWT_TOKEN = options.jwtToken;
+    config.authMethod = 'jwt';
+  }
+
+  const env = ConfigLoader.exportProviderEnvVars(config);
+  env.CODEMIE_MODEL_SOURCE = resolveInitialModelSource(options);
+  if (typeof options.jwtToken === 'string') {
+    env.CODEMIE_AUTH_METHOD = 'jwt';
+    env.CODEMIE_JWT_TOKEN = options.jwtToken;
+  }
+
+  return resolveCopilotModel(env);
+}
+
+async function printModelList(options) {
+  const { selectedModel, availableModels } = await getCopilotModels(options);
+  const currentModel = typeof options.model === 'string' ? options.model : process.env.CODEMIE_MODEL;
+
+  console.log(chalk.bold('\nAvailable models for codemie-copilot:\n'));
+  for (const model of availableModels) {
+    const badges = [];
+    if (model === availableModels[0]) badges.push('recommended');
+    if (currentModel === model) badges.push('current');
+    const suffix = badges.length ? chalk.gray(`  (${badges.join(', ')})`) : '';
+    console.log(`  ${chalk.cyan(model)}${suffix}`);
+  }
+  console.log('');
+}
+
+async function promptForModel(options) {
+  const { selectedModel, availableModels } = await getCopilotModels(options);
+  if (availableModels.length === 0) {
+    throw new Error('No CodeMie model compatible with codemie-copilot is available.');
+  }
+
+  const answer = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'model',
+      message: 'Select model for codemie-copilot:',
+      choices: availableModels.map((model) => {
+        const badges = [];
+        if (model === availableModels[0]) badges.push('recommended');
+        if (process.env.CODEMIE_MODEL === model) badges.push('current');
+        return {
+          name: badges.length ? `${model} (${badges.join(', ')})` : model,
+          value: model,
+        };
+      }),
+      default: selectedModel,
+    },
+  ]);
+
+  return answer.model;
+}
+
+function replaceValuelessModelArg(argv, model) {
+  const rewritten = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if ((arg === '--model' || arg === '-m') && (!argv[i + 1] || argv[i + 1].startsWith('-'))) {
+      rewritten.push(arg, model);
+      continue;
+    }
+    rewritten.push(arg);
+  }
+  return rewritten;
+}
+
+async function handleCopilotOnlyModelUx() {
+  const options = parseCopilotOptions(process.argv);
+  const savedModel = await loadSavedModel();
+  applySavedModelIfNeeded(options, savedModel);
+  process.env.CODEMIE_MODEL_SOURCE = resolveInitialModelSource(options);
+
+  if (options.modelList) {
+    await printModelList(options);
+    process.exit(0);
+  }
+
+  if (options.model === true) {
+    const model = await promptForModel(options);
+    await saveSelectedModel(model);
+    process.argv = replaceValuelessModelArg(process.argv, model);
+    process.env.CODEMIE_MODEL_SOURCE = 'cli';
+  }
+}
+
+try {
+  await handleCopilotOnlyModelUx();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(chalk.red('\n✗ Failed to resolve codemie-copilot models\n'));
+  console.error(chalk.white(message));
+  console.error('');
+  process.exit(1);
+}
+
+const agent = AgentRegistry.getAgent('copilot-cli');
+if (!agent) {
+  console.error('✗ GitHub Copilot CLI agent not found in registry');
+  process.exit(1);
+}
+
+const cli = new AgentCLI(agent);
+await cli.run(process.argv);

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -165,6 +165,47 @@ codemie-gemini --model gemini-2.5-flash "analyze code"  # With config override
 
 **Note:** Installed via Python (pip/uv), not npm. Requires Python 3.9+ and Anthropic or OpenAI API key.
 
+## GitHub Copilot CLI
+
+GitHub Copilot CLI managed by CodeMie for CodeMie-routed SSO and LiteLLM sessions.
+
+**Installation:** `codemie install copilot`
+
+**Requirements:**
+- Node.js 20.0.0 or higher
+- An authenticated CodeMie profile (`codemie setup`)
+- Supported providers: **AI/Run SSO** or **LiteLLM**
+
+**Managed-mode behavior:**
+- Launch with `codemie-copilot`
+- Uninstall with `codemie uninstall copilot`
+- CodeMie routes the supported Copilot path through its own provider/proxy flow
+- The supported managed path does **not** require GitHub login, a GitHub Copilot subscription, or a GitHub personal access token
+- Ambient GitHub credentials are intentionally not used for managed Copilot runs
+
+**Features:**
+- Managed install/uninstall flow through CodeMie
+- CodeMie profile/model routing for GPT-family and Claude-family compatible models
+- Conversation sync and attribution under `copilot-cli`
+- MCP, skills/custom agents, and hook discovery through Copilot-supported locations
+
+**Usage:**
+```bash
+codemie install copilot
+codemie-copilot                          # Interactive mode
+codemie-copilot "explain this file"      # Start with message
+codemie-copilot --task "review this diff"
+codemie uninstall copilot
+```
+
+**Customization locations:**
+- User-level Copilot home: `~/.copilot`
+- User MCP config: `~/.copilot/mcp-config.json`
+- User custom agents: `~/.copilot/agents/`
+- User skills: `~/.copilot/skills/`
+- Project MCP config: `.mcp.json` or `.github/mcp.json`
+- Project agents/skills/hooks: `.github/agents/`, `.github/skills/`, `.github/hooks/`
+
 ## OpenCode
 
 Open-source AI coding assistant with comprehensive session analytics.

--- a/docs/superpowers/plans/2026-08-11-epmcdme-13883-copilot-cli-managed-agent-plan.md
+++ b/docs/superpowers/plans/2026-08-11-epmcdme-13883-copilot-cli-managed-agent-plan.md
@@ -1,0 +1,547 @@
+# EPMCDME-13883 Copilot CLI Managed Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the existing `copilot-cli` integration from analytics-only to a first-class CodeMie-managed agent, while preserving its internal identity and adding the user-facing commands `codemie install copilot`, `codemie uninstall copilot`, and `codemie-copilot`.
+
+**Architecture:** Reuse the existing `src/agents/plugins/copilot-cli/` implementation as the single source of truth and extend the normal managed-agent path around it. Resolve `copilot` as a CLI alias at management-command boundaries, keep the internal registry key as `copilot-cli`, and incrementally wire provider routing, attribution, customization parity, and docs in four logical slices that can land in one PR.
+
+**Tech Stack:** TypeScript, Commander.js, existing `AgentRegistry` / `BaseAgentAdapter` / `AgentCLI` infrastructure, CodeMie provider and session-sync infrastructure, npm-based installation flow.
+
+## Global Constraints
+
+- Keep internal agent identity as `copilot-cli`; do not introduce a second managed `copilot` plugin.
+- Support user-facing commands `codemie install copilot`, `codemie uninstall copilot`, and `codemie-copilot`.
+- Preserve guide-first architecture: CLI → Registry → Plugin → Core → Utils.
+- Tests were initially deferred per repository policy; the user later explicitly requested tests, so focused regression tests are now in scope.
+- Do not perform additional git operations unless explicitly requested by the user.
+- Fail fast when startup would fall back to GitHub login, GitHub-hosted models, or ambient GitHub credentials instead of CodeMie-managed routing.
+- Restrict in-scope provider modes to the ticket requirements: AI/Run SSO and LiteLLM.
+- Avoid unnecessary writes into version-controlled project files for Copilot customization assets.
+- Keep Copilot-specific implementation in `src/agents/plugins/copilot-cli/` and `bin/codemie-copilot.js` unless a shared abstraction clearly benefits multiple agents.
+
+---
+
+
+## Actual implementation status — 2026-08-11
+
+### Implemented in the core slice
+
+- [x] Promoted `copilot-cli` from analytics-only to a managed npm-installed agent using `@github/copilot`.
+- [x] Preserved the canonical internal identity `copilot-cli` and added user-facing alias helpers for `copilot`.
+- [x] Added `codemie-copilot` package binary and launcher.
+- [x] Added Copilot-only launcher UX for `--model-list`, valueless `--model` picker, explicit `--model <name>`, and saved model persistence.
+- [x] Kept Copilot model UX out of shared `AgentCLI`.
+- [x] Added CodeMie-only provider env mapping for Copilot BYOK mode.
+- [x] Removed the invalid Copilot CLI `--offline` argument and retained `COPILOT_OFFLINE=true` as env configuration.
+- [x] Translated CodeMie `--task` to Copilot `--prompt` and added `--allow-all-tools` for non-interactive task runs when needed.
+- [x] Added supported/minimum Copilot CLI version metadata.
+- [x] Limited supported providers to AI/Run SSO and LiteLLM for this ticket.
+- [x] Added model auto-resolution before proxy startup so selected model and proxy headers match.
+- [x] Restricted Copilot model listing/validation to GPT-family and Claude-family models only.
+- [x] Ranked GPT-family defaults ahead of Claude-family defaults while preserving explicit Claude selection.
+- [x] Added Sonnet 5 request normalization for deprecated sampling fields.
+- [x] Added Copilot-only Responses API encrypted-content retry sanitizer.
+- [x] Kept Codex encrypted-content sanitizer behavior separate from the Copilot retry sanitizer.
+
+### Focused regression tests added/updated
+
+- `src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts` verifies Copilot is managed while retaining session-adapter registration.
+- `src/agents/plugins/copilot-cli/__tests__/copilot-cli.models.test.ts` verifies GPT/Claude-only model filtering and explicit unsupported-model rejection.
+- `src/agents/core/__tests__/agent-aliases.test.ts` verifies `copilot` alias and `codemie-copilot` launcher naming.
+- `src/providers/plugins/sso/proxy/plugins/__tests__/copilot-encrypted-content-sanitizer.plugin.test.ts` verifies the Copilot-only retry sanitizer behavior and scoping.
+
+### Still pending after core slice
+
+- [ ] Conversation sync/folder attribution hardening so Copilot never falls through to `Claude Desktop`.
+- [ ] MCP configuration parity.
+- [ ] Skills/custom agents discovery/injection parity.
+- [ ] Hook event mapping/routing parity.
+- [ ] README and public agent documentation updates.
+
+## File Structure
+
+**Create:**
+- `bin/codemie-copilot.js` — direct launcher that resolves `copilot-cli` through `AgentRegistry`
+- `src/agents/plugins/copilot-cli/copilot-cli.models.ts` — Copilot-specific model validation/recommendation rules if they do not fit cleanly in the plugin file
+- `src/agents/plugins/copilot-cli/copilot-cli.hook-transformer.ts` — only if Copilot hook payloads need normalization beyond simple event-name mapping
+- `docs/agents/copilot*.md` or the repo’s existing agent-doc path — Copilot user docs if no appropriate doc file exists yet
+
+**Modify:**
+- `src/agents/plugins/copilot-cli/copilot-cli.plugin.ts` — convert from analytics-only to managed agent, add metadata, lifecycle, install/run/version logic
+- `src/agents/plugins/copilot-cli/copilot-cli.constants.ts` — shared names/client-type constants if needed
+- `src/agents/plugins/copilot-cli/index.ts` — re-export any new Copilot helpers/constants
+- `src/agents/registry.ts` — stop excluding Copilot from manageable paths if `analyticsOnly` is removed or if another safe gating mechanism is adopted
+- `src/cli/commands/install.ts` — resolve `copilot` alias to `copilot-cli`, show Copilot in the available-agents list using the short command form
+- `src/cli/commands/uninstall.ts` — resolve `copilot` alias to `copilot-cli`
+- `src/cli/commands/list.ts` — ensure Copilot appears correctly in list output if needed
+- `src/agents/core/AgentCLI.ts` — install/run help text should present `copilot` alias or `codemie-copilot` launcher where user-facing UX would otherwise show `copilot-cli`
+- `src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts` — map Copilot conversations to a Copilot folder rather than the fallback `Claude Desktop`
+- `package.json` — add the `codemie-copilot` bin entry
+- `README.md` — document install/uninstall/run commands, provider scope, and no-GitHub-auth behavior
+- Any existing agent docs index/overview that lists supported agents
+- Existing Copilot registry tests/docs that assert analytics-only behavior
+
+**Inspect closely while implementing:**
+- `src/agents/core/BaseAgentAdapter.ts` — shared version/install/run behavior and lifecycle hooks
+- `src/agents/core/types.ts` — metadata fields already available for versioning, MCP, extensions, hooks, supported providers, model recommendations
+- `src/agents/plugins/codex/codex.plugin.ts` — reference for provider-managed CLI routing, version gating, lifecycle wiring, and clientType handling
+- `src/agents/plugins/gemini/gemini.plugin.ts` — reference for npm-installed agent metadata, MCP config, extensions config, and hook mapping
+- `src/agents/plugins/kimi/kimi.plugin.ts` — reference for explicit model validation and hook transformer wiring
+- `src/cli/commands/doctor/index.ts` and related checks — understand how managed agents are surfaced in health/doctor flows
+
+## Task Structure
+
+### Task 1 (implemented in core slice; commit deferred): Convert Copilot from analytics-only to a manageable agent
+
+**Files:**
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.plugin.ts`
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.constants.ts`
+- Modify: `src/agents/plugins/copilot-cli/index.ts`
+- Modify: `src/agents/registry.ts`
+
+**Interfaces:**
+- Consumes: `AgentMetadata`, `BaseAgentAdapter`, `SessionAdapter`, `AgentRegistry.getManageableAgents(): AgentAdapter[]`
+- Produces: managed Copilot metadata with concrete `install()`, `uninstall()`, `run(args, env)`, `getVersion()`, optional `installVersion(version?)`, plus a registry entry that management surfaces can return without special-casing a second plugin
+
+- [x] **Step 1: Write the failing test**
+
+Document the expected behavior first in a targeted note or future test draft so implementation is grounded:
+
+```ts
+// Intended assertions after implementation:
+expect(AgentRegistry.getManageableAgents().map((a) => a.name)).toContain('copilot-cli');
+expect(AgentRegistry.getAgent('copilot-cli')!.metadata.analyticsOnly).not.toBe(true);
+expect(AgentRegistry.getAgent('copilot-cli')!.metadata.npmPackage).toBe('@github/copilot');
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Before the user requested tests, this was verified by source inspection rather than running the suite:
+
+- `copilot-cli.plugin.ts` throws `NOT_MANAGED` from `install()`, `uninstall()`, and `run()`
+- `npmPackage` is `null`
+- `analyticsOnly` is `true`
+- `registry.ts` filters analytics-only agents out of `getManageableAgents()`
+
+Expected: source inspection shows the current implementation cannot satisfy the intended behavior.
+
+- [x] **Step 3: Write minimal implementation**
+
+Implement managed-agent metadata and behavior in `copilot-cli.plugin.ts`:
+
+```ts
+export const CopilotCliPluginMetadata: AgentMetadata = {
+  name: COPILOT_CLI_AGENT_NAME,
+  displayName: COPILOT_CLI_DISPLAY_NAME,
+  description: 'GitHub Copilot CLI - AI coding agent managed by CodeMie',
+  npmPackage: '@github/copilot',
+  cliCommand: process.env.CODEMIE_COPILOT_BIN || 'copilot',
+  supportedVersion: COPILOT_SUPPORTED_VERSION,
+  minimumSupportedVersion: COPILOT_MINIMUM_SUPPORTED_VERSION,
+  dataPaths: { home: '.copilot' },
+  envMapping: { baseUrl: [], apiKey: [], model: [] },
+  supportedProviders: ['ai-run-sso', 'litellm'],
+  recommendedModels: [...],
+  blockedModelPatterns: [...],
+  ssoConfig: { enabled: true, clientType: 'codemie-copilot' },
+  // plus mcp/extensions/hook config as slices progress
+};
+```
+
+Then replace refusal-only lifecycle methods with real behavior, keeping `getSessionAdapter()` intact.
+
+- [x] **Step 4: Run test to verify it passes**
+
+After implementation, verify by code inspection and, once tests are explicitly requested, with focused regression tests that:
+
+- Copilot metadata is no longer analytics-only
+- `npmPackage` is set
+- `install()`/`uninstall()` no longer throw `NOT_MANAGED`
+- `registry.ts` can now include Copilot in manageable-agent surfaces
+
+Expected: the source now matches the intended assertions.
+
+- [ ] **Step 5: Commit (deferred until explicitly requested)**
+
+```bash
+git add src/agents/plugins/copilot-cli/copilot-cli.plugin.ts src/agents/plugins/copilot-cli/copilot-cli.constants.ts src/agents/plugins/copilot-cli/index.ts src/agents/registry.ts
+git commit -m "feat(agents): promote copilot cli to managed agent"
+```
+
+### Task 2 (implemented in core slice; commit deferred): Add command aliases and direct launcher support
+
+**Files:**
+- Create: `bin/codemie-copilot.js`
+- Modify: `package.json`
+- Modify: `src/cli/commands/install.ts`
+- Modify: `src/cli/commands/uninstall.ts`
+- Modify: `src/cli/commands/list.ts`
+- Modify: `src/agents/core/AgentCLI.ts`
+
+**Interfaces:**
+- Consumes: `AgentRegistry.getAgent(name): AgentAdapter | undefined`, install/uninstall command argument parsing, `package.json.bin`
+- Produces: `resolveManagedAgentAlias(name: string): string`-style behavior at CLI boundaries and a user-launchable `codemie-copilot` binary that loads `copilot-cli`
+
+- [x] **Step 1: Write the failing test**
+
+Capture the desired alias behavior as concrete expectations:
+
+```ts
+// Intended behavior after implementation:
+expect(resolveInstallTarget('copilot')).toBe('copilot-cli');
+expect(bin['codemie-copilot']).toBe('./bin/codemie-copilot.js');
+expect(helpText).toContain('codemie install copilot');
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Initial source state confirmed before implementation:
+
+- `package.json.bin` has no `codemie-copilot`
+- `bin/` has no `codemie-copilot.js`
+- `install.ts` and `uninstall.ts` perform direct `AgentRegistry.getAgent(name)` lookup, so `copilot` does not resolve
+- `AgentCLI` prints install help using `this.adapter.name`, which would expose `copilot-cli`
+
+Expected: current UX does not support the required commands.
+
+- [x] **Step 3: Write minimal implementation**
+
+Implement alias resolution at the CLI command boundary and add the launcher:
+
+```js
+// bin/codemie-copilot.js
+#!/usr/bin/env node
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+const agent = AgentRegistry.getAgent('copilot-cli');
+if (!agent) process.exit(1);
+await new AgentCLI(agent).run(process.argv);
+```
+
+In install/uninstall/list/help paths, resolve `copilot` to `copilot-cli` before registry lookup, but keep user-facing output on the short form where appropriate.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Verify by inspection that:
+
+- `codemie-copilot` exists in `package.json.bin`
+- the new bin file loads `copilot-cli`
+- install/uninstall accept `copilot`
+- help/next-step text points users to `codemie install copilot` and `codemie-copilot` rather than exposing internal names unnecessarily
+
+Expected: the required user commands are now represented in code.
+
+- [ ] **Step 5: Commit (deferred until explicitly requested)**
+
+```bash
+git add bin/codemie-copilot.js package.json src/cli/commands/install.ts src/cli/commands/uninstall.ts src/cli/commands/list.ts src/agents/core/AgentCLI.ts
+git commit -m "feat(cli): add copilot command aliases and launcher"
+```
+
+### Task 3 (implemented in core slice; commit deferred): Implement CodeMie-only runtime routing, version gating, and fail-fast validation
+
+**Files:**
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.plugin.ts`
+- Create: `src/agents/plugins/copilot-cli/copilot-cli.models.ts` (if needed)
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.constants.ts`
+- Inspect/modify only if necessary: shared provider/model helper modules already used by Codex/Kimi/Gemini
+
+**Actual implementation notes:**
+
+- `src/agents/plugins/copilot-cli/copilot-cli.models.ts` resolves the CodeMie model catalogue and filters to GPT-family/Claude-family models only.
+- `CopilotCliPlugin.setupProxy()` resolves the effective model before proxy startup and stores the available model list in `CODEMIE_COPILOT_AVAILABLE_MODELS` for explicit override validation.
+- `buildCopilotProviderEnv()` writes Copilot BYOK provider variables and uses `COPILOT_PROVIDER_WIRE_API=responses` for GPT-5-family models.
+- `lifecycle.beforeRun` clears ambient GitHub token env vars and applies Copilot provider env.
+- `lifecycle.enrichArgs` maps task/prompt behavior without passing invalid `--offline`.
+- `src/providers/plugins/sso/proxy/plugins/claude-request-normalizer.plugin.ts` strips deprecated Sonnet 5 sampling params.
+- `src/providers/plugins/sso/proxy/plugins/copilot-encrypted-content-sanitizer.plugin.ts` performs the Copilot-only one-shot retry after encrypted reasoning rejection.
+
+
+**Interfaces:**
+- Consumes: `AgentConfig`, `BaseAgentAdapter` lifecycle hooks, provider metadata, profile-derived config from `AgentCLI.handleRun`, version compatibility helpers from `BaseAgentAdapter`
+- Produces: Copilot launch behavior that accepts only CodeMie-managed SSO/LiteLLM paths, validates requested models, and blocks GitHub fallback/login behavior with clear errors
+
+- [x] **Step 1: Write the failing test**
+
+State the intended validations concretely:
+
+```ts
+// Intended behavior after implementation:
+expect(() => assertCopilotProviderSupported('bearer-auth')).toThrow(/supported provider/i);
+expect(() => assertExplicitCopilotModelAllowed('unsupported-model', ['gpt-5.5'])).toThrow(/recommended/i);
+expect(metadata.minimumSupportedVersion).toBeDefined();
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Initial Copilot plugin state confirmed before implementation:
+
+- supported/minimum version metadata
+- provider gating for SSO/LiteLLM only
+- explicit model validation
+- any runtime protection against GitHub-native auth fallback
+
+Expected: current source cannot enforce the ticket’s startup rules.
+
+- [x] **Step 3: Write minimal implementation**
+
+Implement Copilot-specific runtime checks and lifecycle wiring, modeled after Codex/Kimi patterns:
+
+```ts
+function assertCopilotProviderSupported(provider?: string): void {
+  if (!provider || !['ai-run-sso', 'litellm'].includes(provider)) {
+    throw new ConfigurationError('GitHub Copilot CLI via CodeMie currently supports only AI/Run SSO and LiteLLM profiles.');
+  }
+}
+
+function assertExplicitCopilotModelAllowed(model: string, available: string[]): void {
+  // reject unsupported/fallback-prone models; recommend supported ones
+}
+```
+
+Then wire these checks into `lifecycle.beforeRun`, `lifecycle.enrichArgs`, or `run()` so they execute before Copilot is spawned.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Verify by code inspection that:
+
+- metadata contains `supportedVersion` and `minimumSupportedVersion`
+- only `ai-run-sso` and `litellm` are declared supported
+- model validation happens before launch
+- failure messages direct users to CodeMie setup/support paths rather than GitHub login
+
+Expected: source now encodes the ticket’s core failure behavior.
+
+- [ ] **Step 5: Commit (deferred until explicitly requested)**
+
+```bash
+git add src/agents/plugins/copilot-cli/copilot-cli.plugin.ts src/agents/plugins/copilot-cli/copilot-cli.constants.ts src/agents/plugins/copilot-cli/copilot-cli.models.ts
+git commit -m "feat(agents): enforce codemie routing for copilot cli"
+```
+
+### Task 4 (pending): Wire Copilot into health, attribution, and conversation sync
+
+**Files:**
+- Modify: `src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts`
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.plugin.ts`
+- Modify: any doctor/health files only if managed-agent display or checks require explicit Copilot handling
+- Modify: analytics/report identity helpers only if a mismatch exists between `copilot-cli` and `codemie-copilot`
+
+**Interfaces:**
+- Consumes: `resolveConversationFolder(clientType?: string, agentName?: string): string`, AgentCLI `health` command path, managed agent metadata `ssoConfig.clientType`
+- Produces: Copilot sessions attributed to Copilot-specific client identity and conversation folder, never the `Claude Desktop` fallback
+
+- [ ] **Step 1: Write the failing test**
+
+Record the expected sync mapping:
+
+```ts
+expect(resolveConversationFolder('codemie-copilot', undefined)).toBe('copilot-cli');
+expect(resolveConversationFolder(undefined, 'copilot-cli')).toBe('copilot-cli');
+expect(resolveConversationFolder('unknown', 'copilot-cli')).not.toBe('Claude Desktop');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Confirm current source only maps codex/gemini/claude/opencode/pi and otherwise falls back to `DEFAULT_CONVERSATION_FOLDER`.
+
+Expected: Copilot would currently fall through to the fallback bucket.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add explicit Copilot mapping in conversation sync and ensure runtime metadata uses a dedicated client type:
+
+```ts
+if (clientType === 'codemie-copilot' || agentName === 'copilot-cli') {
+  return 'copilot-cli';
+}
+```
+
+If doctor/health surfaces need explicit display normalization, update them to show the agent as GitHub Copilot CLI while preserving internal keying.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Verify by inspection that:
+
+- Copilot now resolves to a dedicated conversation folder
+- Copilot no longer falls back to `Claude Desktop`
+- runtime metadata/clientType and any health output paths are aligned with that identity
+
+Expected: attribution and sync correctness is guaranteed in source.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
+git commit -m "fix(providers): map copilot conversations and attribution"
+```
+
+### Task 5 (pending): Add customization parity metadata and runtime support for MCP, skills/custom agents, and hooks
+
+**Files:**
+- Modify: `src/agents/plugins/copilot-cli/copilot-cli.plugin.ts`
+- Create: `src/agents/plugins/copilot-cli/copilot-cli.hook-transformer.ts` (only if needed)
+- Modify: `src/agents/plugins/copilot-cli/index.ts`
+- Modify any shared extension/MCP helper usage only when Copilot needs metadata-driven integration points
+
+**Interfaces:**
+- Consumes: `AgentMetadata.mcpConfig`, `AgentMetadata.extensionsConfig`, `AgentMetadata.hookConfig`, optional `getHookTransformer(): HookTransformer`, shared MCP/extensions scan utilities
+- Produces: Copilot metadata/runtime capable of discovering/injecting MCP servers, skills/custom agents, and supported hook events through Copilot-supported locations
+
+- [ ] **Step 1: Write the failing test**
+
+Write down the intended metadata shape:
+
+```ts
+expect(CopilotCliPluginMetadata.mcpConfig).toBeDefined();
+expect(CopilotCliPluginMetadata.extensionsConfig?.skillsEntryFile).toBe('SKILL.md');
+expect(CopilotCliPluginMetadata.hookConfig?.eventNameMapping?.SessionStart).toBe('SessionStart');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Confirm current Copilot metadata has no MCP config, extensions config, or hook mapping.
+
+Expected: customization parity is absent today.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add metadata and helper wiring consistent with Copilot’s supported surfaces:
+
+```ts
+extensionsConfig: {
+  project: '.github/copilot',
+  global: '~/.copilot',
+  skillsEntryFile: 'SKILL.md',
+},
+hookConfig: {
+  eventNameMapping: {
+    SessionStart: 'SessionStart',
+    SessionEnd: 'SessionEnd',
+    UserPromptSubmit: 'UserPromptSubmit',
+    PreToolUse: 'PreToolUse',
+    PostToolUse: 'PostToolUse',
+    Stop: 'Stop',
+    ErrorOccurred: 'PermissionRequest',
+  },
+},
+```
+
+Adjust the exact paths/event mapping to Copilot’s real supported locations and semantics, preferring CodeMie-owned/user-level placement over version-controlled project writes where possible.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Verify by inspection that:
+
+- Copilot metadata now advertises MCP/extensions/hook support
+- any hook transformer is only introduced if payload normalization is truly required
+- project/global asset paths align with the chosen non-invasive placement strategy
+
+Expected: customization parity is represented in code and ready for runtime use.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agents/plugins/copilot-cli/copilot-cli.plugin.ts src/agents/plugins/copilot-cli/index.ts src/agents/plugins/copilot-cli/copilot-cli.hook-transformer.ts
+git commit -m "feat(agents): add copilot customization parity"
+```
+
+### Task 6 (pending): Update docs and user-facing guidance
+
+**Files:**
+- Modify: `README.md`
+- Modify/Create: agent docs files that enumerate supported agents and usage examples
+- Modify: any help/overview docs that should mention `copilot`
+
+**Interfaces:**
+- Consumes: approved design decisions, final command surface, supported provider scope
+- Produces: user docs that show install/uninstall/run commands, provider requirements, and the no-GitHub-login/subscription expectation for CodeMie-managed Copilot CLI
+
+- [ ] **Step 1: Write the failing test**
+
+Define the minimum doc expectations:
+
+```md
+- README mentions `codemie install copilot`
+- README mentions `codemie-copilot`
+- Docs state that supported CodeMie-managed Copilot CLI runs do not require GitHub login/subscription
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Inspect current docs and confirm Copilot is not documented alongside other managed agents.
+
+Expected: the current docs do not satisfy the acceptance criteria.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add concise documentation covering:
+
+- install: `codemie install copilot`
+- uninstall: `codemie uninstall copilot`
+- run: `codemie-copilot` and `codemie-copilot --task "..."`
+- supported provider modes in scope
+- requirement for an authenticated CodeMie profile
+- explicit statement that GitHub login/subscription/PAT is not required in the supported CodeMie-managed path
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Verify by reading the edited docs that all required commands and expectations are present and consistent with implementation naming.
+
+Expected: docs satisfy the ticket’s release criteria.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/agents/*.md
+git commit -m "docs(agents): document codemie managed copilot cli"
+```
+
+## Self-Review
+
+### 1. Spec coverage
+
+- Managed-agent promotion: covered by Tasks 1–3.
+- `copilot` alias support and `codemie-copilot` launcher: covered by Task 2.
+- Version gating and fail-fast routing: covered by Task 3.
+- Attribution and conversation sync correctness: covered by Task 4.
+- MCP / skills / custom agents / hooks parity: covered by Task 5.
+- README and agent docs updates: covered by Task 6.
+
+No uncovered approved-design requirement remains.
+
+### 2. Placeholder scan
+
+Checked for red-flag placeholders such as “TODO”, “implement later”, or vague “add error handling” without concrete location/action. The plan uses explicit files, concrete intended behaviors, and concrete command blocks.
+
+### 3. Type consistency
+
+- Internal key remains `copilot-cli` everywhere in produced interfaces.
+- User-facing alias is consistently `copilot` only at command boundaries.
+- Client identity is consistently referred to as `codemie-copilot`.
+- Conversation folder expectation is consistently `copilot-cli`.
+
+
+### Task 7 (completed): Add focused regression tests for implemented core behavior
+
+**Files:**
+- Create: `src/agents/plugins/copilot-cli/__tests__/copilot-cli.models.test.ts`
+- Create: `src/agents/core/__tests__/agent-aliases.test.ts`
+- Create: `src/providers/plugins/sso/proxy/plugins/__tests__/copilot-encrypted-content-sanitizer.plugin.test.ts`
+- Modify: `src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts`
+
+**Implemented assertions:**
+
+- [x] Copilot appears in manageable agent surfaces and retains analytics/session adapter registration.
+- [x] `copilot` resolves to internal `copilot-cli`, while launcher/help commands render as `codemie-copilot` and `codemie install copilot`.
+- [x] Copilot model list excludes generic OpenAI/o-series/Codex-only/non-Claude/non-GPT model names.
+- [x] Explicit unsupported model overrides fail with Copilot-specific GPT/Claude guidance.
+- [x] Copilot encrypted-content retry sanitizer is scoped to `codemie-copilot` and does not apply to Codex.
+- [x] Copilot encrypted-content retry removes replayed reasoning state and `reasoning.encrypted_content` includes before retrying.
+
+**Verification command:**
+
+```bash
+npx vitest run --project unit   src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts   src/agents/plugins/copilot-cli/__tests__/copilot-cli.models.test.ts   src/agents/core/__tests__/agent-aliases.test.ts   src/providers/plugins/sso/proxy/plugins/__tests__/copilot-encrypted-content-sanitizer.plugin.test.ts
+```

--- a/docs/superpowers/specs/2026-08-11-epmcdme-13883-copilot-cli-managed-agent-design.md
+++ b/docs/superpowers/specs/2026-08-11-epmcdme-13883-copilot-cli-managed-agent-design.md
@@ -1,0 +1,439 @@
+# EPMCDME-13883 — GitHub Copilot CLI as a first-class CodeMie managed agent
+
+## Goal
+
+Allow developers to install and run GitHub Copilot CLI through CodeMie as a first-class managed agent, using CodeMie-managed provider configuration and governance rather than GitHub-native authentication or hosted models.
+
+User-facing commands must include:
+
+- `codemie install copilot`
+- `codemie uninstall copilot`
+- `codemie-copilot`
+
+while preserving the existing internal product identity as `copilot-cli`.
+
+## Problem statement
+
+The repository already contains a `copilot-cli` plugin and session adapter, but it is analytics-only today. The current implementation explicitly refuses install, uninstall, and run operations, and the registry excludes it from manageable-agent surfaces.
+
+This creates a gap versus other CodeMie-supported agents such as Claude, Codex, Gemini, OpenCode, and Kimi:
+
+- Copilot CLI cannot be installed through `codemie install`
+- Copilot CLI cannot be launched as `codemie-copilot`
+- Copilot CLI cannot participate in normal CodeMie agent health and management flows
+- Copilot sessions risk attribution/sync inconsistencies because they are not yet fully wired into managed-agent identity flows
+
+The new implementation must promote the existing `copilot-cli` integration to a standard CodeMie-managed agent without renaming the internal agent identity.
+
+## External behavior constraints
+
+GitHub Copilot CLI must run in CodeMie-managed BYOK/provider mode without requiring GitHub login, GitHub Copilot subscription, or a personal access token, provided the active CodeMie profile is configured for a supported provider mode.
+
+The implementation must not silently fall back to:
+
+- GitHub-hosted models
+- GitHub login or device-code auth
+- ambient GitHub credentials already present on the machine
+- a different agent identity for attribution or conversation sync
+
+When startup conditions are invalid, the system must fail fast with a CodeMie-directed message.
+
+## Naming and identity model
+
+### Internal identity
+
+The internal agent identity remains:
+
+- agent key: `copilot-cli`
+- display name: `GitHub Copilot CLI`
+
+The existing Copilot-specific files under `src/agents/plugins/copilot-cli/` remain the implementation home.
+
+### User-facing aliases
+
+The CLI must support:
+
+- `codemie install copilot`
+- `codemie uninstall copilot`
+- `codemie-copilot`
+
+These aliases must resolve to the single underlying `copilot-cli` plugin.
+
+### Why internal identity stays unchanged
+
+Keeping `copilot-cli` avoids:
+
+- confusion with non-CLI Copilot products
+- migration work across analytics and existing identity-based logic
+- avoidable breakage of anything already working under the current agent key
+
+## High-level approach
+
+Upgrade the existing `copilot-cli` plugin in place from analytics-only to a fully managed agent.
+
+This means:
+
+- keep the existing Copilot session adapter and analytics parsing code
+- remove analytics-only restrictions from the practical managed path
+- implement install/uninstall/run/version behavior in the same plugin
+- add command aliases and direct launcher support at the CLI boundary
+- extend identity/sync/customization infrastructure to recognize Copilot as a first-class agent
+
+No duplicate `copilot` plugin should be introduced.
+
+
+## Implemented core decisions as of 2026-08-11
+
+The core slice has been implemented with the following concrete choices:
+
+- `copilot-cli` remains the canonical registry/plugin identity.
+- `copilot` is a user-facing management alias for install, uninstall, list, update, and help surfaces.
+- `codemie-copilot` is a dedicated launcher binary for Copilot CLI.
+- Copilot-only model UX lives in `bin/codemie-copilot.js`, not in shared `AgentCLI`:
+  - `codemie-copilot --model-list` prints available Copilot-compatible CodeMie models.
+  - `codemie-copilot --model` opens an interactive picker.
+  - `codemie-copilot --model <name>` keeps the existing explicit-model behavior.
+  - picker selections are persisted under `~/.codemie/agents/copilot-cli/model.json`.
+  - model precedence is explicit CLI model, `CODEMIE_MODEL`, saved Copilot model, then auto-resolution.
+- Copilot-compatible model listing and validation is intentionally restricted to GPT-family and Claude-family models only.
+  Broader OpenAI-family names such as generic `openai`, `o1`, `o3`, `o4`, or standalone `codex` are not treated as Copilot-compatible unless the model name is also GPT-family.
+- Default model auto-resolution ranks GPT-family models ahead of Claude-family models, while still allowing explicit Claude selection.
+- GPT-5-family traffic is routed through Copilot Responses API provider mode by setting `COPILOT_PROVIDER_WIRE_API=responses`.
+- Claude-family Copilot traffic uses Anthropic-shaped provider mode.
+- Copilot clears ambient GitHub auth env vars before launch (`GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_TOKEN`) to avoid GitHub-native auth fallback.
+- The invalid `--offline` CLI argument is not passed to Copilot; offline behavior is represented only through the provider environment (`COPILOT_OFFLINE=true`).
+- `--task` is translated to Copilot CLI's `--prompt`, and non-interactive prompt runs receive `--allow-all-tools` when the user has not supplied an approval flag.
+- AI/Run SSO and LiteLLM are the supported provider modes for this slice.
+- The SSO proxy uses the dedicated client type `codemie-copilot` for Copilot attribution.
+- Copilot startup resolves the final model before proxy startup so proxy headers and Copilot request model stay aligned.
+- The Claude request normalizer strips deprecated sampling fields for Sonnet 5-style models where those fields produce runtime 400s.
+- A Copilot-only encrypted-content sanitizer retries Responses API encrypted-reasoning failures once after removing replayed reasoning state. Codex keeps its original sanitizer behavior and is not opted into the Copilot retry path.
+
+## Delivery slices
+
+The work ships in one PR but is implemented in four logical slices.
+
+### Slice A — Core managed agent
+
+Scope:
+
+- promote `copilot-cli` from analytics-only to manageable agent
+- add install/uninstall support
+- add `codemie-copilot` launcher
+- add CLI alias support for `copilot` in install/uninstall management flows
+- add supported/minimum version enforcement
+- add CodeMie-only provider/model/auth routing
+- add fail-fast validation for unsupported runtime conditions
+- add health-check participation in the same shape as other managed agents
+
+### Slice B — Attribution and sync correctness
+
+Scope:
+
+- dedicated Copilot client identity for runtime attribution
+- explicit conversation-folder resolution for Copilot
+- prevent fallback filing into `Claude Desktop`
+- normalize Copilot identity across reporting and sync surfaces where required
+
+### Slice C — Customization parity
+
+Scope:
+
+- MCP configuration support
+- skills and custom agents discovery/injection
+- hook routing and event mapping
+- use Copilot-supported config/asset surfaces without unnecessarily writing to version-controlled project files
+
+### Slice D — Documentation and polish
+
+Scope:
+
+- README updates
+- agent documentation updates
+- install/usage examples
+- requirements/provider documentation
+- explicit documentation that CodeMie-managed Copilot CLI does not require GitHub subscription/login for supported BYOK/provider paths
+- optional help/setup text updates if they materially improve discoverability
+
+## Detailed design
+
+## Slice A — Core managed agent
+
+### A1. Registry and management behavior
+
+The existing `copilot-cli` plugin remains the only plugin implementation for Copilot CLI.
+
+Required changes:
+
+- stop excluding the Copilot plugin from manageable-agent flows
+- ensure `codemie install`, `codemie uninstall`, `codemie list`, and first-run management surfaces can resolve the Copilot plugin
+- keep analytics/session-adapter resolution unified with management behavior
+
+The preferred model is one metadata source and one plugin implementation for all Copilot CLI capabilities.
+
+### A2. Install/uninstall alias resolution
+
+Alias resolution should occur at the CLI command boundary before registry lookup.
+
+Required behavior:
+
+- `codemie install copilot` resolves to agent `copilot-cli`
+- `codemie uninstall copilot` resolves to agent `copilot-cli`
+- error/help output should present the short command form where user-facing clarity matters
+
+This avoids duplicating metadata or introducing a synthetic `copilot` plugin.
+
+### A3. Direct launcher
+
+Add a new binary entrypoint:
+
+- `bin/codemie-copilot.js`
+
+The launcher loads `AgentRegistry.getAgent('copilot-cli')`, instantiates `AgentCLI`, and executes through the standard managed-agent path. It also owns Copilot-only UX that should not be added to shared `AgentCLI`:
+
+- `--model-list` prints the Copilot-compatible model catalogue.
+- valueless `--model` opens an interactive picker.
+- `--model <name>` continues to work as an explicit model override.
+- selected picker models are saved for future Copilot launches under the CodeMie agent state directory.
+
+This keeps model-picking behavior local to Copilot because Copilot CLI does not expose the same in-session `/model` surface as CodeMie Codex.
+
+### A4. Plugin promotion from analytics-only
+
+The Copilot plugin must implement standard managed-agent operations:
+
+- `install()`
+- `uninstall()`
+- `run()`
+- `installVersion()` if version pinning uses the shared install flow
+- `getVersion()` as needed to normalize Copilot version output
+
+The existing session adapter remains attached to the same plugin.
+
+### A5. Version policy
+
+Copilot must follow the same version-governance pattern as other managed agents.
+
+Metadata must include:
+
+- `supportedVersion`
+- `minimumSupportedVersion`
+
+Behavior:
+
+- below minimum: startup blocked
+- above supported: startup allowed with warning
+- `codemie install copilot --supported` installs the verified version
+- already-installed detection works for normal install flows
+
+### A6. CodeMie-only provider/auth routing
+
+Every managed Copilot session must run only through CodeMie-managed configuration.
+
+Hard requirements:
+
+- startup must use provider/auth/model settings derived from the active CodeMie profile or explicit CLI override
+- startup must not depend on GitHub-native auth state
+- startup must not silently use GitHub-hosted models
+- startup must not silently accept ambient GitHub credentials as the operative auth path
+
+Implementation may use environment variables, generated config, or both, but the result must force Copilot into the CodeMie-owned provider path.
+
+### A7. Model selection and validation
+
+Model resolution priority is:
+
+1. explicit CLI override (`codemie-copilot --model <name>`)
+2. `CODEMIE_MODEL` / profile-derived model
+3. saved Copilot picker selection from `~/.codemie/agents/copilot-cli/model.json`
+4. auto-resolution from the CodeMie model catalogue
+
+Before launching Copilot CLI, the runtime must:
+
+- resolve the final model before proxy startup
+- validate it against Copilot compatibility rules
+- reject unsupported models with a clear message
+- pass the selected model to both Copilot provider env and the proxy model configuration
+
+Compatibility is deliberately limited to Claude-family and GPT-family models that have tool-calling and streaming support. The user-facing model list must not include unrelated model families or generic OpenAI/o-series/Codex-only names.
+
+The failure must name:
+
+- requested model
+- reason it is unsupported
+- recommended alternatives
+
+No silent model substitution or fallback to GitHub-hosted models is allowed.
+
+### A8. Provider scope for this ticket
+
+The ticket explicitly requires supported operation for:
+
+- AI/Run SSO
+- LiteLLM key mode
+
+Other provider modes remain out of scope unless they already work incidentally through shared infrastructure and do not create extra support burden.
+
+### A9. Health-check participation
+
+Copilot must participate in agent health in the same shape as peer agents.
+
+Core health scope:
+
+- installation status
+- detected version
+- provider configuration readiness
+- model reachability or model-configuration readiness
+
+Customization-specific health details can be extended later under Slice C where needed.
+
+### A10. Failure behavior
+
+Core managed-agent startup must fail fast for:
+
+- missing authenticated or usable CodeMie profile
+- unsupported model
+- installed Copilot version below minimum supported version
+- configuration states that would cause GitHub-native auth/model fallback
+
+The failure text must direct users toward CodeMie setup or supported model/version choices rather than any GitHub login flow.
+
+## Slice B — Attribution and conversation sync
+
+### B1. Runtime attribution identity
+
+Runtime requests should carry a dedicated Copilot client identity suitable for attribution and backend recognition.
+
+The exact identifier should distinguish Copilot from other agents while staying compatible with existing backend/client conventions.
+
+### B2. Conversation folder resolution
+
+Conversation sync logic must explicitly recognize Copilot and never file it under the generic fallback folder.
+
+Recognition must cover at least:
+
+- `agentName === 'copilot-cli'`
+- Copilot runtime client type used by the managed launcher path
+
+Preferred behavior when uncertain:
+
+- skip sync safely
+- do not misclassify under `Claude Desktop`
+
+### B3. Analytics/report consistency
+
+Any analytics/report layer that depends on agent naming or client identity should consistently treat Copilot as Copilot CLI.
+
+The implementation must preserve existing Copilot analytics behavior while ensuring new managed-agent runs are attributed correctly.
+
+## Slice C — Customization parity
+
+## C1. MCP support
+
+Copilot should expose CodeMie-managed MCP servers through Copilot-supported configuration surfaces.
+
+Required behavior:
+
+- support project/user MCP discovery where Copilot allows it
+- integrate with existing CodeMie MCP summary/config utilities through plugin metadata where possible
+- avoid ad hoc Copilot-only config reading logic when shared infrastructure already fits
+
+### C2. Skills and custom agents
+
+Copilot should discover CodeMie-managed skills and custom agents through Copilot-supported extension/config directories.
+
+Required behavior:
+
+- define `extensionsConfig` for Copilot
+- map CodeMie project/global scopes into Copilot-supported personal/project locations
+- preserve the single plugin identity while making extensions discoverable inside Copilot sessions
+
+### C3. Hooks
+
+Copilot should execute CodeMie hooks for supported equivalent session/tool events.
+
+Required behavior:
+
+- define hook event mapping for Copilot-supported events
+- add a hook transformer if payload normalization is required
+- ignore non-equivalent or unsupported events without breaking runtime behavior
+
+### C4. Asset placement policy
+
+Customization parity should avoid unnecessary writes into the version-controlled repository tree.
+
+Preferred rule:
+
+- use user-level or CodeMie-owned Copilot directories by default
+- use project-scoped locations only where Copilot explicitly expects them and where that aligns with the desired user experience
+
+## Slice D — Documentation and polish
+
+Documentation must describe Copilot alongside other managed agents.
+
+Required doc content:
+
+- install command: `codemie install copilot`
+- uninstall command: `codemie uninstall copilot`
+- launcher: `codemie-copilot`
+- supported provider modes for this feature
+- requirements such as Node version and authenticated CodeMie profile
+- explicit statement that supported CodeMie-managed Copilot CLI runs do not require GitHub subscription/login/PAT
+- examples for interactive and single-task usage
+
+Documentation locations should include at least the README and agent-facing docs already used for peer agents.
+
+## File and component impact
+
+Likely impacted areas include:
+
+- `src/agents/plugins/copilot-cli/` — main implementation home
+- `src/agents/registry.ts` — manageable-agent behavior if needed
+- `src/cli/commands/install.ts` — alias resolution and listing behavior
+- `src/cli/commands/uninstall.ts` — alias resolution
+- `src/cli/commands/list.ts` and related management surfaces — if alias/display handling needs updates
+- `src/agents/core/` shared behavior only where genuinely reusable
+- `src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts` — Copilot folder resolution
+- health-check / doctor surfaces where managed-agent recognition is required
+- `package.json` / `bin/` — `codemie-copilot` entrypoint
+- README and agent docs
+
+## Non-goals
+
+The following remain out of scope for this ticket unless they fall out naturally with no meaningful added scope:
+
+- ACP adapter / IDE integration for Copilot
+- mid-session model-family switching
+- GitHub-hosted Copilot features that depend on GitHub authentication
+- support for a user's own GitHub Copilot subscription as an alternative mode
+- broader provider-mode expansion beyond the explicitly requested SSO and LiteLLM paths
+- changes to how CodeMie authors skills, hooks, or MCP servers
+- session analytics/token-cost expansion beyond what already exists for Copilot analytics
+
+## Risks and open implementation concerns
+
+Key implementation risks called out by the ticket and current codebase:
+
+- proxy wire-format support differs between GPT-family and Claude-family models
+- backend/client attribution may require explicit Copilot client recognition
+- Copilot-specific provider normalization is needed for Responses API encrypted reasoning replay and Claude Sonnet 5 sampling-field compatibility
+- customization parity may reveal differences between Copilot-supported project/user asset locations and current CodeMie extension assumptions
+
+Implemented mitigations so far:
+
+- resolve model before proxy startup so the proxy and Copilot agree on the model
+- route GPT-5-family Copilot sessions through Responses API provider shape
+- strip deprecated Sonnet 5 sampling fields before upstream forwarding
+- retry Copilot-only encrypted reasoning replay failures once without replayed reasoning state
+- keep Codex sanitizer behavior separate from Copilot retry behavior
+
+Remaining concern areas are conversation sync attribution, customization parity, and release documentation.
+
+## Recommended implementation order
+
+1. Slice A — core managed agent
+2. Slice B — attribution and conversation sync correctness
+3. Slice C — customization parity (MCP, then skills/custom agents, then hooks)
+4. Slice D — docs and release polish
+
+This order produces an incrementally testable path while still landing as a single pull request.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "codemie-kimi": "./bin/codemie-kimi.js",
     "codemie-kimi-acp": "./bin/codemie-kimi-acp.js",
     "codemie-mcp-proxy": "./bin/codemie-mcp-proxy.js",
-    "proxy-daemon": "./bin/proxy-daemon.js"
+    "proxy-daemon": "./bin/proxy-daemon.js",
+    "codemie-copilot": "./bin/codemie-copilot.js"
   },
   "files": [
     "dist",

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -19,6 +19,8 @@ import { CodexPluginMetadata } from '../plugins/codex/codex.plugin.js';
 import { KimiPluginMetadata } from '../plugins/kimi/kimi.plugin.js';
 import { KimiAcpPluginMetadata } from '../plugins/kimi/kimi-acp.plugin.js';
 import { PiPluginMetadata } from '../plugins/pi/pi.plugin.js';
+import { CopilotCliPluginMetadata } from '../plugins/copilot-cli/index.js';
+import { getAgentInstallCommand, getAgentLauncherCommand } from './agent-aliases.js';
 import { createAssistantsSetupCommand } from '../../cli/commands/assistants/setup/index.js';
 import { createSkillsSetupCommand } from '../../cli/commands/skills/setup/index.js';
 import type { TargetAgent } from '../../cli/commands/shared/agent-targets.js';
@@ -158,7 +160,7 @@ export class AgentCLI {
       if (!(await this.adapter.isInstalled())) {
         console.log(chalk.red(`\n✗ ${this.adapter.displayName} is not installed\n`));
         console.log(chalk.white('Install it with:\n'));
-        console.log(chalk.cyan(`  codemie install ${this.adapter.name}\n`));
+        console.log(chalk.cyan(`  ${getAgentInstallCommand(this.adapter.name)}\n`));
 
         // Windows-specific guidance for PATH refresh issue
         this.displayWindowsPathGuidance();
@@ -437,7 +439,7 @@ export class AgentCLI {
 
         console.log(chalk.red(`\n✗ ${this.adapter.displayName} is not installed\n`));
         console.log(chalk.white('Install it with:\n'));
-        console.log(chalk.cyan(`  codemie install ${this.adapter.name}\n`));
+        console.log(chalk.cyan(`  ${getAgentInstallCommand(this.adapter.name)}\n`));
 
         // Windows-specific guidance for PATH refresh issue
         if (isWindows) {
@@ -580,6 +582,7 @@ export class AgentCLI {
       'kimi': KimiPluginMetadata,
       'kimi-acp': KimiAcpPluginMetadata,
       'pi': PiPluginMetadata,
+      'copilot-cli': CopilotCliPluginMetadata,
     };
     return metadataMap[this.adapter.name];
   }
@@ -624,7 +627,7 @@ export class AgentCLI {
       if (recommendedModels && recommendedModels.length > 0) {
         const modelExamples = recommendedModels.slice(0, 3).join(', ');
         const suggestedModel = recommendedModels[0];
-        const command = this.adapter.name.startsWith('codemie-') ? this.adapter.name : `codemie-${this.adapter.name}`;
+        const command = getAgentLauncherCommand(this.adapter.name);
 
         console.log(chalk.white(`  1. ${this.adapter.displayName} requires compatible models (e.g., ${modelExamples})`));
         console.log(chalk.white('  2. Update profile: ') + chalk.cyan('codemie setup'));

--- a/src/agents/core/__tests__/agent-aliases.test.ts
+++ b/src/agents/core/__tests__/agent-aliases.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAgentInstallCommand,
+  getAgentLauncherCommand,
+  getAgentUninstallCommand,
+  getUserFacingAgentName,
+  resolveAgentAlias,
+} from '../agent-aliases.js';
+
+describe('agent aliases', () => {
+  it('maps the user-facing copilot command to the internal copilot-cli agent', () => {
+    expect(resolveAgentAlias('copilot')).toBe('copilot-cli');
+    expect(resolveAgentAlias('copilot-cli')).toBe('copilot-cli');
+  });
+
+  it('keeps copilot-cli internal while rendering Copilot user-facing commands', () => {
+    expect(getUserFacingAgentName('copilot-cli')).toBe('copilot');
+    expect(getAgentInstallCommand('copilot-cli')).toBe('codemie install copilot');
+    expect(getAgentUninstallCommand('copilot-cli')).toBe('codemie uninstall copilot');
+    expect(getAgentLauncherCommand('copilot-cli')).toBe('codemie-copilot');
+  });
+
+  it('leaves unrelated agents on the generic launcher convention', () => {
+    expect(resolveAgentAlias('codex')).toBe('codex');
+    expect(getUserFacingAgentName('codex')).toBe('codex');
+    expect(getAgentLauncherCommand('codex')).toBe('codemie-codex');
+  });
+});

--- a/src/agents/core/agent-aliases.ts
+++ b/src/agents/core/agent-aliases.ts
@@ -1,0 +1,47 @@
+/**
+ * User-facing aliases for agent-management and launcher commands.
+ *
+ * Internal registry identities remain canonical (for example `copilot-cli`) while
+ * selected user-facing commands are shortened for ergonomics.
+ */
+
+const MANAGED_AGENT_ALIASES: Record<string, string> = {
+  copilot: 'copilot-cli',
+};
+
+const USER_FACING_AGENT_NAMES: Record<string, string> = {
+  'copilot-cli': 'copilot',
+};
+
+const LAUNCHER_COMMANDS: Record<string, string> = {
+  'copilot-cli': 'codemie-copilot',
+};
+
+/** Resolve a user-facing agent alias to the canonical registry key. */
+export function resolveAgentAlias(name: string | undefined): string | undefined {
+  if (!name) return name;
+  return MANAGED_AGENT_ALIASES[name] ?? name;
+}
+
+/** Preferred short name for install/uninstall/list/help surfaces. */
+export function getUserFacingAgentName(name: string): string {
+  return USER_FACING_AGENT_NAMES[name] ?? name;
+}
+
+/** Preferred launcher command for the agent. */
+export function getAgentLauncherCommand(name: string): string {
+  if (name.startsWith('codemie-')) {
+    return name;
+  }
+  return LAUNCHER_COMMANDS[name] ?? `codemie-${name}`;
+}
+
+/** Convenience for install-command hints. */
+export function getAgentInstallCommand(name: string): string {
+  return `codemie install ${getUserFacingAgentName(name)}`;
+}
+
+/** Convenience for uninstall-command hints. */
+export function getAgentUninstallCommand(name: string): string {
+  return `codemie uninstall ${getUserFacingAgentName(name)}`;
+}

--- a/src/agents/plugins/copilot-cli/__tests__/copilot-cli.conversations-processor.test.ts
+++ b/src/agents/plugins/copilot-cli/__tests__/copilot-cli.conversations-processor.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+describe('CopilotCliConversationsProcessor', () => {
+  let tempHome: string;
+  let originalCodemieHome: string | undefined;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'copilot-conv-test-'));
+    originalCodemieHome = process.env.CODEMIE_HOME;
+    process.env.CODEMIE_HOME = tempHome;
+    vi.resetModules();
+
+    const sessionsDir = join(tempHome, 'sessions');
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(
+      join(sessionsDir, 'sess-copilot.json'),
+      JSON.stringify({
+        sessionId: 'sess-copilot',
+        agentName: 'copilot-cli',
+        provider: 'ai-run-sso',
+        startTime: Date.now(),
+        workingDirectory: '/repo/app',
+        status: 'active',
+        activeDurationMs: 0,
+        correlation: { status: 'matched', agentSessionId: 'cp-turn-1', retryCount: 0 },
+      })
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+    if (originalCodemieHome === undefined) {
+      delete process.env.CODEMIE_HOME;
+    } else {
+      process.env.CODEMIE_HOME = originalCodemieHome;
+    }
+  });
+
+  it('writes assistant thoughts for tool calls and stores response_time in seconds', async () => {
+    const { CopilotCliConversationsProcessor } = await import('../session/processors/copilot-cli.conversations-processor.js');
+    const processor = new CopilotCliConversationsProcessor();
+
+    const parsedSession = {
+      sessionId: 'sess-copilot',
+      agentName: 'GitHub Copilot CLI',
+      metadata: {
+        createdAt: '2026-08-11T11:29:15.437Z',
+        projectPath: '/repo/app',
+      },
+      messages: [
+        {
+          type: 'user',
+          timestamp: '2026-08-11T11:29:21.539Z',
+          message: { role: 'user', content: 'Hi' },
+        },
+        {
+          type: 'assistant',
+          timestamp: '2026-08-11T11:29:25.092Z',
+          message: {
+            role: 'assistant',
+            model: 'gpt-5.5-2026-04-24',
+            content: 'Hello there',
+            toolRequests: [
+              { toolCallId: 'call-1', name: 'view', arguments: { path: '/repo/app/file.ts' } },
+            ],
+          },
+        },
+      ],
+      metrics: { userPrompts: [{ count: 1, text: 'Hi' }] },
+    } as unknown as import('../../../core/session/BaseSessionAdapter.js').ParsedSession;
+
+    const result = await processor.process(
+      parsedSession,
+      {
+        agentSessionId: 'cp-turn-1',
+      } as unknown as import('../../../core/session/BaseProcessor.js').ProcessingContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.recordsProcessed).toBe(2);
+
+    const spool = join(tempHome, 'sessions', 'sess-copilot_conversation.jsonl');
+    expect(existsSync(spool)).toBe(true);
+    const [line] = readFileSync(spool, 'utf-8').trim().split('\n').map((entry) => JSON.parse(entry));
+    const assistant = line.payload.history[1];
+
+    expect(assistant.response_time).toBe(3.55);
+    expect(assistant.thoughts).toHaveLength(1);
+    expect(assistant.thoughts[0]).toMatchObject({
+      author_type: 'Tool',
+      author_name: 'view',
+      input_text: JSON.stringify({ path: '/repo/app/file.ts' }, null, 2),
+      metadata: {
+        call_id: 'call-1',
+        event_kind: 'tool_call',
+      },
+    });
+  });
+});

--- a/src/agents/plugins/copilot-cli/__tests__/copilot-cli.models.test.ts
+++ b/src/agents/plugins/copilot-cli/__tests__/copilot-cli.models.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { LlmModel } from '../../../../providers/plugins/sso/sso.http-client.js';
+
+const fetchCodeMieLlmModelsMock = vi.fn<() => Promise<LlmModel[]>>();
+
+vi.mock('../../../../providers/plugins/sso/sso.http-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../providers/plugins/sso/sso.http-client.js')>();
+  return {
+    ...actual,
+    fetchCodeMieLlmModels: fetchCodeMieLlmModelsMock,
+  };
+});
+
+function model(overrides: Partial<LlmModel>): LlmModel {
+  return {
+    base_name: overrides.base_name ?? overrides.deployment_name ?? overrides.label ?? 'unknown',
+    deployment_name: overrides.deployment_name ?? overrides.base_name ?? overrides.label ?? 'unknown',
+    label: overrides.label ?? overrides.deployment_name ?? overrides.base_name ?? 'unknown',
+    enabled: overrides.enabled ?? true,
+    provider: overrides.provider,
+    default: overrides.default,
+    features: {
+      tools: true,
+      streaming: true,
+      ...overrides.features,
+    },
+  };
+}
+
+describe('copilot-cli model resolution', () => {
+  beforeEach(() => {
+    fetchCodeMieLlmModelsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists only GPT and Claude family models', async () => {
+    fetchCodeMieLlmModelsMock.mockResolvedValue([
+      model({ deployment_name: 'gpt-5.5-2026-04-24' }),
+      model({ deployment_name: 'claude-sonnet-4.6' }),
+      model({ deployment_name: 'o4-mini', provider: 'openai' }),
+      model({ deployment_name: 'codex-fast', provider: 'openai' }),
+      model({ deployment_name: 'text-embedding-3-large' }),
+      model({ deployment_name: 'gemini-2.5-pro' }),
+    ]);
+
+    const { resolveCopilotModel } = await import('../copilot-cli.models.js');
+    const result = await resolveCopilotModel({
+      CODEMIE_BASE_URL: 'https://api.codemie.example',
+      CODEMIE_JWT_TOKEN: 'jwt-token',
+    });
+
+    expect(result.availableModels).toEqual(['gpt-5.5-2026-04-24', 'claude-sonnet-4.6']);
+    expect(result.selectedModel).toBe('gpt-5.5-2026-04-24');
+  });
+
+  it('does not classify generic OpenAI, o-series, or standalone codex names as compatible', async () => {
+    const { isCopilotCompatibleModelName } = await import('../copilot-cli.models.js');
+
+    expect(isCopilotCompatibleModelName('gpt-5.4')).toBe(true);
+    expect(isCopilotCompatibleModelName('claude-sonnet-5')).toBe(true);
+    expect(isCopilotCompatibleModelName('openai-o4-mini')).toBe(false);
+    expect(isCopilotCompatibleModelName('o3')).toBe(false);
+    expect(isCopilotCompatibleModelName('codex-fast')).toBe(false);
+  });
+
+  it('rejects explicit non-GPT/non-Claude model overrides with Copilot-specific guidance', async () => {
+    const { assertExplicitCopilotModelAllowed } = await import('../copilot-cli.models.js');
+
+    expect(() => assertExplicitCopilotModelAllowed('o4-mini', ['gpt-5.5', 'claude-sonnet-4.6']))
+      .toThrow(/GPT-family or Claude-family model/);
+  });
+});

--- a/src/agents/plugins/copilot-cli/__tests__/copilot-cli.parse.test.ts
+++ b/src/agents/plugins/copilot-cli/__tests__/copilot-cli.parse.test.ts
@@ -196,6 +196,60 @@ describe('CopilotCliSessionAdapter.parseSessionFile', () => {
     expect(parsed.metrics!.userPrompts).toEqual([{ count: 1, text: 'hello there' }]);
   });
 
+  it('reads the real content-based Copilot transcript fields', async () => {
+    const contentFile = join(dir, 'content-shaped.jsonl');
+    writeFileSync(
+      contentFile,
+      [
+        {
+          type: 'session.start',
+          timestamp: '2026-08-11T11:29:15.489Z',
+          data: {
+            sessionId: 'cp-content',
+            copilotVersion: '1.0.79',
+            startTime: '2026-08-11T11:29:15.437Z',
+            context: {
+              cwd: '/repo/app',
+              gitRoot: '/repo/app',
+              branch: 'main',
+              repository: 'org/app',
+            },
+          },
+        },
+        {
+          type: 'user.message',
+          timestamp: '2026-08-11T11:29:21.539Z',
+          data: { content: 'Hi from content' },
+        },
+        {
+          type: 'assistant.message',
+          timestamp: '2026-08-11T11:29:25.092Z',
+          data: {
+            model: 'gpt-5.5-2026-04-24',
+            content: 'Hello from content',
+            outputTokens: 11,
+            toolRequests: [{ toolCallId: 'tool-1', name: 'view', arguments: { path: '/repo/app/a.ts' } }],
+          },
+        },
+      ].map((l) => JSON.stringify(l)).join('\n') + '\n'
+    );
+
+    const parsed = await newAdapter().parseSessionFile(contentFile, 'cp-content');
+    const turnRecords = parsed.messages as Array<{
+      type?: string;
+      message?: { role?: string; content?: string; model?: string };
+    }>;
+
+    expect(parsed.metrics!.userPrompts).toEqual([{ count: 1, text: 'Hi from content' }]);
+    expect(turnRecords.find((m) => m.type === 'user')?.message?.content).toBe('Hi from content');
+    expect(turnRecords.find((m) => m.type === 'assistant')?.message).toMatchObject({
+      role: 'assistant',
+      model: 'gpt-5.5-2026-04-24',
+      content: 'Hello from content',
+      toolRequests: [{ toolCallId: 'tool-1', name: 'view', arguments: { path: '/repo/app/a.ts' } }],
+    });
+  });
+
   it('merges session.shutdown line totals into the per-file operations without duplicating', async () => {
     const parsed = await newAdapter().parseSessionFile(file, 'sess-1');
     const ops = parsed.metrics!.fileOperations!;

--- a/src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts
+++ b/src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts
@@ -28,6 +28,44 @@ describe('copilot-cli registration', () => {
     expect(metadata.npmPackage).toBe('@github/copilot');
   });
 
+  it('advertises Copilot MCP, extension, and hook metadata', () => {
+    const metadata = AgentRegistry.getAgent('copilot-cli')!.metadata;
+
+    expect(metadata.extensionsConfig).toMatchObject({
+      project: '.github',
+      global: '~/.copilot',
+      skillsEntryFile: 'SKILL.md',
+    });
+    expect(metadata.extensionsConfig?.dirNames).toMatchObject({
+      agents: ['agents'],
+      commands: [],
+      skills: ['skills'],
+      hooks: ['hooks'],
+      rules: [],
+    });
+    expect(metadata.extensionsConfig?.extraProjectDirs).toEqual(['.github/copilot']);
+
+    expect(metadata.mcpConfig).toMatchObject({
+      project: {
+        path: ['.mcp.json', '.github/mcp.json'],
+        jsonPath: 'mcpServers',
+      },
+      user: {
+        path: '~/.copilot/mcp-config.json',
+        jsonPath: 'mcpServers',
+      },
+    });
+
+    expect(metadata.hookConfig?.eventNameMapping).toMatchObject({
+      SessionStart: 'SessionStart',
+      SessionEnd: 'SessionEnd',
+      UserPromptSubmit: 'UserPromptSubmit',
+      PreToolUse: 'UserPromptSubmit',
+      PostToolUse: 'Stop',
+      Notification: 'PermissionRequest',
+    });
+  });
+
   it('does not disturb existing agents', () => {
     for (const name of ['claude', 'codex', 'gemini', 'kimi', 'opencode']) {
       expect(AgentRegistry.getAgent(name), `${name} should still resolve`).toBeDefined();

--- a/src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts
+++ b/src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts
@@ -22,15 +22,10 @@ describe('copilot-cli registration', () => {
     expect(AgentRegistry.getAgent('copilot-cli')!.metadata.displayName).toBe('GitHub Copilot CLI');
   });
 
-  it('is marked analytics-only so the ownership gate exempts it', () => {
-    expect(AgentRegistry.getAgent('copilot-cli')!.metadata.analyticsOnly).toBe(true);
-  });
-
-  it('refuses to be installed or launched by CodeMie', async () => {
-    const plugin = AgentRegistry.getAgent('copilot-cli')!;
-
-    await expect(plugin.install()).rejects.toThrow(/not managed by CodeMie/i);
-    await expect(plugin.run([])).rejects.toThrow(/not managed by CodeMie/i);
+  it('is managed by CodeMie and exposes npm metadata', () => {
+    const metadata = AgentRegistry.getAgent('copilot-cli')!.metadata;
+    expect(metadata.analyticsOnly).not.toBe(true);
+    expect(metadata.npmPackage).toBe('@github/copilot');
   });
 
   it('does not disturb existing agents', () => {
@@ -41,20 +36,14 @@ describe('copilot-cli registration', () => {
 });
 
 /**
- * An analytics-only agent must be invisible to every agent-MANAGEMENT surface.
- *
- * Overriding install()/uninstall()/run() to refuse is not sufficient: `codemie update`
- * never calls the adapter at all — updateAgent() reads metadata.npmPackage and calls
- * npm.installGlobal(..., { force: true }) directly. Left visible, CodeMie would
- * force-reinstall a user's global Copilot, and install/uninstall/list/doctor/first-time
- * would advertise commands that always error.
+ * Copilot now participates in the same management surfaces as other first-class agents
+ * while still exposing its session adapter for analytics.
  */
-describe('copilot-cli is excluded from agent-management surfaces', () => {
-  it('is absent from getManageableAgents()', () => {
+describe('copilot-cli is included in agent-management surfaces', () => {
+  it('is present in getManageableAgents()', () => {
     const names = AgentRegistry.getManageableAgents().map((a) => a.name);
 
-    expect(names).not.toContain('copilot-cli');
-    // Manageable agents are otherwise untouched.
+    expect(names).toContain('copilot-cli');
     for (const name of ['claude', 'codex', 'gemini', 'kimi', 'opencode']) {
       expect(names, `${name} must stay manageable`).toContain(name);
     }
@@ -64,14 +53,7 @@ describe('copilot-cli is excluded from agent-management surfaces', () => {
     expect(AgentRegistry.getAllAgents().map((a) => a.name)).toContain('copilot-cli');
   });
 
-  it('is absent from getInstalledAgents(), which only feeds management surfaces', async () => {
-    const names = (await AgentRegistry.getInstalledAgents()).map((a) => a.name);
-    expect(names).not.toContain('copilot-cli');
-  });
-
-  it('declares a null npmPackage, so `codemie update` cannot npm-install it', () => {
-    // Defense in depth: even if a management surface is missed, updateAgent() throws
-    // "cannot be updated (no npm package configured)" instead of mutating a global install.
-    expect(AgentRegistry.getAgent('copilot-cli')!.metadata.npmPackage).toBeNull();
+  it('declares the npm package used for managed installation', () => {
+    expect(AgentRegistry.getAgent('copilot-cli')!.metadata.npmPackage).toBe('@github/copilot');
   });
 });

--- a/src/agents/plugins/copilot-cli/copilot-cli.constants.ts
+++ b/src/agents/plugins/copilot-cli/copilot-cli.constants.ts
@@ -10,3 +10,9 @@ export const COPILOT_CLI_AGENT_NAME = 'copilot-cli';
 
 /** User-facing label shown in the analytics report and terminal output. */
 export const COPILOT_CLI_DISPLAY_NAME = 'GitHub Copilot CLI';
+
+/** User-facing short name used by install/uninstall surfaces. */
+export const COPILOT_CLI_INSTALL_ALIAS = 'copilot';
+
+/** Runtime client type used for managed Copilot sessions. */
+export const COPILOT_CLI_CLIENT_TYPE = 'codemie-copilot';

--- a/src/agents/plugins/copilot-cli/copilot-cli.models.ts
+++ b/src/agents/plugins/copilot-cli/copilot-cli.models.ts
@@ -1,0 +1,244 @@
+import type { LlmModel } from '../../../providers/plugins/sso/sso.http-client.js';
+import { fetchCodeMieLlmModels } from '../../../providers/plugins/sso/sso.http-client.js';
+import { CodeMieSSO } from '../../../providers/plugins/sso/sso.auth.js';
+import { ConfigurationError } from '../../../utils/errors.js';
+import { logger } from '../../../utils/logger.js';
+
+export interface CopilotModelResolution {
+  selectedModel: string;
+  availableModels: string[];
+}
+
+interface RankedCopilotModel {
+  model: LlmModel;
+  id: string;
+  score: number[];
+}
+
+type ConfigSource = 'default' | 'global' | 'project' | 'env' | 'cli';
+
+const COPILOT_INCOMPATIBLE_MODEL_PATTERNS: RegExp[] = [
+  /embedding/i,
+  /rerank/i,
+  /whisper/i,
+  /tts/i,
+  /moderation/i,
+  /image/i,
+  /vision-only/i,
+];
+
+const GPT_FAMILY_PATTERNS: RegExp[] = [
+  /\bgpt\b/i,
+];
+
+const CLAUDE_FAMILY_PATTERNS: RegExp[] = [
+  /claude/i,
+  /anthropic/i,
+  /sonnet/i,
+  /opus/i,
+  /haiku/i,
+];
+
+function getModelId(model: LlmModel): string | undefined {
+  return model.deployment_name || model.base_name || model.label;
+}
+
+function getSearchText(model: LlmModel): string {
+  return [
+    model.deployment_name,
+    model.base_name,
+    model.label,
+    model.provider,
+  ].filter(Boolean).join(' ').toLowerCase();
+}
+
+export function isCopilotCompatibleModelName(modelName: string | undefined): modelName is string {
+  if (!modelName) return false;
+  if (COPILOT_INCOMPATIBLE_MODEL_PATTERNS.some((pattern) => pattern.test(modelName))) {
+    return false;
+  }
+  return GPT_FAMILY_PATTERNS.some((pattern) => pattern.test(modelName))
+    || CLAUDE_FAMILY_PATTERNS.some((pattern) => pattern.test(modelName));
+}
+
+function isCopilotCompatibleModel(model: LlmModel): boolean {
+  if (!model.enabled) return false;
+  if (model.features?.tools === false || model.features?.streaming === false) {
+    return false;
+  }
+
+  const id = getModelId(model);
+  if (!id || !isCopilotCompatibleModelName(id)) {
+    const searchText = getSearchText(model);
+    if (!isCopilotCompatibleModelName(searchText)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function extractVersionParts(text: string): number[] {
+  const lower = text.toLowerCase();
+  const gptMatch = lower.match(/gpt[-.]?(\d+)(?:[-.](\d+))?(?:[-.](\d+))?/);
+  const claudeDateMatch = lower.match(/(20\d{2})[-.]?(\d{2})[-.]?(\d{2})/);
+  const claudeGenMatch = lower.match(/claude(?:[-_.]?(\d+))?(?:[-_.](\d+))?/);
+
+  const version = [
+    gptMatch?.[1] ?? claudeGenMatch?.[1],
+    gptMatch?.[2] ?? claudeGenMatch?.[2],
+    gptMatch?.[3],
+  ].map((part) => (part ? Number(part) : 0));
+
+  if (claudeDateMatch) {
+    version.push(Number(claudeDateMatch[1]), Number(claudeDateMatch[2]), Number(claudeDateMatch[3]));
+  } else {
+    version.push(0, 0, 0);
+  }
+
+  return version;
+}
+
+function rankModel(model: LlmModel): RankedCopilotModel {
+  const id = getModelId(model);
+  if (!id) {
+    throw new ConfigurationError('Cannot rank Copilot model without a model identifier');
+  }
+
+  const searchText = getSearchText(model);
+  const preferredGpt55Bonus = /gpt[-_.]?5[-_.]?5(?:[-_.]|$)/i.test(searchText) ? 1 : 0;
+  const preferredGpt54Bonus = /gpt[-_.]?5[-_.]?4(?:[-_.]|$)/i.test(searchText) ? 1 : 0;
+  const preferredGptCodexBonus = /gpt[-_.]?5[-_.]?[23].*codex/i.test(searchText) ? 1 : 0;
+  const preferredClaudeBonus = /claude[-_.]?(?:sonnet[-_.]?)?(?:4(?:[-_.]5|[-_.]6)?|5)(?:[-_.]|$)/i.test(searchText) ? 1 : 0;
+  const gptFamilyBonus = GPT_FAMILY_PATTERNS.some((pattern) => pattern.test(searchText)) ? 1 : 0;
+  const claudeFamilyBonus = CLAUDE_FAMILY_PATTERNS.some((pattern) => pattern.test(searchText)) ? 1 : 0;
+  const defaultBonus = model.default ? 1 : 0;
+  const toolBonus = model.features?.tools === false ? 0 : 1;
+  const streamingBonus = model.features?.streaming === false ? 0 : 1;
+  const temperatureBonus = model.features?.temperature === false ? 1 : 0;
+
+  return {
+    model,
+    id,
+    score: [
+      preferredGpt55Bonus,
+      preferredGpt54Bonus,
+      preferredGptCodexBonus,
+      gptFamilyBonus,
+      preferredClaudeBonus,
+      claudeFamilyBonus,
+      temperatureBonus,
+      toolBonus,
+      streamingBonus,
+      ...extractVersionParts(searchText),
+      defaultBonus,
+    ],
+  };
+}
+
+function compareRankedModels(a: RankedCopilotModel, b: RankedCopilotModel): number {
+  const max = Math.max(a.score.length, b.score.length);
+  for (let i = 0; i < max; i++) {
+    const diff = (b.score[i] ?? 0) - (a.score[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+async function fetchCodeMieModelsForCopilot(env: NodeJS.ProcessEnv): Promise<LlmModel[]> {
+  const jwtToken = env.CODEMIE_JWT_TOKEN;
+  const baseUrl = env.CODEMIE_BASE_URL;
+
+  if (jwtToken && baseUrl) {
+    logger.debug('[copilot-cli-models] Fetching CodeMie model list via JWT auth');
+    return fetchCodeMieLlmModels(baseUrl, jwtToken);
+  }
+
+  const codeMieUrl = env.CODEMIE_URL;
+  if (codeMieUrl) {
+    const sso = new CodeMieSSO();
+    const credentials = await sso.getStoredCredentials(codeMieUrl);
+    if (!credentials) {
+      throw new ConfigurationError(
+        `SSO credentials not found for ${codeMieUrl}. Run: codemie setup or codemie profile login --url ${codeMieUrl}`
+      );
+    }
+
+    logger.debug('[copilot-cli-models] Fetching CodeMie model list via SSO auth');
+    return fetchCodeMieLlmModels(credentials.apiUrl, credentials.cookies);
+  }
+
+  return [];
+}
+
+export async function resolveCopilotModel(env: NodeJS.ProcessEnv): Promise<CopilotModelResolution> {
+  const currentModel = env.CODEMIE_MODEL;
+  const modelSource = (env.CODEMIE_MODEL_SOURCE || 'default') as ConfigSource;
+
+  let rawModels: LlmModel[] = [];
+  try {
+    rawModels = await fetchCodeMieModelsForCopilot(env);
+  } catch (error) {
+    if (isCopilotCompatibleModelName(currentModel)) {
+      const configuredModel = currentModel;
+      logger.debug('[copilot-cli-models] Failed to fetch CodeMie models; keeping compatible configured model', {
+        error: error instanceof Error ? error.message : String(error),
+        model: configuredModel,
+      });
+      return { selectedModel: configuredModel, availableModels: [configuredModel] };
+    }
+    throw error;
+  }
+
+  const rankedModels = rawModels
+    .filter(isCopilotCompatibleModel)
+    .map(rankModel)
+    .sort(compareRankedModels);
+
+  if (rankedModels.length === 0) {
+    if (isCopilotCompatibleModelName(currentModel)) {
+      const configuredModel = currentModel;
+      logger.debug('[copilot-cli-models] CodeMie returned no explicitly compatible Copilot models; keeping configured model');
+      return { selectedModel: configuredModel, availableModels: [configuredModel] };
+    }
+
+    throw new ConfigurationError(
+      'No CodeMie model compatible with GitHub Copilot CLI is available. ' +
+      'Use a model with tool calling and streaming support, such as gpt-5.5 or claude-sonnet-4.6.'
+    );
+  }
+
+  const selectedModel = rankedModels[0].id;
+  const rankedIds = rankedModels.map((entry) => entry.id);
+  const shouldPreserveConfiguredModel = modelSource === 'cli' || modelSource === 'env';
+  const effectiveModel =
+    shouldPreserveConfiguredModel && currentModel && rankedIds.includes(currentModel)
+      ? currentModel
+      : selectedModel;
+
+  if (currentModel && currentModel !== effectiveModel) {
+    logger.info(`[copilot-cli-models] Using ${effectiveModel} for Copilot instead of profile model ${currentModel}`);
+  }
+
+  return {
+    selectedModel: effectiveModel,
+    availableModels: rankedModels.map((entry) => entry.id),
+  };
+}
+
+export function assertExplicitCopilotModelAllowed(model: string, availableModels: string[]): void {
+  if (!isCopilotCompatibleModelName(model)) {
+    throw new ConfigurationError(
+      `Model "${model}" is not compatible with codemie-copilot. ` +
+      `Use a GPT-family or Claude-family model with tool calling and streaming support` +
+      `${availableModels.length ? ` such as: ${availableModels.join(', ')}` : '.'}`
+    );
+  }
+
+  if (availableModels.length > 0 && !availableModels.includes(model)) {
+    throw new ConfigurationError(
+      `Model "${model}" is not available in CodeMie for codemie-copilot. ` +
+      `Available models: ${availableModels.join(', ')}`
+    );
+  }
+}

--- a/src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
+++ b/src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
@@ -26,6 +26,22 @@ const COPILOT_MINIMUM_SUPPORTED_VERSION = '1.0.70';
 const COPILOT_COMPATIBLE_PROVIDERS = ['ai-run-sso', 'litellm'] as const;
 const COPILOT_RECOMMENDED_MODELS = ['gpt-5.5', 'claude-sonnet-4.6', 'gpt-5.4'];
 
+function buildCopilotHookConfig(env: NodeJS.ProcessEnv, sessionId: string) {
+  return {
+    agentName: env.CODEMIE_AGENT || COPILOT_CLI_AGENT_NAME,
+    sessionId,
+    provider: env.CODEMIE_PROVIDER,
+    apiBaseUrl: env.CODEMIE_BASE_URL,
+    ssoUrl: env.CODEMIE_URL,
+    syncApiUrl: env.CODEMIE_SYNC_API_URL,
+    version: env.CODEMIE_CLI_VERSION,
+    profileName: env.CODEMIE_PROFILE_NAME,
+    project: env.CODEMIE_PROJECT,
+    model: env.CODEMIE_MODEL,
+    clientType: COPILOT_CLI_CLIENT_TYPE,
+  };
+}
+
 function buildCopilotProviderEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   if (!env.CODEMIE_BASE_URL) {
     throw new ConfigurationError(
@@ -82,6 +98,39 @@ export const CopilotCliPluginMetadata: AgentMetadata = {
   dataPaths: {
     home: '.copilot',
   },
+  extensionsConfig: {
+    project: '.github',
+    global: '~/.copilot',
+    skillsEntryFile: 'SKILL.md',
+    dirNames: {
+      agents: ['agents'],
+      commands: [],
+      skills: ['skills'],
+      hooks: ['hooks'],
+      rules: [],
+    },
+    extraProjectDirs: ['.github/copilot'],
+  },
+  mcpConfig: {
+    project: {
+      path: ['.mcp.json', '.github/mcp.json'],
+      jsonPath: 'mcpServers',
+    },
+    user: {
+      path: '~/.copilot/mcp-config.json',
+      jsonPath: 'mcpServers',
+    },
+  },
+  hookConfig: {
+    eventNameMapping: {
+      SessionStart: 'SessionStart',
+      SessionEnd: 'SessionEnd',
+      UserPromptSubmit: 'UserPromptSubmit',
+      PreToolUse: 'UserPromptSubmit',
+      PostToolUse: 'Stop',
+      Notification: 'PermissionRequest',
+    },
+  },
   envMapping: {
     baseUrl: [],
     apiKey: [],
@@ -99,6 +148,26 @@ export const CopilotCliPluginMetadata: AgentMetadata = {
     '--task': { type: 'flag', target: '--prompt' },
   },
   lifecycle: {
+    async onSessionStart(sessionId: string, env: NodeJS.ProcessEnv) {
+      try {
+        const { processEvent } = await import('../../../cli/commands/hook.js');
+        await processEvent(
+          {
+            hook_event_name: 'SessionStart',
+            session_id: sessionId,
+            transcript_path: '',
+            permission_mode: 'default',
+            cwd: process.cwd(),
+            source: 'startup',
+          },
+          buildCopilotHookConfig(env, sessionId)
+        );
+        logger.info(`[copilot-cli] SessionStart hook completed for session ${sessionId}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`[copilot-cli] SessionStart hook failed (non-blocking): ${message}`);
+      }
+    },
     async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig) {
       assertCopilotProviderSupported(config);
 
@@ -106,6 +175,12 @@ export const CopilotCliPluginMetadata: AgentMetadata = {
       delete env.GH_TOKEN;
       delete env.GITHUB_TOKEN;
       delete env.COPILOT_TOKEN;
+
+      if (!env.COPILOT_HOME) {
+        env.COPILOT_HOME = this.resolveDataPath();
+      }
+
+      await this.ensureDirectory(env.COPILOT_HOME);
 
       const availableModels = (env.CODEMIE_COPILOT_AVAILABLE_MODELS || '')
         .split(',')
@@ -143,6 +218,42 @@ export const CopilotCliPluginMetadata: AgentMetadata = {
       }
 
       return enriched;
+    },
+    async onSessionEnd(exitCode: number, env: NodeJS.ProcessEnv) {
+      const sessionId = env.CODEMIE_SESSION_ID;
+      if (!sessionId) {
+        logger.debug('[copilot-cli] No CODEMIE_SESSION_ID in environment, skipping session end');
+        return;
+      }
+
+      try {
+        const adapter = new CopilotCliSessionAdapter(CopilotCliPluginMetadata);
+        const sessions = await adapter.discoverSessions({
+          maxAgeDays: 1,
+          limit: 1,
+          cwd: process.cwd(),
+        });
+
+        const transcriptPath = sessions[0]?.filePath ?? '';
+        const agentSessionId = sessions[0]?.sessionId ?? sessionId;
+
+        const { processEvent } = await import('../../../cli/commands/hook.js');
+        await processEvent(
+          {
+            hook_event_name: 'SessionEnd',
+            session_id: agentSessionId,
+            transcript_path: transcriptPath,
+            permission_mode: 'default',
+            cwd: process.cwd(),
+            reason: exitCode === 0 ? 'exit' : `exit(${exitCode})`,
+          },
+          buildCopilotHookConfig(env, sessionId)
+        );
+        logger.info(`[copilot-cli] SessionEnd hook completed for session ${sessionId}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`[copilot-cli] SessionEnd hook failed (non-blocking): ${message}`);
+      }
     },
   },
 };

--- a/src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
+++ b/src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
@@ -1,48 +1,150 @@
-/**
- * GitHub Copilot CLI — analytics-only agent plugin.
- *
- * CodeMie does NOT install, launch, configure, or proxy Copilot. This plugin exists solely
- * so `AgentRegistry` can hand the analytics pipeline a `SessionAdapter`: `native-loader.ts`
- * resolves adapters via `AgentRegistry.getAgent(name)?.getSessionAdapter?.()`, and there is
- * no analytics-only bypass around the registry.
- *
- * The mutating lifecycle methods inherited from `BaseAgentAdapter` are therefore overridden
- * to refuse. Left inherited, `install()` would npm-install `@github/copilot` and `run()`
- * would launch it — both outside this integration's remit.
- */
-
-import type { AgentMetadata } from '../../core/types.js';
+import type { AgentConfig, AgentMetadata } from '../../core/types.js';
 import { BaseAgentAdapter } from '../../core/BaseAgentAdapter.js';
 import type { SessionAdapter } from '../../core/session/BaseSessionAdapter.js';
 import { CopilotCliSessionAdapter } from './copilot-cli.session.js';
 import { ConfigurationError } from '../../../utils/errors.js';
-import { COPILOT_CLI_AGENT_NAME, COPILOT_CLI_DISPLAY_NAME } from './copilot-cli.constants.js';
+import { commandExists, exec } from '../../../utils/processes.js';
+import { logger } from '../../../utils/logger.js';
+import {
+  COPILOT_CLI_AGENT_NAME,
+  COPILOT_CLI_CLIENT_TYPE,
+  COPILOT_CLI_DISPLAY_NAME,
+} from './copilot-cli.constants.js';
+import {
+  assertExplicitCopilotModelAllowed,
+  resolveCopilotModel,
+} from './copilot-cli.models.js';
 
-export { COPILOT_CLI_AGENT_NAME, COPILOT_CLI_DISPLAY_NAME };
+export {
+  COPILOT_CLI_AGENT_NAME,
+  COPILOT_CLI_CLIENT_TYPE,
+  COPILOT_CLI_DISPLAY_NAME,
+} from './copilot-cli.constants.js';
 
-const NOT_MANAGED =
-  'GitHub Copilot CLI is not managed by CodeMie. It is supported for analytics only — ' +
-  'install and run it with the `copilot` command directly (npm package `@github/copilot`).';
+const COPILOT_SUPPORTED_VERSION = '1.0.79';
+const COPILOT_MINIMUM_SUPPORTED_VERSION = '1.0.70';
+const COPILOT_COMPATIBLE_PROVIDERS = ['ai-run-sso', 'litellm'] as const;
+const COPILOT_RECOMMENDED_MODELS = ['gpt-5.5', 'claude-sonnet-4.6', 'gpt-5.4'];
+
+function buildCopilotProviderEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  if (!env.CODEMIE_BASE_URL) {
+    throw new ConfigurationError(
+      'CodeMie base URL is not configured for Copilot CLI. Run codemie setup and try again.'
+    );
+  }
+
+  if (!env.CODEMIE_MODEL) {
+    throw new ConfigurationError(
+      'No CodeMie model is configured for Copilot CLI. Run codemie setup or pass --model.'
+    );
+  }
+
+  const providerType = /^claude/i.test(env.CODEMIE_MODEL) ? 'anthropic' : 'openai';
+  const providerEnv: Record<string, string> = {
+    COPILOT_PROVIDER_BASE_URL: env.CODEMIE_BASE_URL,
+    COPILOT_PROVIDER_TYPE: providerType,
+    COPILOT_MODEL: env.CODEMIE_MODEL,
+    COPILOT_PROVIDER_MODEL_ID: env.CODEMIE_MODEL,
+    COPILOT_PROVIDER_WIRE_MODEL: env.CODEMIE_MODEL,
+    COPILOT_OFFLINE: 'true',
+  };
+
+  if (/^gpt[-_.]?5/i.test(env.CODEMIE_MODEL)) {
+    providerEnv.COPILOT_PROVIDER_WIRE_API = 'responses';
+  }
+
+  if (env.CODEMIE_API_KEY) {
+    providerEnv.COPILOT_PROVIDER_API_KEY = env.CODEMIE_API_KEY;
+    providerEnv.COPILOT_PROVIDER_BEARER_TOKEN = env.CODEMIE_API_KEY;
+  }
+
+  return providerEnv;
+}
+
+function assertCopilotProviderSupported(config: AgentConfig): void {
+  const provider = config.provider;
+  if (!provider || !COPILOT_COMPATIBLE_PROVIDERS.includes(provider as (typeof COPILOT_COMPATIBLE_PROVIDERS)[number])) {
+    throw new ConfigurationError(
+      'GitHub Copilot CLI via CodeMie currently supports only AI/Run SSO and LiteLLM profiles. ' +
+      'Run codemie setup to choose a supported provider.'
+    );
+  }
+}
 
 export const CopilotCliPluginMetadata: AgentMetadata = {
   name: COPILOT_CLI_AGENT_NAME,
   displayName: COPILOT_CLI_DISPLAY_NAME,
-  description: 'GitHub Copilot CLI — analytics ingestion only (not managed by CodeMie)',
-  // Deliberately null, even though Copilot ships as @github/copilot. `codemie update`
-  // bypasses the adapter entirely — updateAgent() reads metadata.npmPackage and runs
-  // `npm install -g <pkg> --force`, which would overwrite the user's own Copilot install.
-  // Null makes that path fail safe ("cannot be updated") instead of destructively, as
-  // defense in depth behind the getManageableAgents() exclusion.
-  npmPackage: null,
-  cliCommand: 'copilot',
+  description: 'GitHub Copilot CLI - AI coding agent managed by CodeMie',
+  npmPackage: '@github/copilot',
+  cliCommand: process.env.CODEMIE_COPILOT_BIN || 'copilot',
+  supportedVersion: COPILOT_SUPPORTED_VERSION,
+  minimumSupportedVersion: COPILOT_MINIMUM_SUPPORTED_VERSION,
   dataPaths: {
     home: '.copilot',
   },
-  // Required by AgentMetadata but inapplicable here: CodeMie never launches Copilot, so
-  // there is no environment to map and no provider to route it through.
-  envMapping: {},
-  supportedProviders: [],
-  analyticsOnly: true,
+  envMapping: {
+    baseUrl: [],
+    apiKey: [],
+    model: [],
+  },
+  supportedProviders: [...COPILOT_COMPATIBLE_PROVIDERS],
+  blockedModelPatterns: [/embedding/i, /rerank/i, /whisper/i, /tts/i, /image/i],
+  recommendedModels: [...COPILOT_RECOMMENDED_MODELS],
+  ssoConfig: {
+    enabled: true,
+    clientType: COPILOT_CLI_CLIENT_TYPE,
+  },
+  sessionAnalyticsReport: true,
+  flagMappings: {
+    '--task': { type: 'flag', target: '--prompt' },
+  },
+  lifecycle: {
+    async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig) {
+      assertCopilotProviderSupported(config);
+
+      // Prevent fallback to GitHub-native auth even when GitHub credentials exist.
+      delete env.GH_TOKEN;
+      delete env.GITHUB_TOKEN;
+      delete env.COPILOT_TOKEN;
+
+      const availableModels = (env.CODEMIE_COPILOT_AVAILABLE_MODELS || '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (env.CODEMIE_MODEL) {
+        assertExplicitCopilotModelAllowed(env.CODEMIE_MODEL, availableModels);
+      }
+
+      const providerEnv = buildCopilotProviderEnv(env);
+      Object.assign(env, providerEnv);
+
+      logger.debug('[copilot-cli] Prepared provider env for managed Copilot session', {
+        provider: config.provider,
+        model: env.CODEMIE_MODEL,
+        providerType: providerEnv.COPILOT_PROVIDER_TYPE,
+        clientType: COPILOT_CLI_CLIENT_TYPE,
+      });
+
+      return env;
+    },
+    enrichArgs(args: string[], _config: AgentConfig): string[] {
+      const enriched = [...args];
+
+      const hasPrompt = enriched.includes('-p') || enriched.includes('--prompt');
+      const hasAutoApproval = enriched.includes('--allow-all') || enriched.includes('--allow-all-tools') || enriched.includes('--yolo');
+      const hasModel = enriched.includes('--model');
+
+      if (hasPrompt && !hasAutoApproval) {
+        enriched.push('--allow-all-tools');
+      }
+
+      if (!hasModel && process.env.CODEMIE_MODEL) {
+        enriched.push('--model', process.env.CODEMIE_MODEL);
+      }
+
+      return enriched;
+    },
+  },
 };
 
 export class CopilotCliPlugin extends BaseAgentAdapter {
@@ -59,18 +161,48 @@ export class CopilotCliPlugin extends BaseAgentAdapter {
     return this.sessionAdapter;
   }
 
-  /** Refused: analytics-only. See {@link NOT_MANAGED}. */
-  async install(): Promise<void> {
-    throw new ConfigurationError(NOT_MANAGED);
+  protected override async setupProxy(env: NodeJS.ProcessEnv): Promise<void> {
+    if (env.CODEMIE_PROVIDER !== 'ai-run-sso' && env.CODEMIE_AUTH_METHOD !== 'jwt') {
+      await super.setupProxy(env);
+      return;
+    }
+
+    const modelSource = env.CODEMIE_MODEL_SOURCE;
+    const explicitModel = env.CODEMIE_MODEL && (modelSource === 'cli' || modelSource === 'env')
+      ? env.CODEMIE_MODEL
+      : undefined;
+    const { selectedModel, availableModels } = await resolveCopilotModel(env);
+
+    if (explicitModel) {
+      assertExplicitCopilotModelAllowed(explicitModel, availableModels);
+      env.CODEMIE_MODEL = explicitModel;
+    } else {
+      env.CODEMIE_MODEL = selectedModel;
+    }
+
+    env.CODEMIE_COPILOT_AVAILABLE_MODELS = availableModels.join(',');
+
+    await super.setupProxy(env);
   }
 
-  /** Refused: analytics-only. See {@link NOT_MANAGED}. */
-  async uninstall(): Promise<void> {
-    throw new ConfigurationError(NOT_MANAGED);
+  override async isInstalled(): Promise<boolean> {
+    if (!this.metadata.cliCommand) {
+      return true;
+    }
+    return commandExists(this.metadata.cliCommand);
   }
 
-  /** Refused: analytics-only. See {@link NOT_MANAGED}. */
-  async run(_args: string[], _env?: Record<string, string>): Promise<void> {
-    throw new ConfigurationError(NOT_MANAGED);
+  override async getVersion(): Promise<string | null> {
+    if (!this.metadata.cliCommand) {
+      return null;
+    }
+
+    try {
+      const result = await exec(this.metadata.cliCommand, ['--version']);
+      const match = result.stdout.trim().match(/(\d+\.\d+\.\d+)/);
+      return match ? match[1] : result.stdout.trim() || null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/agents/plugins/copilot-cli/copilot-cli.session.ts
+++ b/src/agents/plugins/copilot-cli/copilot-cli.session.ts
@@ -245,7 +245,12 @@ export class CopilotCliSessionAdapter implements SessionAdapter {
           break;
         }
         case 'user.message': {
-          const text = (event.data as { text?: string } | undefined)?.text;
+          const data = (event.data as { text?: string; content?: string } | undefined) ?? {};
+          const text = typeof data.text === 'string' && data.text.trim()
+            ? data.text
+            : typeof data.content === 'string'
+              ? data.content
+              : undefined;
           if (typeof text === 'string' && text.trim()) {
             userPrompts.push({ count: 1, text });
           }
@@ -272,7 +277,14 @@ export class CopilotCliSessionAdapter implements SessionAdapter {
             timestamp: event.timestamp,
             cwd,
             gitBranch: branch,
-            message: { role: 'assistant', model: data.model ?? currentModel },
+            message: {
+              role: 'assistant',
+              model: data.model ?? currentModel,
+              content: typeof (data as { content?: string }).content === 'string'
+                ? (data as { content?: string }).content
+                : '',
+              toolRequests: Array.isArray(data.toolRequests) ? data.toolRequests : [],
+            },
           };
           if (!record.message.model) {
             unlabelledTurns.push(record);

--- a/src/agents/plugins/copilot-cli/index.ts
+++ b/src/agents/plugins/copilot-cli/index.ts
@@ -2,5 +2,11 @@ export {
   CopilotCliPlugin,
   CopilotCliPluginMetadata,
   COPILOT_CLI_AGENT_NAME,
+  COPILOT_CLI_CLIENT_TYPE,
   COPILOT_CLI_DISPLAY_NAME,
 } from './copilot-cli.plugin.js';
+export {
+  assertExplicitCopilotModelAllowed,
+  isCopilotCompatibleModelName,
+  resolveCopilotModel,
+} from './copilot-cli.models.js';

--- a/src/agents/plugins/copilot-cli/session/processors/copilot-cli.conversations-processor.ts
+++ b/src/agents/plugins/copilot-cli/session/processors/copilot-cli.conversations-processor.ts
@@ -2,28 +2,403 @@
  * Conversations processor for Copilot CLI sessions.
  *
  * Copilot persists prompt text in `events.jsonl`; `parseSessionFile` captures it into
- * `metrics.userPrompts`.
+ * `ParsedSession.messages`. Unlike Claude and Pi, Copilot does not currently emit
+ * mid-turn hook events through CodeMie, so this processor drains the whole discovered
+ * transcript on SessionEnd and appends pending payload windows to the standard
+ * `_conversation.jsonl` spool for the shared sync pipeline.
  */
 
+import { appendFile, mkdir } from 'fs/promises';
+import { dirname } from 'path';
 import type {
   SessionProcessor,
   ProcessingContext,
   ProcessingResult,
 } from '../../../../core/session/BaseProcessor.js';
 import type { ParsedSession } from '../../../../core/session/BaseSessionAdapter.js';
+import { getSessionConversationPath } from '../../../../core/session/session-config.js';
+import { CODEMIE_ASSISTANT_ID, CONVERSATION_PROCESSOR_NAME } from '../../../../../providers/plugins/sso/session/processors/conversations/constants.js';
+import type { ConversationPayloadRecord } from '../../../../../providers/plugins/sso/session/processors/conversations/types.js';
+import { CONVERSATION_SYNC_STATUS } from '../../../../../providers/plugins/sso/session/processors/conversations/types.js';
+import { readJSONL } from '../../../../../providers/plugins/sso/session/utils/jsonl-reader.js';
+import { logger } from '../../../../../utils/logger.js';
+
+interface CopilotTurnRecord {
+  role?: 'user' | 'assistant';
+  timestamp?: string;
+  message?: {
+    role?: 'user' | 'assistant';
+    content?: string;
+    model?: string;
+    toolRequests?: Array<{
+      toolCallId?: string;
+      name?: string;
+      arguments?: unknown;
+    }>;
+  };
+}
+
+type CopilotThought = {
+  id: string;
+  parent_id: string | null;
+  metadata: Record<string, unknown>;
+  in_progress: boolean;
+  input_text: string;
+  message: string;
+  author_type: 'Tool' | 'Agent';
+  author_name: string;
+  output_format: string;
+  error: boolean;
+  interrupted: boolean;
+  aborted: boolean;
+  children: unknown[];
+};
+
+type CopilotEventKind = 'assistant_commentary' | 'tool_call' | 'tool_output';
+
+interface CopilotTurnEvent {
+  kind: CopilotEventKind;
+  sourceIndex: number;
+  timestamp?: string;
+  text?: string;
+  callId?: string;
+  toolName?: string;
+  inputText?: string;
+  error?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+interface CopilotConversationTurn {
+  historyIndex: number;
+  user?: { text: string; timestamp?: string };
+  assistant?: { text: string; timestamp?: string; model?: string };
+  events: CopilotTurnEvent[];
+}
+
+function asTurnRecord(value: unknown): CopilotTurnRecord | null {
+  if (!value || typeof value !== 'object') return null;
+  return value as CopilotTurnRecord;
+}
+
+function parseTimestampMs(value?: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function calculateResponseTimeSeconds(start?: string, end?: string): number | undefined {
+  const startMs = parseTimestampMs(start);
+  const endMs = parseTimestampMs(end);
+  if (startMs === undefined || endMs === undefined || endMs < startMs) {
+    return undefined;
+  }
+  return Math.max(0, Math.round(((endMs - startMs) / 1000) * 100) / 100);
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function buildThoughts(events: CopilotTurnEvent[], historyIndex: number): CopilotThought[] {
+  const thoughts: CopilotThought[] = [];
+  const toolThoughtByCallId = new Map<string, CopilotThought>();
+
+  for (const event of events) {
+    if (event.kind === 'assistant_commentary') {
+      if (!event.text?.trim()) continue;
+      thoughts.push({
+        id: `copilot-commentary-${historyIndex}-${event.sourceIndex}`,
+        parent_id: null,
+        metadata: {
+          timestamp: event.timestamp,
+          source_index: event.sourceIndex,
+          event_kind: event.kind,
+          ...(event.metadata ?? {}),
+        },
+        in_progress: false,
+        input_text: '',
+        message: event.text,
+        author_type: 'Agent',
+        author_name: 'GitHub Copilot CLI',
+        output_format: 'text',
+        error: false,
+        interrupted: false,
+        aborted: false,
+        children: [],
+      });
+      continue;
+    }
+
+    if (event.kind === 'tool_output') {
+      const pending = event.callId ? toolThoughtByCallId.get(event.callId) : undefined;
+      if (pending) {
+        pending.message = event.text ?? '';
+        pending.error = event.error === true;
+        pending.metadata = {
+          ...pending.metadata,
+          output_source_index: event.sourceIndex,
+          output_timestamp: event.timestamp,
+          ...(event.metadata ?? {}),
+        };
+        toolThoughtByCallId.delete(event.callId!);
+        continue;
+      }
+    }
+
+    const thought: CopilotThought = {
+      id: event.callId || `copilot-tool-${historyIndex}-${event.sourceIndex}`,
+      parent_id: null,
+      metadata: {
+        timestamp: event.timestamp,
+        source_index: event.sourceIndex,
+        event_kind: event.kind,
+        ...(event.callId && { call_id: event.callId }),
+        ...(event.metadata ?? {}),
+      },
+      in_progress: false,
+      input_text: event.inputText ?? '',
+      message: event.text ?? '',
+      author_type: 'Tool',
+      author_name: event.toolName || 'Unknown Tool',
+      output_format: 'text',
+      error: event.error === true,
+      interrupted: false,
+      aborted: false,
+      children: [],
+    };
+    thoughts.push(thought);
+    if (event.kind === 'tool_call' && event.callId) {
+      toolThoughtByCallId.set(event.callId, thought);
+    }
+  }
+
+  return thoughts;
+}
+
+function toHistory(turn: CopilotConversationTurn): any[] {
+  const history: any[] = [];
+
+  if (turn.user?.text) {
+    history.push({
+      role: 'User',
+      message: turn.user.text,
+      message_raw: turn.user.text,
+      history_index: turn.historyIndex,
+      date: turn.user.timestamp,
+      file_names: [],
+    });
+  }
+
+  if (turn.assistant?.text) {
+    const thoughts = buildThoughts(turn.events, turn.historyIndex);
+    history.push({
+      role: 'Assistant',
+      message: turn.assistant.text,
+      message_raw: turn.assistant.text,
+      history_index: turn.historyIndex,
+      date: turn.assistant.timestamp,
+      response_time: calculateResponseTimeSeconds(turn.user?.timestamp, turn.assistant.timestamp),
+      assistant_id: CODEMIE_ASSISTANT_ID,
+      thoughts: thoughts.length > 0 ? thoughts : undefined,
+    });
+  }
+
+  return history;
+}
+
+function buildTurns(messages: unknown[]): CopilotConversationTurn[] {
+  const turns: CopilotConversationTurn[] = [];
+  let current: CopilotConversationTurn | null = null;
+  let historyIndex = -1;
+
+  for (const [sourceIndex, raw] of messages.entries()) {
+    const record = asTurnRecord(raw);
+    const role = record?.message?.role;
+    const content = record?.message?.content?.trim();
+
+    if (!role || !content) {
+      continue;
+    }
+
+    if (role === 'user') {
+      historyIndex += 1;
+      current = {
+        historyIndex,
+        user: {
+          text: content,
+          timestamp: record.timestamp,
+        },
+        events: [],
+      };
+      turns.push(current);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    current.assistant = {
+      text: content,
+      timestamp: record.timestamp,
+      model: record.message?.model,
+    };
+
+    const toolRequests = Array.isArray(record.message?.toolRequests)
+      ? record.message?.toolRequests
+      : [];
+
+    if (toolRequests.length > 0) {
+      for (const request of toolRequests) {
+        current.events.push({
+          kind: 'tool_call',
+          sourceIndex,
+          timestamp: record.timestamp,
+          callId: request.toolCallId,
+          toolName: request.name,
+          inputText: stringify(request.arguments),
+          metadata: {
+            tool_arguments: request.arguments,
+          },
+        });
+      }
+    } else {
+      current.events.push({
+        kind: 'assistant_commentary',
+        sourceIndex,
+        timestamp: record.timestamp,
+        text: content,
+      });
+    }
+  }
+
+  return turns;
+}
 
 export class CopilotCliConversationsProcessor implements SessionProcessor {
   readonly name = 'copilot-cli-conversations';
-  readonly priority = 20;
+  readonly priority = 2;
 
   shouldProcess(session: ParsedSession): boolean {
-    return (session.metrics?.userPrompts?.length ?? 0) > 0;
+    if (process.env.CODEMIE_CONV_SYNC_DISABLED === '1') return false;
+    return session.messages.length > 0;
   }
 
-  async process(session: ParsedSession, _context: ProcessingContext): Promise<ProcessingResult> {
+  async process(session: ParsedSession, context: ProcessingContext): Promise<ProcessingResult> {
+    const conversationId = context.agentSessionId?.trim();
+    if (!conversationId) {
+      logger.warn(`[${this.name}] Missing agentSessionId for session ${session.sessionId}; skipping conversation sync`);
+      return {
+        success: true,
+        message: 'Skipped: missing Copilot conversation id',
+        metadata: { recordsProcessed: 0, skipReason: 'MISSING_CONVERSATION_ID' },
+      };
+    }
+
+    const turns = buildTurns(session.messages);
+    if (turns.length === 0) {
+      return {
+        success: true,
+        message: 'No conversation turns generated',
+        metadata: { recordsProcessed: 0 },
+      };
+    }
+
+    const conversationsPath = getSessionConversationPath(session.sessionId);
+    await mkdir(dirname(conversationsPath), { recursive: true });
+
+    const existingPayloads = await readJSONL<ConversationPayloadRecord>(conversationsPath);
+
+    const { SessionStore } = await import('../../../../core/session/SessionStore.js');
+    const sessionStore = new SessionStore();
+    const sessionMetadata = await sessionStore.loadSession(session.sessionId);
+
+    let lastHistoryIndex = sessionMetadata?.sync?.conversations?.lastSyncedHistoryIndex ?? -1;
+    for (const payload of existingPayloads) {
+      if (payload.payload.conversationId !== conversationId) continue;
+      for (const idx of payload.historyIndices) {
+        lastHistoryIndex = Math.max(lastHistoryIndex, idx);
+      }
+    }
+
+    let payloadsWritten = 0;
+    let recordsProcessed = 0;
+    let lastSentinel: string | undefined;
+    let lastModel: string | undefined;
+
+    for (const turn of turns) {
+      if (turn.historyIndex <= lastHistoryIndex) {
+        continue;
+      }
+
+      const history = toHistory(turn);
+      if (history.length === 0) {
+        continue;
+      }
+
+      const sentinel = `${conversationId}@${turn.historyIndex}`;
+      const payloadRecord: ConversationPayloadRecord = {
+        payloadId: sentinel,
+        timestamp: Date.now(),
+        isTurnContinuation: false,
+        historyIndices: history.map((entry: any) => entry.history_index),
+        messageCount: history.length,
+        lastProcessedMessageUuid: sentinel,
+        payload: {
+          conversationId,
+          history,
+          assistantId: CODEMIE_ASSISTANT_ID,
+          llmModel: turn.assistant?.model,
+        },
+        status: CONVERSATION_SYNC_STATUS.PENDING,
+      };
+
+      await appendFile(conversationsPath, JSON.stringify(payloadRecord) + '\n');
+
+      payloadsWritten += 1;
+      recordsProcessed += history.length;
+      lastHistoryIndex = turn.historyIndex;
+      lastSentinel = sentinel;
+      lastModel = turn.assistant?.model ?? lastModel;
+    }
+
+    if (payloadsWritten === 0) {
+      return {
+        success: true,
+        message: 'No new conversation payloads',
+        metadata: { recordsProcessed: 0 },
+      };
+    }
+
+    logger.info(
+      `[${CONVERSATION_PROCESSOR_NAME}] Queued ${payloadsWritten} Copilot conversation payload` +
+      `${payloadsWritten === 1 ? '' : 's'} for session ${session.sessionId}`
+    );
+
     return {
       success: true,
-      metadata: { recordsProcessed: session.metrics?.userPrompts?.length ?? 0 },
+      message: `Queued ${payloadsWritten} Copilot conversation payload(s)`,
+      metadata: {
+        recordsProcessed,
+        payloadsWritten,
+        syncUpdates: {
+          conversations: {
+            lastSyncedMessageUuid: lastSentinel,
+            lastSyncedHistoryIndex: lastHistoryIndex,
+            conversationId,
+            totalMessagesSynced: recordsProcessed,
+            totalSyncAttempts: 1,
+            lastSyncAt: Date.now(),
+          },
+        },
+        llmModel: lastModel,
+      },
     };
   }
 }

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -40,8 +40,6 @@ export class AgentRegistry {
     AgentRegistry.registerPlugin(new PiPlugin());
     AgentRegistry.registerPlugin(new KimiPlugin());
     AgentRegistry.registerPlugin(new KimiAcpPlugin());
-    // Analytics-only: CodeMie never installs, launches, or manages Copilot — this
-    // registration exists so the analytics pipeline can reach its session adapter.
     AgentRegistry.registerPlugin(new CopilotCliPlugin());
 
     AgentRegistry.initialized = true;

--- a/src/cli/commands/analytics/__tests__/native-loader.test.ts
+++ b/src/cli/commands/analytics/__tests__/native-loader.test.ts
@@ -225,12 +225,11 @@ describe('loadNativeSessions — external session labeling', () => {
 
 /**
  * The ownership gate stops analytics silently counting UNMANAGED runs of an agent CodeMie
- * CAN manage (EPMCDME-13367). An analytics-only agent has no managed variant, so it can
- * never carry an ownership marker — applying the gate would tag every one of its sessions
- * `native-external`, which sources/sessions-source.ts filters out by default, dropping
- * 100% of them and making the integration a silent no-op.
+ * CAN manage (EPMCDME-13367). Copilot CLI used to be analytics-only and was exempt from
+ * that gate; now it is a managed CodeMie agent, so unowned native Copilot sessions follow
+ * the same native-external classification as other managed agents.
  */
-describe('loadNativeSessions — ownership gate exemption for analytics-only agents', () => {
+describe('loadNativeSessions — ownership gate for managed Copilot CLI', () => {
   const copilotParsed = {
     sessionId: 'cp1',
     agentName: 'GitHub Copilot CLI',
@@ -249,7 +248,7 @@ describe('loadNativeSessions — ownership gate exemption for analytics-only age
     metrics: { tools: {} },
   } as never;
 
-  /** Deps with NO ownership marker — the situation every Copilot session is in. */
+  /** Deps with NO ownership marker — an unmanaged/native run of a CodeMie-manageable agent. */
   function unownedDeps(agentName: string, sessionId: string, parsedSession: unknown): NativeLoaderDeps {
     return {
       trackedLogPaths: () => new Set<string>(),
@@ -272,19 +271,17 @@ describe('loadNativeSessions — ownership gate exemption for analytics-only age
     };
   }
 
-  it('tags an unowned copilot-cli session native-unmanaged, not native-external', async () => {
+  it('tags an unowned copilot-cli session native-external now that Copilot is managed', async () => {
     const results = await loadNativeSessions(undefined, unownedDeps('copilot-cli', 'cp1', copilotParsed));
 
     expect(results).toHaveLength(1);
-    // 'native-external' would mean sessions-source.ts filters it out by default, i.e. the
-    // feature ships displaying nothing. Plain 'native' would claim CodeMie launched it.
-    expect(results[0].startEvent!.data.provider).toBe('native-unmanaged');
+    expect(results[0].startEvent!.data.provider).toBe('native-external');
   });
 
-  it('keeps native-unmanaged out of the native-external filter', async () => {
-    // sessions-source.ts includes anything that is not exactly 'native-external'.
+  it('does not apply the analytics-only native-unmanaged exemption to copilot-cli', async () => {
     const results = await loadNativeSessions(undefined, unownedDeps('copilot-cli', 'cp1', copilotParsed));
-    expect(results[0].startEvent!.data.provider).not.toBe('native-external');
+
+    expect(results[0].startEvent!.data.provider).not.toBe('native-unmanaged');
   });
 
   it('still tags an unowned claude session as native-external', async () => {

--- a/src/cli/commands/analytics/native-loader.ts
+++ b/src/cli/commands/analytics/native-loader.ts
@@ -40,10 +40,9 @@ function isPiAgent(agentName: string): boolean {
  * Agents CodeMie only reads analytics for and never installs, launches, or manages.
  *
  * The ownership gate below exists to stop analytics silently counting UNMANAGED runs of an
- * agent CodeMie CAN manage (EPMCDME-13367). An analytics-only agent has no managed variant,
- * so it can never carry an ownership marker — applying the gate would tag 100% of its
- * sessions `native-external` and drop them from the default report, making the integration
- * a silent no-op.
+ * agent CodeMie CAN manage (EPMCDME-13367). A truly analytics-only agent has no managed
+ * variant, so it can never carry an ownership marker — applying the gate would tag 100% of
+ * its sessions `native-external` and drop them from the default report.
  */
 function isAnalyticsOnlyAgent(agentName: string): boolean {
   try {
@@ -745,12 +744,11 @@ export async function loadNativeSessions(
     }
     const raw = synthesizeRawSession(agentName, descriptor, parsed);
     if (raw.startEvent && !deps.hasOwnershipMarker(descriptor.filePath)) {
-      // Analytics-only agents can never carry an ownership marker, so tagging them
-      // 'native-external' would drop 100% of their sessions from the default report.
-      // They still are not CodeMie-managed though, so they get their own tag rather than
-      // the plain 'native' that means "CodeMie launched this" — otherwise the report
-      // cannot distinguish managed from unmanaged usage. 'native-unmanaged' passes the
-      // sessions-source filter (included by default) while staying honest about origin.
+      // Truly analytics-only agents can never carry an ownership marker, so tagging them
+      // 'native-external' would drop 100% of their sessions from the default report. They
+      // still are not CodeMie-managed, so they get their own tag rather than the plain
+      // 'native' that means "CodeMie launched this". Managed agents, including Copilot CLI,
+      // remain 'native-external' when their transcript lacks CodeMie ownership.
       raw.startEvent.data.provider = isAnalyticsOnlyAgent(agentName)
         ? 'native-unmanaged'
         : 'native-external';

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { AgentRegistry } from '@/agents/registry.js';
+import { getAgentInstallCommand, getAgentLauncherCommand, getUserFacingAgentName, resolveAgentAlias } from '@/agents/core/agent-aliases.js';
 import { AgentInstallationError, getErrorMessage } from '@/utils/errors.js';
 import { logger } from '@/utils/logger.js';
 import { restoreCliBinLink } from '@/utils/cli-bin.js';
@@ -46,7 +47,7 @@ export function createInstallCommand(): Command {
             const versionStr = version ? chalk.white(` (${version})`) : '';
 
             console.log(chalk.bold(`  ${agent.displayName}`) + versionStr);
-            console.log(`    Command: ${chalk.cyan(`codemie install ${agent.name}`)}`);
+            console.log(`    Command: ${chalk.cyan(getAgentInstallCommand(agent.name))}`);
             console.log(`    Status: ${status}`);
             console.log(`    ${chalk.white(agent.description)}`);
             console.log();
@@ -90,7 +91,8 @@ export function createInstallCommand(): Command {
         }
 
         // Try agent first
-        const agent = AgentRegistry.getAgent(name);
+        const canonicalName = resolveAgentAlias(name) || name;
+        const agent = AgentRegistry.getAgent(canonicalName);
 
         if (agent) {
           // Determine which version to install
@@ -220,7 +222,7 @@ export function createInstallCommand(): Command {
                 console.log();
                 console.log(chalk.yellow(`⚠️  Note: This version (${displayVersion}) is newer than the supported version (${compat.supportedVersion}).`));
                 console.log(chalk.yellow(`   You may encounter compatibility issues with the CodeMie backend.`));
-                console.log(chalk.yellow(`   To install the supported version, run:`), chalk.blueBright(`codemie install ${agent.name} --supported`));
+                console.log(chalk.yellow(`   To install the supported version, run:`), chalk.blueBright(`${getAgentInstallCommand(agent.name)} --supported`));
               }
             }
 
@@ -239,7 +241,7 @@ export function createInstallCommand(): Command {
               // Default hints for regular agents
               console.log(chalk.cyan('💡 Next steps:'));
               // Handle special case where agent name already includes 'codemie-' prefix
-              const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
+              const command = getAgentLauncherCommand(agent.name);
               console.log(chalk.white(`   Interactive mode:`), chalk.blueBright(command));
               console.log(chalk.white(`   Single task:`), chalk.blueBright(`${command} --task "your task"`));
               console.log();
@@ -320,7 +322,7 @@ export function createInstallCommand(): Command {
           console.log(chalk.cyan('💡 Available agents:'));
           const allAgents = AgentRegistry.getManageableAgents();
           for (const agent of allAgents) {
-            console.log(chalk.white(`   • ${agent.name}`));
+            console.log(chalk.white(`   • ${getUserFacingAgentName(agent.name)}`));
           }
           console.log();
           console.log(chalk.cyan('💡 Tip:') + ' Run ' + chalk.blueBright('codemie install') + ' to see all agents');

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { AgentRegistry } from '../../agents/registry.js';
+import { getUserFacingAgentName } from '../../agents/core/agent-aliases.js';
 import { logger } from '../../utils/logger.js';
 import chalk from 'chalk';
 
@@ -22,13 +23,14 @@ export function createListCommand(): Command {
           console.log(chalk.bold('\n📦 Available Agents:\n'));
 
           for (const agent of agents) {
+            const userFacingName = getUserFacingAgentName(agent.name);
             const installed = await agent.isInstalled();
             const status = installed ? chalk.green('✓ installed') : chalk.white('not installed');
             const version = installed ? await agent.getVersion() : null;
             const versionStr = version ? chalk.white(` (${version})`) : '';
 
             console.log(chalk.bold(`  ${agent.displayName}`) + versionStr);
-            console.log(`    Command: ${chalk.cyan(agent.name)}`);
+            console.log(`    Command: ${chalk.cyan(userFacingName)}`);
             console.log(`    Status: ${status}`);
             console.log(`    ${chalk.white(agent.description)}`);
             console.log();

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { AgentRegistry } from '@/agents/registry.js';
+import { getAgentUninstallCommand, getUserFacingAgentName, resolveAgentAlias } from '@/agents/core/agent-aliases.js';
 import { AgentNotFoundError, getErrorMessage } from '@/utils/errors.js';
 import {
   STATUSLINE_NAME,
@@ -54,7 +55,7 @@ export function createUninstallCommand(): Command {
               const versionStr = version ? chalk.white(` (${version})`) : '';
 
               console.log(chalk.bold(`  ${agent.displayName}`) + versionStr);
-              console.log(`    Command: ${chalk.cyan(`codemie uninstall ${agent.name}`)}`);
+              console.log(`    Command: ${chalk.cyan(getAgentUninstallCommand(agent.name))}`);
               console.log(`    ${chalk.white(agent.description)}`);
               console.log();
             }
@@ -80,7 +81,8 @@ export function createUninstallCommand(): Command {
         }
 
         // Try agent first
-        const agent = AgentRegistry.getAgent(name);
+        const canonicalName = resolveAgentAlias(name) || name;
+        const agent = AgentRegistry.getAgent(canonicalName);
 
         if (agent) {
           // Check if installed
@@ -151,7 +153,7 @@ export function createUninstallCommand(): Command {
           console.log(chalk.cyan('💡 Available agents and frameworks:'));
           const allAgents = AgentRegistry.getManageableAgents();
           for (const agent of allAgents) {
-            console.log(chalk.white(`   • ${agent.name}`));
+            console.log(chalk.white(`   • ${getUserFacingAgentName(agent.name)}`));
           }
 
           const { FrameworkRegistry } = await import('../../frameworks/index.js');

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { AgentRegistry } from '../../agents/registry.js';
+import { getAgentInstallCommand, getUserFacingAgentName, resolveAgentAlias } from '../../agents/core/agent-aliases.js';
 import { AgentAdapter } from '../../agents/core/types.js';
 import { AgentNotFoundError, AgentInstallationError, getErrorMessage } from '../../utils/errors.js';
 import { logger } from '../../utils/logger.js';
@@ -253,7 +254,8 @@ export function createUpdateCommand(): Command {
 
         // Case 1: Update specific agent
         if (name) {
-          const agent = AgentRegistry.getAgent(name);
+          const canonicalName = resolveAgentAlias(name) || name;
+          const agent = AgentRegistry.getAgent(canonicalName);
 
           if (!agent) {
             throw new AgentNotFoundError(name);
@@ -269,7 +271,7 @@ export function createUpdateCommand(): Command {
           const installed = await agent.isInstalled();
           if (!installed) {
             console.log(chalk.yellow(`${agent.displayName} is not installed`));
-            console.log(chalk.cyan(`💡 Install it with: codemie install ${agent.name}`));
+            console.log(chalk.cyan(`💡 Install it with: ${getAgentInstallCommand(agent.name)}`));
             return;
           }
 
@@ -405,7 +407,7 @@ export function createUpdateCommand(): Command {
           console.log(chalk.cyan('💡 Available agents:'));
           const allAgents = AgentRegistry.getManageableAgents();
           for (const agent of allAgents) {
-            console.log(chalk.white(`   • ${agent.name}`));
+            console.log(chalk.white(`   • ${getUserFacingAgentName(agent.name)}`));
           }
           console.log();
           console.log(chalk.cyan('💡 Tip:') + ' Run ' + chalk.blueBright('codemie update --check') + ' to see installed agents');

--- a/src/cli/first-time.ts
+++ b/src/cli/first-time.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { ConfigLoader } from '../utils/config.js';
 import { AgentRegistry, BUILTIN_AGENT_NAME } from '../agents/registry.js';
+import { getAgentInstallCommand, getAgentLauncherCommand } from '../agents/core/agent-aliases.js';
 import type { AgentAdapter } from '../agents/core/types.js';
 
 /**
@@ -92,13 +93,13 @@ export class FirstTimeExperience {
     const { external } = this.getAgents();
 
     external.forEach(agent => {
-      const installCmd = `codemie install ${agent.name}`.padEnd(30);
+      const installCmd = getAgentInstallCommand(agent.name).padEnd(30);
       console.log(chalk.white('  $ ') + chalk.green(installCmd) + chalk.white(`# Install ${agent.displayName}`));
     });
 
     external.forEach(agent => {
       // Handle special case where agent name already includes 'codemie-' prefix
-      const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
+      const command = getAgentLauncherCommand(agent.name);
       const runCmd = command.padEnd(30);
       console.log(chalk.white('  $ ') + chalk.green(runCmd) + chalk.white(`# Run ${agent.displayName}`));
     });
@@ -162,7 +163,7 @@ export class FirstTimeExperience {
       console.log(chalk.cyan('  codemie list') + chalk.white('              # List available agents'));
 
       external.forEach(agent => {
-        const paddedCommand = `codemie install ${agent.name}`.padEnd(28);
+        const paddedCommand = getAgentInstallCommand(agent.name).padEnd(28);
         console.log(chalk.cyan(`  ${paddedCommand}`) + chalk.white(`# Install ${agent.displayName}`));
       });
 
@@ -194,7 +195,7 @@ export class FirstTimeExperience {
     const allAgents = AgentRegistry.getManageableAgents();
     allAgents.forEach(agent => {
       // Handle special case where agent name already includes 'codemie-' prefix
-      const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
+      const command = getAgentLauncherCommand(agent.name);
       const paddedCommand = command.padEnd(28);
       console.log(chalk.cyan(`  ${paddedCommand}`) + chalk.white(`# Run ${agent.displayName}`));
     });
@@ -233,9 +234,9 @@ export class FirstTimeExperience {
       console.log(chalk.cyan('3. Install additional agents:'));
 
       external.forEach(agent => {
-        const installCmd = `codemie install ${agent.name}`.padEnd(35);
+        const installCmd = getAgentInstallCommand(agent.name).padEnd(35);
         // Handle special case where agent name already includes 'codemie-' prefix
-        const command = agent.name.startsWith('codemie-') ? agent.name : `codemie-${agent.name}`;
+        const command = getAgentLauncherCommand(agent.name);
         const runCmd = command.padEnd(35);
 
         console.log(chalk.white('   $ ') + chalk.green(installCmd) + chalk.white(`# Install ${agent.displayName}`));

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/copilot-encrypted-content-sanitizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/copilot-encrypted-content-sanitizer.plugin.test.ts
@@ -1,0 +1,127 @@
+import { IncomingMessage } from 'http';
+import { Readable } from 'stream';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CopilotEncryptedContentSanitizerPlugin } from '../copilot-encrypted-content-sanitizer.plugin.js';
+import type { PluginContext, ProxyInterceptor, UpstreamResponseTools } from '../types.js';
+import type { ProxyContext } from '../../proxy-types.js';
+import { logger } from '../../../../../../utils/logger.js';
+
+const AFFINITY_REJECTION = JSON.stringify({
+  error: {
+    code: 'invalid_encrypted_content',
+    message: 'Encrypted content could not be decrypted or parsed.',
+  },
+});
+
+function createPluginContext(clientType?: string): PluginContext {
+  return {
+    config: {
+      targetApiUrl: 'https://api.example.com',
+      provider: 'test',
+      sessionId: 'test-session',
+      clientType,
+    },
+    logger,
+  };
+}
+
+function createProxyContext(body: unknown, url = '/v1/responses'): ProxyContext {
+  const requestBody = Buffer.from(JSON.stringify(body), 'utf-8');
+  return {
+    requestId: 'test-req',
+    sessionId: 'test-session',
+    agentName: 'copilot-cli',
+    method: 'POST',
+    url,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': String(requestBody.length),
+    },
+    requestBody,
+    requestStartTime: Date.now(),
+    metadata: {},
+  };
+}
+
+function response(statusCode: number): IncomingMessage {
+  const stream = Readable.from([]) as IncomingMessage;
+  stream.statusCode = statusCode;
+  stream.statusMessage = statusCode >= 400 ? 'Bad Request' : 'OK';
+  stream.headers = { 'content-type': 'application/json' };
+  return stream;
+}
+
+function createTools(retryResponse = response(200)): UpstreamResponseTools & {
+  retry: ReturnType<typeof vi.fn<[Buffer], Promise<IncomingMessage>>>;
+  fromBuffer: ReturnType<typeof vi.fn<[IncomingMessage, Buffer], IncomingMessage>>;
+} {
+  return {
+    readBody: vi.fn(async () => Buffer.from(AFFINITY_REJECTION, 'utf-8')),
+    retry: vi.fn(async () => retryResponse),
+    fromBuffer: vi.fn((upstream) => upstream),
+  };
+}
+
+describe('CopilotEncryptedContentSanitizerPlugin', () => {
+  let plugin: CopilotEncryptedContentSanitizerPlugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new CopilotEncryptedContentSanitizerPlugin();
+  });
+
+  it('is scoped only to codemie-copilot', async () => {
+    await expect(plugin.createInterceptor(createPluginContext('codemie-copilot'))).resolves.toBeDefined();
+    await expect(plugin.createInterceptor(createPluginContext('codemie-codex')))
+      .rejects.toThrow('Plugin disabled for agent: codemie-codex');
+  });
+
+  it('retries Responses API encrypted-content failures once without replayed reasoning state', async () => {
+    const interceptor: ProxyInterceptor = await plugin.createInterceptor(createPluginContext('codemie-copilot'));
+    const context = createProxyContext({
+      model: 'gpt-5.5-2026-04-24',
+      include: ['reasoning.encrypted_content', 'usage'],
+      input: [
+        { type: 'message', role: 'user', content: 'hello' },
+        { type: 'reasoning', id: 'rs_1', encrypted_content: 'deployment-bound-state' },
+      ],
+    });
+    const tools = createTools();
+
+    const result = await interceptor.onUpstreamResponse!(context, response(400), tools);
+
+    expect(result.statusCode).toBe(200);
+    expect(tools.retry).toHaveBeenCalledTimes(1);
+    const retryBody = JSON.parse(tools.retry.mock.calls[0][0].toString('utf-8'));
+    expect(retryBody.include).toEqual(['usage']);
+    expect(retryBody.input).toEqual([{ type: 'message', role: 'user', content: 'hello' }]);
+    expect(context.headers['content-length']).toBe(String(context.requestBody!.length));
+  });
+
+  it('returns the original failure body when there is no encrypted-content marker', async () => {
+    const interceptor: ProxyInterceptor = await plugin.createInterceptor(createPluginContext('codemie-copilot'));
+    const context = createProxyContext({ input: [{ type: 'reasoning', encrypted_content: 'state' }] });
+    const tools = createTools();
+    tools.readBody.mockResolvedValue(Buffer.from('{"error":"different"}', 'utf-8'));
+
+    const original = response(400);
+    const result = await interceptor.onUpstreamResponse!(context, original, tools);
+
+    expect(result).toBe(original);
+    expect(tools.retry).not.toHaveBeenCalled();
+    expect(tools.fromBuffer).toHaveBeenCalledWith(original, Buffer.from('{"error":"different"}', 'utf-8'));
+  });
+
+  it('does not retry non-Responses traffic', async () => {
+    const interceptor: ProxyInterceptor = await plugin.createInterceptor(createPluginContext('codemie-copilot'));
+    const context = createProxyContext({ input: [{ type: 'reasoning', encrypted_content: 'state' }] }, '/v1/chat/completions');
+    const tools = createTools();
+
+    const original = response(400);
+    const result = await interceptor.onUpstreamResponse!(context, original, tools);
+
+    expect(result).toBe(original);
+    expect(tools.readBody).not.toHaveBeenCalled();
+    expect(tools.retry).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/claude-request-normalizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/claude-request-normalizer.plugin.ts
@@ -8,15 +8,20 @@
  * 1. Models that DO NOT support thinking (e.g. claude-haiku-4-5, 4-6):
  *    → strips the thinking field entirely to prevent API errors
  *
- * 2. Models that require adaptive thinking API (e.g. claude-opus-4-7+):
+ * 2. Models that require adaptive thinking API (e.g. claude-opus-4-7+, claude-sonnet-5):
  *    → "enabled"  → thinking: { type: "adaptive" } + output_config.effort
- *    → "disabled" → delete the thinking field
+ *    → "disabled" → either preserve or delete the field depending on model support
+ *
+ * 3. Models that deprecate sampling parameters (e.g. claude-sonnet-5):
+ *    → strips temperature / top_p / top_k entirely to prevent API errors
  *
  * Problem: Claude Code sends `thinking: { type: "enabled", budget_tokens: N }`.
  * - Haiku models reject thinking field with HTTP 400
  * - Opus 4-7+ requires adaptive thinking format with output_config.effort
+ * - Sonnet 5 rejects manual extended thinking and sampling parameters
  *
- * Scope: Enabled for codemie-claude (Claude Code via SSO proxy) and claude-desktop (Desktop 3P mode).
+ * Scope: Enabled for codemie-claude (Claude Code via SSO proxy), codemie-copilot
+ * (GitHub Copilot CLI via BYOK Anthropic shape), and claude-desktop (Desktop 3P mode).
  *
  * To add model support: update NO_THINKING_MODEL_PATTERNS or ADAPTIVE_THINKING_MODEL_PATTERNS.
  */
@@ -40,6 +45,7 @@ const NO_THINKING_MODEL_PATTERNS: RegExp[] = [
  */
 const ADAPTIVE_THINKING_MODEL_PATTERNS: RegExp[] = [
   /claude-opus-4-[7-9](?:[^0-9]|$)/i,  // claude-opus-4-7/8/9 and date-tagged variants (e.g. claude-opus-4-7-20250514); excludes claude-opus-4-70+
+  /claude-sonnet-5(?:[^0-9]|$)/i,      // claude-sonnet-5 and date-tagged variants
 ];
 
 function modelDisablesThinking(modelName: string): boolean {
@@ -48,6 +54,14 @@ function modelDisablesThinking(modelName: string): boolean {
 
 function modelRequiresAdaptiveThinking(modelName: string): boolean {
   return ADAPTIVE_THINKING_MODEL_PATTERNS.some(p => p.test(modelName));
+}
+
+function modelPreservesDisabledThinking(modelName: string): boolean {
+  return /claude-sonnet-5(?:[^0-9]|$)/i.test(modelName);
+}
+
+function modelDisablesSamplingParameters(modelName: string): boolean {
+  return /claude-sonnet-5(?:[^0-9]|$)/i.test(modelName);
 }
 
 /**
@@ -103,6 +117,13 @@ function handleAdaptiveThinkingTransform(body: any, model: string): boolean {
       `[claude-request-normalizer] Transformed thinking: "enabled" → "adaptive", effort="${effort}" for model: ${model}`
     );
   } else {
+    if (modelPreservesDisabledThinking(model)) {
+      logger.debug(
+        `[claude-request-normalizer] Preserved thinking.type="disabled" for model: ${model}`
+      );
+      return false;
+    }
+
     delete body.thinking;
     logger.debug(
       `[claude-request-normalizer] Removed unsupported thinking.type="disabled" for model: ${model}`
@@ -112,8 +133,31 @@ function handleAdaptiveThinkingTransform(body: any, model: string): boolean {
   return true;
 }
 
+function handleDeprecatedSamplingParams(body: any, model: string): boolean {
+  if (!modelDisablesSamplingParameters(model)) {
+    return false;
+  }
+
+  const stripped: string[] = [];
+  for (const key of ['temperature', 'top_p', 'top_k'] as const) {
+    if (key in body) {
+      delete body[key];
+      stripped.push(key);
+    }
+  }
+
+  if (stripped.length === 0) {
+    return false;
+  }
+
+  logger.debug(
+    `[claude-request-normalizer] Stripped deprecated sampling params for model ${model}: ${stripped.join(', ')}`
+  );
+  return true;
+}
+
 /** Agents whose Claude API requests need thinking normalization */
-const ALLOWED_AGENTS = ['codemie-claude', 'claude-desktop'];
+const ALLOWED_AGENTS = ['codemie-claude', 'codemie-copilot', 'claude-desktop'];
 
 export class ClaudeRequestNormalizerPlugin implements ProxyPlugin {
   id = '@codemie/proxy-claude-request-normalizer';
@@ -146,21 +190,22 @@ class ClaudeRequestNormalizerInterceptor implements ProxyInterceptor {
       const bodyStr = context.requestBody.toString('utf-8');
       const body = JSON.parse(bodyStr);
 
-      if (!body.thinking) {
-        return;
-      }
-
       const model = (typeof body.model === 'string' && body.model) || this.configModel || '';
       if (!model) {
         return;
       }
 
-      // Chain handlers: first match wins and modifies body
-      const modified =
-        handleNoThinkingModels(body, model) ||
-        handleAdaptiveThinkingTransform(body, model);
+      const modifiedBySampling = handleDeprecatedSamplingParams(body, model);
 
-      if (modified) {
+      let modifiedByThinking = false;
+      if (body.thinking) {
+        // Chain handlers: first match wins and modifies body
+        modifiedByThinking =
+          handleNoThinkingModels(body, model) ||
+          handleAdaptiveThinkingTransform(body, model);
+      }
+
+      if (modifiedBySampling || modifiedByThinking) {
         const newBodyStr = JSON.stringify(body);
         context.requestBody = Buffer.from(newBodyStr, 'utf-8');
         context.headers['content-length'] = String(context.requestBody.length);

--- a/src/providers/plugins/sso/proxy/plugins/copilot-encrypted-content-sanitizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/copilot-encrypted-content-sanitizer.plugin.ts
@@ -1,0 +1,172 @@
+/**
+ * Copilot Encrypted Content Sanitizer
+ * Priority: 16 (after generic request sanitizer, before header injection)
+ *
+ * GitHub Copilot CLI can replay Responses API reasoning items whose
+ * `encrypted_content` is deployment-bound. If LiteLLM/Azure rejects a replayed
+ * item before the response is streamed downstream, retry the same request once
+ * after stripping replayed reasoning state so the Copilot session can continue.
+ *
+ * Scope: codemie-copilot only. The Codex sanitizer intentionally keeps its
+ * original latch-only behavior in codex-encrypted-content-sanitizer.plugin.ts.
+ */
+
+import type { IncomingMessage } from 'http';
+import { ProxyPlugin, PluginContext, ProxyInterceptor, UpstreamResponseTools } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+
+const ALLOWED_AGENTS = ['codemie-copilot'];
+const ENCRYPTED_CONTENT_INCLUDE = 'reasoning.encrypted_content';
+const RESPONSES_PATH_SUFFIX = '/responses';
+const UNUSABLE_REASONING_STATE_MARKERS = [
+  'invalid_encrypted_content',
+  'Items are not persisted when',
+];
+
+interface SanitizeResult {
+  value: unknown;
+  modified: boolean;
+  removedCount: number;
+}
+
+export class CopilotEncryptedContentSanitizerPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-copilot-encrypted-content-sanitizer';
+  name = 'Copilot Encrypted Content Sanitizer';
+  version = '1.0.0';
+  priority = 16;
+
+  async createInterceptor(context: PluginContext): Promise<ProxyInterceptor> {
+    const clientType = context.config.clientType;
+    if (!clientType || !ALLOWED_AGENTS.includes(clientType)) {
+      throw new Error(`Plugin disabled for agent: ${clientType}`);
+    }
+
+    return new CopilotEncryptedContentSanitizerInterceptor(clientType);
+  }
+}
+
+class CopilotEncryptedContentSanitizerInterceptor implements ProxyInterceptor {
+  name = 'copilot-encrypted-content-sanitizer';
+
+  constructor(private readonly clientType: string) {}
+
+  async onUpstreamResponse(
+    context: ProxyContext,
+    response: IncomingMessage,
+    tools: UpstreamResponseTools
+  ): Promise<IncomingMessage> {
+    if (!this.isResponsesRequest(context) || (response.statusCode ?? 200) < 400) {
+      return response;
+    }
+
+    const responseBody = await tools.readBody(response);
+    const marker = UNUSABLE_REASONING_STATE_MARKERS.find(m => responseBody.includes(m));
+    if (!marker) {
+      return tools.fromBuffer(response, responseBody);
+    }
+
+    const sanitizedRequest = this.sanitizeRequestBody(context);
+    if (!sanitizedRequest) {
+      return tools.fromBuffer(response, responseBody);
+    }
+
+    logger.warn(
+      `[${this.name}] Upstream rejected replayed reasoning state for ${this.clientType} ("${marker}"). ` +
+      `Retrying once without reasoning state: ${sanitizedRequest.removedCount} item(s) removed.`
+    );
+
+    return tools.retry(sanitizedRequest.body);
+  }
+
+  private isResponsesRequest(context: ProxyContext): boolean {
+    const path = context.url.split('?')[0].replace(/\/+$/, '');
+    return path.endsWith(RESPONSES_PATH_SUFFIX);
+  }
+
+  private sanitizeRequestBody(context: ProxyContext): { body: Buffer; removedCount: number } | null {
+    if (!context.requestBody || !context.headers['content-type']?.includes('application/json')) {
+      return null;
+    }
+
+    try {
+      const body = JSON.parse(context.requestBody.toString('utf-8')) as unknown;
+      const sanitized = sanitizeValue(body);
+      if (!sanitized.modified) {
+        return null;
+      }
+
+      const newBody = Buffer.from(JSON.stringify(sanitized.value), 'utf-8');
+      context.requestBody = newBody;
+      context.headers['content-length'] = String(newBody.length);
+
+      return { body: newBody, removedCount: sanitized.removedCount };
+    } catch {
+      return null;
+    }
+  }
+}
+
+function sanitizeValue(value: unknown): SanitizeResult {
+  if (Array.isArray(value)) {
+    let modified = false;
+    let removedCount = 0;
+    const sanitizedItems: unknown[] = [];
+
+    for (const item of value) {
+      if (isReasoningInputItem(item)) {
+        modified = true;
+        removedCount++;
+        continue;
+      }
+
+      const sanitized = sanitizeValue(item);
+      modified = modified || sanitized.modified;
+      removedCount += sanitized.removedCount;
+      sanitizedItems.push(sanitized.value);
+    }
+
+    return { value: sanitizedItems, modified, removedCount };
+  }
+
+  if (!isPlainObject(value)) {
+    return { value, modified: false, removedCount: 0 };
+  }
+
+  let modified = false;
+  let removedCount = 0;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, childValue] of Object.entries(value)) {
+    if (key === 'encrypted_content') {
+      modified = true;
+      removedCount++;
+      continue;
+    }
+
+    if (key === 'include' && Array.isArray(childValue)) {
+      const filteredInclude = childValue.filter(item => item !== ENCRYPTED_CONTENT_INCLUDE);
+      if (filteredInclude.length !== childValue.length) {
+        modified = true;
+        removedCount += childValue.length - filteredInclude.length;
+      }
+      result[key] = filteredInclude;
+      continue;
+    }
+
+    const sanitized = sanitizeValue(childValue);
+    modified = modified || sanitized.modified;
+    removedCount += sanitized.removedCount;
+    result[key] = sanitized.value;
+  }
+
+  return { value: result, modified, removedCount };
+}
+
+function isReasoningInputItem(value: unknown): boolean {
+  return isPlainObject(value) && value.type === 'reasoning';
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
@@ -34,7 +34,7 @@ class HeaderInjectionInterceptor implements ProxyInterceptor {
 
     // LiteLLM can use these headers for Responses API session affinity when
     // its router is configured with session-aware pre-call checks.
-    if (this.context.config.clientType === 'codemie-codex') {
+    if (this.context.config.clientType === 'codemie-codex' || this.context.config.clientType === 'codemie-copilot') {
       context.headers['x-litellm-session-id'] = context.sessionId;
     }
 

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -16,6 +16,7 @@ import { RequestSanitizerPlugin } from './request-sanitizer.plugin.js';
 import { ClaudeRequestNormalizerPlugin } from './claude-request-normalizer.plugin.js';
 import { KimiRequestNormalizerPlugin } from './kimi-request-normalizer.plugin.js';
 import { CodexEncryptedContentSanitizerPlugin } from './codex-encrypted-content-sanitizer.plugin.js';
+import { CopilotEncryptedContentSanitizerPlugin } from './copilot-encrypted-content-sanitizer.plugin.js';
 import { VsCodeRequestNormalizerPlugin } from './vscode-request-normalizer.plugin.js';
 import { LoggingPlugin } from './logging.plugin.js';
 import { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
@@ -37,6 +38,7 @@ export function registerCorePlugins(): void {
   registry.register(new KimiRequestNormalizerPlugin()); // Priority 14 - caps Kimi output token requests for upstream limits
   registry.register(new RequestSanitizerPlugin()); // Priority 15 - strips unsupported reasoning params
   registry.register(new CodexEncryptedContentSanitizerPlugin()); // Priority 16 - forwards Responses reasoning state; strips it only after upstream rejects a replay
+  registry.register(new CopilotEncryptedContentSanitizerPlugin()); // Priority 16 - retries Copilot once after encrypted reasoning replay rejection
   registry.register(new VsCodeRequestNormalizerPlugin()); // Priority 17 - constrains VS Code user identifiers
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
@@ -58,6 +60,7 @@ export {
   ClaudeRequestNormalizerPlugin,
   KimiRequestNormalizerPlugin,
   CodexEncryptedContentSanitizerPlugin,
+  CopilotEncryptedContentSanitizerPlugin,
   VsCodeRequestNormalizerPlugin,
   LoggingPlugin,
 };

--- a/src/providers/plugins/sso/proxy/plugins/types.ts
+++ b/src/providers/plugins/sso/proxy/plugins/types.ts
@@ -81,6 +81,17 @@ export interface ProxyInterceptor {
   /** Called after response headers received (BEFORE body streaming) */
   onResponseHeaders?(context: ProxyContext, headers: IncomingHttpHeaders): Promise<void>;
 
+  /**
+   * Called after the upstream response is received but before headers/body are
+   * streamed downstream. Interceptors may return the original response or a
+   * replacement response (for example, after a sanitized one-shot retry).
+   */
+  onUpstreamResponse?(
+    context: ProxyContext,
+    response: IncomingMessage,
+    tools: UpstreamResponseTools
+  ): Promise<IncomingMessage>;
+
   /** Called during streaming (optional, for transform/inspection) */
   onResponseChunk?(context: ProxyContext, chunk: Buffer): Promise<Buffer | null>;
 
@@ -111,6 +122,12 @@ export interface ProxyInterceptor {
     res: ServerResponse,
     httpClient: ProxyHTTPClient
   ): Promise<boolean>;
+}
+
+export interface UpstreamResponseTools {
+  readBody(response: IncomingMessage): Promise<Buffer>;
+  retry(requestBody: Buffer): Promise<IncomingMessage>;
+  fromBuffer(response: IncomingMessage, body: Buffer): IncomingMessage;
 }
 
 /**

--- a/src/providers/plugins/sso/proxy/sso.proxy.ts
+++ b/src/providers/plugins/sso/proxy/sso.proxy.ts
@@ -25,6 +25,7 @@
 import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
 import { URL } from 'url';
+import { Readable } from 'stream';
 import { ProviderRegistry } from '../../../core/registry.js';
 import { AuthMethod } from '../../../core/types.js';
 import type { JWTCredentials, SSOCredentials } from '../../../core/types.js';
@@ -33,7 +34,7 @@ import { ProxyHTTPClient } from './proxy-http-client.js';
 import { ProxyConfig, ProxyContext } from './proxy-types.js';
 import { AuthenticationError, NetworkError, TimeoutError, normalizeError } from './proxy-errors.js';
 import { getPluginRegistry } from './plugins/registry.js';
-import { PluginContext, ProxyInterceptor, ResponseMetadata } from './plugins/types.js';
+import { PluginContext, ProxyInterceptor, ResponseMetadata, UpstreamResponseTools } from './plugins/types.js';
 import './plugins/index.js'; // Auto-register core plugins
 
 /**
@@ -319,12 +320,14 @@ export class CodeMieProxy {
       );
 
       logger.debug(`[proxy] Forwarding request to upstream for ${context.requestId}`);
-      const upstreamResponse = await this.httpClient.forward(targetUrl, {
+      let upstreamResponse = await this.httpClient.forward(targetUrl, {
         method: req.method!,
         headers: context.headers,
         body: context.requestBody || undefined
       });
       logger.debug(`[proxy] Received upstream response object for ${context.requestId}`);
+
+      upstreamResponse = await this.runUpstreamResponseHooks(context, upstreamResponse, targetUrl, req.method!);
 
       // 4. Run onResponseHeaders hooks (BEFORE streaming)
       await this.runHook('onResponseHeaders', interceptor =>
@@ -558,6 +561,52 @@ export class CodeMieProxy {
         // Continue with other interceptors
       }
     }
+  }
+
+  private async runUpstreamResponseHooks(
+    context: ProxyContext,
+    upstreamResponse: IncomingMessage,
+    targetUrl: URL,
+    method: string
+  ): Promise<IncomingMessage> {
+    let response = upstreamResponse;
+
+    const tools: UpstreamResponseTools = {
+      readBody: (incoming) => this.httpClient.readResponseBody(incoming),
+      retry: (requestBody) => this.httpClient.forward(targetUrl, {
+        method,
+        headers: context.headers,
+        body: requestBody,
+      }),
+      fromBuffer: (incoming, body) => this.createBufferedResponse(incoming, body),
+    };
+
+    for (const interceptor of this.interceptors) {
+      if (!interceptor.onUpstreamResponse) {
+        continue;
+      }
+
+      try {
+        response = await interceptor.onUpstreamResponse(context, response, tools);
+      } catch (error) {
+        logger.error(`[CodeMieProxy] Upstream response hook error in ${interceptor.name}:`, error);
+      }
+    }
+
+    return response;
+  }
+
+  private createBufferedResponse(source: IncomingMessage, body: Buffer): IncomingMessage {
+    const readable = Readable.from(body) as IncomingMessage;
+
+    readable.statusCode = source.statusCode;
+    readable.statusMessage = source.statusMessage;
+    readable.headers = {
+      ...source.headers,
+      'content-length': String(body.length),
+    };
+
+    return readable;
   }
 
   /**

--- a/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
@@ -31,7 +31,9 @@ describe('createSyncProcessor — Copilot folder mapping', () => {
   });
 
   afterEach(async () => {
-    // fs/promises rm with maxRetries handles Windows ENOTEMPTY when file handles are briefly held
+    // Close logger's write stream so Windows releases the lock on the log file before rm
+    const { logger } = await import('@/utils/logger.js');
+    await logger.close();
     await rm(tempHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     if (originalCodemieHome === undefined) {
       delete process.env.CODEMIE_HOME;

--- a/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const upsertConversation = vi.fn();
+
+vi.mock('../apiClient.js', () => ({
+  createApiClient: vi.fn(() => ({
+    upsertConversation,
+  })),
+}));
+
+describe('createSyncProcessor — Copilot folder mapping', () => {
+  let tempHome: string;
+  let originalCodemieHome: string | undefined;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'copilot-sync-folder-'));
+    originalCodemieHome = process.env.CODEMIE_HOME;
+    process.env.CODEMIE_HOME = tempHome;
+    upsertConversation.mockReset();
+    upsertConversation.mockResolvedValue({
+      success: true,
+      message: 'Conversation synced successfully',
+      conversation_id: 'cp-conv-1',
+      new_messages: 2,
+      total_messages: 2,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+    if (originalCodemieHome === undefined) {
+      delete process.env.CODEMIE_HOME;
+    } else {
+      process.env.CODEMIE_HOME = originalCodemieHome;
+    }
+  });
+
+  it('routes codemie-copilot sessions to the copilot-cli folder', async () => {
+    const { createSyncProcessor } = await import('../syncProcessor.js');
+
+    const sessionsDir = join(tempHome, 'sessions');
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(
+      join(sessionsDir, 'sess-copilot_conversation.jsonl'),
+      JSON.stringify({
+        payloadId: 'cp-conv-1@0',
+        timestamp: Date.now(),
+        isTurnContinuation: false,
+        historyIndices: [0, 0],
+        messageCount: 2,
+        lastProcessedMessageUuid: 'cp-conv-1@0',
+        payload: {
+          conversationId: 'cp-conv-1',
+          history: [
+            { role: 'User', message: 'hello', history_index: 0 },
+            { role: 'Assistant', message: 'world', history_index: 0 },
+          ],
+        },
+        status: 'pending',
+      }) + '\n'
+    );
+
+    const processor = createSyncProcessor();
+    const result = await processor.process(
+      { sessionId: 'sess-copilot', agentName: 'copilot-cli' } as never,
+      {
+        apiBaseUrl: 'http://localhost:4000',
+        cookies: '',
+        clientType: 'codemie-copilot',
+        version: '0.0.0',
+        dryRun: false,
+      } as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(upsertConversation).toHaveBeenCalledTimes(1);
+    expect(upsertConversation.mock.calls[0][3]).toBe('copilot-cli');
+  });
+});

--- a/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/__tests__/syncProcessor-folder-mapping.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -29,8 +30,9 @@ describe('createSyncProcessor — Copilot folder mapping', () => {
     });
   });
 
-  afterEach(() => {
-    rmSync(tempHome, { recursive: true, force: true });
+  afterEach(async () => {
+    // fs/promises rm with maxRetries handles Windows ENOTEMPTY when file handles are briefly held
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     if (originalCodemieHome === undefined) {
       delete process.env.CODEMIE_HOME;
     } else {

--- a/src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts
+++ b/src/providers/plugins/sso/session/processors/conversations/syncProcessor.ts
@@ -265,6 +265,9 @@ function resolveConversationFolder(clientType?: string, agentName?: string): str
   if (clientType === 'codemie-codex' || agentName === 'codex') {
     return 'codex';
   }
+  if (clientType === 'codemie-copilot' || agentName === 'copilot-cli') {
+    return 'copilot-cli';
+  }
   if (clientType === 'codemie-gemini' || agentName === 'gemini') {
     return 'gemini';
   }


### PR DESCRIPTION
# Summary

Implements `EPMCDME-13883` by turning GitHub Copilot CLI into a CodeMie-managed agent.

Users can now:
- install with `codemie install copilot`
- run with `codemie-copilot`
- uninstall with `codemie uninstall copilot`

The internal registry key remains `copilot-cli`.

# Changes

- promoted `copilot-cli` from analytics-only to a managed agent
- added `copilot` alias support and `codemie-copilot` launcher
- restricted managed Copilot support to AI/Run SSO and LiteLLM
- added model/version gating and blocked fallback to ambient GitHub auth
- wired Copilot into CodeMie session hooks and conversation sync
- mapped Copilot conversations to the `copilot-cli` folder instead of `Claude Desktop`
- added MCP / skills / custom agent / hook metadata for Copilot-supported locations
- fixed Copilot transcript parsing for the real event schema
- fixed Copilot conversation duration units
- added Copilot tool-call thoughts so tool activity appears in CodeMie UI
- updated README and agent docs

# Impact
Users can now run use codemie proxy to install/uninstall and run Copilot CLI.

Checklist
- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated
- [x] No breaking changes