### PR TITLE
fix(cli): normalize root base-url to code-assistant-api path

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -156,7 +156,7 @@ codemie-claude --jwt-token "<YOUR_JWT_TOKEN>" "analyze this code"
 
 **Without Any Prior Setup:**
 
-`--jwt-token` works standalone — no `codemie setup` needed. Just supply `--base-url` if the URL is not already configured:
+`--jwt-token` works standalone — no `codemie setup` needed. Just supply `--base-url` if the URL is not already configured. You can pass either the root CodeMie host or the `/code-assistant-api` path directly — the CLI appends `/code-assistant-api` automatically when it's missing:
 
 ```bash
 codemie-claude \
@@ -264,6 +264,17 @@ codemie doctor
 # Check token structure
 echo $CODEMIE_JWT_TOKEN | awk -F. '{print NF}'  # Should output: 3
 ```
+
+**`API Error: 405 Not Allowed`:**
+
+This means the request reached your CodeMie host but was rejected before hitting the Code Assistant API — usually because `--base-url` (or `CODEMIE_BASE_URL`) points at a path the API doesn't route requests through. The CLI automatically appends `/code-assistant-api` to a root URL, so both of these are equivalent and safe to use:
+
+```bash
+--base-url "https://<your-codemie-host>"
+--base-url "https://<your-codemie-host>/code-assistant-api"
+```
+
+If you still see a 405 after this, confirm the host itself (not just the path) is correct, and check `~/.codemie/logs/` for the exact upstream URL the CLI attempted.
 
 ## MCP Server Authentication
 

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -224,6 +224,18 @@ export class AgentCLI {
         config.authMethod = AuthMethod.JWT;
       }
 
+      // Normalize a user-supplied --base-url (or one loaded from a profile) so the
+      // required /code-assistant-api path is always present, even when the root
+      // CodeMie URL is passed. Idempotent: leaves an already-correct URL untouched.
+      // Keyed on provider (not authMethod) because stored SSO profiles never set
+      // authMethod — proxy routing there is decided by provider.authType === 'sso'.
+      if (
+        config.baseUrl
+        && (config.provider === ProviderName.AI_RUN_SSO || config.provider === ProviderName.BEARER_AUTH)
+      ) {
+        config.baseUrl = ensureApiBase(config.baseUrl);
+      }
+
       // Validate --reasoning-effort (catches both CLI flag and profile defaults)
       if (config.reasoningEffort) {
         const { normalizeReasoningEffort } = await import('./reasoning-effort.js');


### PR DESCRIPTION
## Summary
`--base-url` (or a stored SSO/JWT profile's `codeMieUrl`) only worked when pointed at the full `/code-assistant-api` path. Passing the root CodeMie host (e.g. `https://codemie.lab.epam.com`) caused `API Error: 405 Not Allowed`, because requests went to `/v1/messages` on the root domain instead of `/code-assistant-api/v1/messages`.

## Changes
- `src/agents/core/AgentCLI.ts`: normalize `config.baseUrl` with `ensureApiBase()` whenever `config.provider` is `ai-run-sso` or `bearer-auth` (the two CodeMie-native auth routes that proxy through the local CodeMie proxy). Idempotent — an already-correct `/code-assistant-api` URL is left untouched. Keyed on `provider` rather than `authMethod` because stored SSO profiles never populate `authMethod`.
- `docs/AUTHENTICATION.md`: document that root or `/code-assistant-api` URLs are both accepted, and add a troubleshooting entry for the `405 Not Allowed` error.

## Testing
- [x] Manual testing done — verified end-to-end against a live CodeMie SSO backend (`codemie.lab.epam.com`) with `CODEMIE_DEBUG=true`, confirming `/v1/messages` now resolves through `/code-assistant-api` and returns `200 OK` instead of `405`.
- [ ] Tests added/updated (none requested)

## Checklist
- [x] Code follows project standards
- [x] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`

Refs: [EPMCDME-14096](https://jiraeu.epam.com/browse/EPMCDME-14096)