### PR TITLE
refactor(agents): unify plugin implementations across 5 agent plugins

### DIFF
--- a/docs/superpowers/plans/2026-08-17-plugins-unification.md
+++ b/docs/superpowers/plans/2026-08-17-plugins-unification.md
@@ -1,0 +1,1027 @@
+# Plugins Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate four cross-plugin code duplications and add a `PLUGIN_GUIDE.md` that makes the plugin contract explicit.
+
+**Architecture:** Each task is independently mergeable. Tasks 1–3 touch the plugin layer only. Task 4 refactors the session-adapter layer by converting the `SessionAdapter` interface to an abstract class. Task 5 adds documentation only.
+
+**Tech Stack:** TypeScript, Node.js ≥ 20, Vitest, ES modules (`.js` extensions on all imports), `@/` alias for deep imports.
+
+## Global Constraints
+
+- ES modules only — all imports use `.js` extension, no `require()`.
+- `@/` alias for imports crossing more than two directory levels (e.g. `@/utils/paths.js`).
+- No `console.log` — use `logger.debug/info/warn/error`.
+- No `any` — use explicit types.
+- `interface` for external shapes; `class` for implementations.
+- No tests or git operations unless explicitly requested.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/agents/core/utils/args.ts` | **Create** — `getExplicitModelArg()` shared utility |
+| `src/agents/core/BaseAgentAdapter.ts` | **Modify** — update `getVersion()` and `isInstalled()` |
+| `src/agents/plugins/claude/claude.plugin.ts` | **Modify** — add `dataPaths.binary`, remove `getVersion()` and `isInstalled()` overrides |
+| `src/agents/plugins/codex/codex.plugin.ts` | **Modify** — remove `getExplicitModelArg()`, remove `getVersion()` override |
+| `src/agents/plugins/gemini/gemini.plugin.ts` | **Modify** — remove `getVersion()` override |
+| `src/agents/plugins/kimi/kimi.plugin.ts` | **Modify** — remove `getExplicitModelArg()`, remove `getVersion()` and `isInstalled()` overrides |
+| `src/agents/core/session/BaseSessionAdapter.ts` | **Modify** — add `AbstractBaseSessionAdapter` abstract class (interface stays) |
+| `src/agents/plugins/claude/claude.session.ts` | **Modify** — extend `AbstractBaseSessionAdapter`, remove processor boilerplate |
+| `src/agents/plugins/codex/codex.session.ts` | **Modify** — extend `AbstractBaseSessionAdapter`, remove processor boilerplate |
+| `src/agents/plugins/gemini/gemini.session-adapter.ts` | **Modify** — extend `AbstractBaseSessionAdapter`, remove processor boilerplate |
+| `src/agents/plugins/kimi/kimi.session.ts` | **Modify** — extend `AbstractBaseSessionAdapter`, remove processor boilerplate |
+| `src/agents/plugins/opencode/opencode.session.ts` | **Modify** — extend `AbstractBaseSessionAdapter`, remove processor boilerplate |
+| `src/agents/plugins/PLUGIN_GUIDE.md` | **Create** — plugin authoring guide |
+
+---
+
+## Task 1: Extract `getExplicitModelArg()` to a shared utility
+
+**Files:**
+- Create: `src/agents/core/utils/args.ts`
+- Modify: `src/agents/plugins/codex/codex.plugin.ts` (line 429, the module-private function)
+- Modify: `src/agents/plugins/kimi/kimi.plugin.ts` (line 384, the module-private function)
+
+**Interfaces:**
+- Produces: `getExplicitModelArg(args: string[]): string | undefined` — exported from `args.ts`
+- Consumed by: Task 1 only (Codex and Kimi plugins)
+
+- [ ] **Step 1: Create `src/agents/core/utils/args.ts`**
+
+```typescript
+/**
+ * Shared CLI argument utilities for agent plugins.
+ */
+
+/**
+ * Returns the value of the first -m / --model / --model=<val> argument found,
+ * or undefined if none is present.
+ */
+export function getExplicitModelArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-m' || arg === '--model') {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--model=')) {
+      return arg.slice('--model='.length);
+    }
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 2: Update `codex/codex.plugin.ts` — import from utils, delete local copy**
+
+At the top of the file, add the import:
+```typescript
+import { getExplicitModelArg } from '../../core/utils/args.js';
+```
+
+Delete the module-level private function at the bottom of the file (lines 429–441):
+```typescript
+// DELETE THIS ENTIRE FUNCTION:
+function getExplicitModelArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-m' || arg === '--model') {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--model=')) {
+      return arg.slice('--model='.length);
+    }
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 3: Update `kimi/kimi.plugin.ts` — import from utils, delete local copy**
+
+At the top of the file, add the import alongside the other imports:
+```typescript
+import { getExplicitModelArg } from '../../core/utils/args.js';
+```
+
+Delete the module-level private function at the bottom of the file (lines 384–396):
+```typescript
+// DELETE THIS ENTIRE FUNCTION:
+function getExplicitModelArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-m' || arg === '--model') {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--model=')) {
+      return arg.slice('--model='.length);
+    }
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+---
+
+## Task 2: Centralise `getVersion()` in `BaseAgentAdapter`
+
+This task updates the base `getVersion()` to try `dataPaths.binary` first (on non-win32) and parse semver from stdout — then removes the redundant overrides in Claude, Gemini, Kimi, and Codex. It also adds `dataPaths.binary` to Claude's metadata (Kimi already has it).
+
+**Files:**
+- Modify: `src/agents/core/BaseAgentAdapter.ts` — update `getVersion()` (~line 232)
+- Modify: `src/agents/plugins/claude/claude.plugin.ts` — add `dataPaths.binary`, delete `getVersion()` override
+- Modify: `src/agents/plugins/gemini/gemini.plugin.ts` — delete `getVersion()` override (~line 224)
+- Modify: `src/agents/plugins/kimi/kimi.plugin.ts` — delete `getVersion()` override (~line 292)
+- Modify: `src/agents/plugins/codex/codex.plugin.ts` — delete `getVersion()` override (~line 497)
+
+**Interfaces:**
+- Consumes: `exec` from `src/utils/processes.ts`, `resolveHomeDir` from `src/utils/paths.ts`
+- Produces: `BaseAgentAdapter.getVersion(): Promise<string | null>` — now tries binary path + parses semver
+
+- [ ] **Step 1: Update `BaseAgentAdapter.getVersion()` (~line 232)**
+
+Replace the current implementation:
+```typescript
+// BEFORE:
+async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  try {
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+```
+
+With:
+```typescript
+// AFTER:
+async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  const parseVersion = (stdout: string): string | null => {
+    const match = stdout.match(/(\d+\.\d+\.\d+)/);
+    return match ? match[1] : stdout.trim() || null;
+  };
+
+  // On non-win32, prefer the native binary path when configured.
+  // This handles agents installed outside PATH (e.g. ~/.local/bin/claude, ~/.kimi-code/bin/kimi).
+  if (process.platform !== 'win32' && this.metadata.dataPaths?.binary) {
+    const { resolveHomeDir } = await import('../../utils/paths.js');
+    const binaryPath = resolveHomeDir(this.metadata.dataPaths.binary);
+    try {
+      const result = await exec(binaryPath, ['--version']);
+      return parseVersion(result.stdout);
+    } catch {
+      // Binary path unavailable — fall through to cliCommand
+    }
+  }
+
+  try {
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+    return parseVersion(result.stdout);
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 2: Add `dataPaths.binary` to `ClaudePluginMetadata` in `claude/claude.plugin.ts`**
+
+The `dataPaths` object already exists in Claude's metadata. Add the `binary` field:
+```typescript
+// BEFORE:
+dataPaths: {
+  home: '.claude',
+},
+
+// AFTER:
+dataPaths: {
+  home: '.claude',
+  binary: '.local/bin/claude',
+},
+```
+
+- [ ] **Step 3: Delete `getVersion()` override from `claude/claude.plugin.ts` (~line 319)**
+
+Remove the entire method (lines 319–358 approximately):
+```typescript
+// DELETE THIS ENTIRE METHOD from ClaudePlugin class:
+async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  const { exec } = await import('../../../utils/processes.js');
+
+  // Try full path first on Unix systems (native installer places binary at ~/.local/bin/claude)
+  if (process.platform !== 'win32') {
+    const fullPath = resolveHomeDir('.local/bin/claude');
+    try {
+      const result = await exec(fullPath, ['--version']);
+
+      // Parse version from output like '2.1.23 (Claude Code)'
+      const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
+      if (versionMatch) {
+        return versionMatch[1];
+      }
+
+      return result.stdout.trim();
+    } catch {
+      // Full path check failed, fall through to PATH check
+    }
+  }
+
+  // Fall back to command in PATH (works for npm installations, Windows, etc.)
+  try {
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+
+    // Parse version from output like '2.1.23 (Claude Code)'
+    // Extract just the version number
+    const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
+    if (versionMatch) {
+      return versionMatch[1];
+    }
+
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+```
+
+After deletion, check whether the `resolveHomeDir` import is still needed (it is — used in `afterRun` and `isInstalled`). Leave it.
+
+- [ ] **Step 4: Delete `getVersion()` override from `gemini/gemini.plugin.ts` (~line 224)**
+
+Remove the entire method from `GeminiPlugin`:
+```typescript
+// DELETE THIS ENTIRE METHOD:
+async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  try {
+    const { exec } = await import('../../../utils/processes.js');
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+
+    // Parse semver from output (handles both '0.29.5' and '0.29.5 (Gemini CLI)' formats)
+    const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
+    if (versionMatch) {
+      return versionMatch[1];
+    }
+
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+```
+
+After deletion, remove the dynamic `import('../../../utils/processes.js')` if `exec` is no longer used anywhere in the file — but check first, since `exec` may be used elsewhere. In this file it is not used elsewhere, so if you imported it at the top level, check for remaining usages.
+
+- [ ] **Step 5: Delete `getVersion()` override from `kimi/kimi.plugin.ts` (~line 292)**
+
+Remove the entire method from `KimiPlugin`:
+```typescript
+// DELETE THIS ENTIRE METHOD:
+override async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  const parseVersion = (output: string): string | null => {
+    const match = output.match(/(\d+\.\d+\.\d+)/);
+    return match ? match[1] : output.trim() || null;
+  };
+
+  // Try native installer full path first on Unix systems
+  // (native installer places binary at ~/.kimi-code/bin/kimi)
+  if (process.platform !== 'win32') {
+    const nativePath = resolveHomeDir(KIMI_NATIVE_BINARY_PATH);
+    try {
+      const result = await exec(nativePath, ['--version']);
+      return parseVersion(result.stdout);
+    } catch {
+      // Native path check failed, fall through to legacy path
+    }
+
+    // Legacy / npm location
+    const fullPath = resolveHomeDir('.local/bin/kimi');
+    try {
+      const result = await exec(fullPath, ['--version']);
+      return parseVersion(result.stdout);
+    } catch {
+      // Full path check failed, fall through to PATH check
+    }
+  }
+
+  // Fall back to command in PATH
+  try {
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+    return parseVersion(result.stdout);
+  } catch {
+    return null;
+  }
+}
+```
+
+Note: Kimi's `dataPaths.binary` is already `'.kimi-code/bin/kimi'` (= `KIMI_NATIVE_BINARY_PATH`), so the base now covers the primary path. The legacy `'.local/bin/kimi'` fallback is intentionally dropped — it was an npm installation artefact superseded by the native installer.
+
+- [ ] **Step 6: Delete `getVersion()` override from `codex/codex.plugin.ts` (~line 497)**
+
+Remove the entire method from `CodexPlugin`:
+```typescript
+// DELETE THIS ENTIRE METHOD:
+async getVersion(): Promise<string | null> {
+  if (!this.metadata.cliCommand) {
+    return null;
+  }
+
+  try {
+    const result = await exec(this.metadata.cliCommand, ['--version']);
+    const output = result.stdout.trim();
+    const versionMatch = output.match(/(\d+\.\d+\.\d+)/);
+    return versionMatch ? versionMatch[1] : output;
+  } catch {
+    return null;
+  }
+}
+```
+
+Codex has no `dataPaths.binary` (it is npm-only), so the base falls straight to `exec(cliCommand)` — behaviour is identical.
+
+- [ ] **Step 7: Verify build passes**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+---
+
+## Task 3: Centralise `isInstalled()` in `BaseAgentAdapter`
+
+Updates the base `isInstalled()` to check `dataPaths.binary` first on non-win32, then removes the overrides in Claude and Kimi.
+
+**Files:**
+- Modify: `src/agents/core/BaseAgentAdapter.ts` — update `isInstalled()` (~line 215)
+- Modify: `src/agents/plugins/claude/claude.plugin.ts` — delete `isInstalled()` override
+- Modify: `src/agents/plugins/kimi/kimi.plugin.ts` — delete `isInstalled()` override
+
+**Interfaces:**
+- Consumes: `resolveHomeDir` from `src/utils/paths.ts`, `exec` and `commandExists` from `src/utils/processes.ts`
+- Produces: `BaseAgentAdapter.isInstalled(): Promise<boolean>` — tries binary path before PATH
+
+- [ ] **Step 1: Update `BaseAgentAdapter.isInstalled()` (~line 215)**
+
+Replace the current implementation:
+```typescript
+// BEFORE:
+async isInstalled(): Promise<boolean> {
+  if (!this.metadata.cliCommand) {
+    return true; // Built-in agents are always "installed"
+  }
+
+  try {
+    // Use commandExists which handles Windows (where) vs Unix (which)
+    const { commandExists } = await import('../../utils/processes.js');
+    return await commandExists(this.metadata.cliCommand);
+  } catch {
+    return false;
+  }
+}
+```
+
+With:
+```typescript
+// AFTER:
+async isInstalled(): Promise<boolean> {
+  if (!this.metadata.cliCommand) {
+    return true; // Built-in agents are always "installed"
+  }
+
+  // On non-win32, try the native binary path first when configured.
+  // Agents installed outside PATH (e.g. native installers) set dataPaths.binary.
+  if (process.platform !== 'win32' && this.metadata.dataPaths?.binary) {
+    const { resolveHomeDir } = await import('../../utils/paths.js');
+    const binaryPath = resolveHomeDir(this.metadata.dataPaths.binary);
+    try {
+      const result = await exec(binaryPath, ['--version']);
+      if (result.code === 0) {
+        return true;
+      }
+    } catch {
+      // Binary path unavailable — fall through to PATH check
+    }
+  }
+
+  try {
+    const { commandExists } = await import('../../utils/processes.js');
+    return await commandExists(this.metadata.cliCommand);
+  } catch {
+    return false;
+  }
+}
+```
+
+Note: `exec` is already imported at the top of `BaseAgentAdapter.ts` — no new import needed.
+
+- [ ] **Step 2: Delete `isInstalled()` override from `claude/claude.plugin.ts` (~line 382)**
+
+Remove the entire method from `ClaudePlugin`:
+```typescript
+// DELETE THIS ENTIRE METHOD:
+async isInstalled(): Promise<boolean> {
+  if (!this.metadata.cliCommand) {
+    return true; // Built-in agents are always "installed"
+  }
+
+  // On Unix systems, check full path first (native installer places binary at ~/.local/bin/claude)
+  // This avoids PATH issues where ~/.local/bin is not in user's PATH
+  if (process.platform !== 'win32') {
+    const fullPath = resolveHomeDir('.local/bin/claude');
+    try {
+      const { exec } = await import('../../../utils/processes.js');
+      const result = await exec(fullPath, ['--version']);
+      if (result.code === 0) {
+        return true;
+      }
+    } catch {
+      // Full path check failed, fall through to PATH check
+    }
+  }
+
+  // Fall back to base implementation (checks if command is in PATH)
+  return super.isInstalled();
+}
+```
+
+- [ ] **Step 3: Delete `isInstalled()` override from `kimi/kimi.plugin.ts` (~line 139)**
+
+Remove the entire method from `KimiPlugin`:
+```typescript
+// DELETE THIS ENTIRE METHOD:
+override async isInstalled(): Promise<boolean> {
+  if (!this.metadata.cliCommand) {
+    return true;
+  }
+
+  if (await commandExists(this.metadata.cliCommand)) {
+    return true;
+  }
+
+  if (process.platform !== 'win32') {
+    // Native installer location
+    const nativePath = resolveHomeDir(KIMI_NATIVE_BINARY_PATH);
+    try {
+      const result = await exec(nativePath, ['--version']);
+      if (result.code === 0) {
+        return true;
+      }
+    } catch {
+      // Native path check failed, fall through
+    }
+
+    // Legacy / npm location
+    const fullPath = resolveHomeDir('.local/bin/kimi');
+    try {
+      const result = await exec(fullPath, ['--version']);
+      return result.code === 0;
+    } catch {
+      // Full path check failed, fall through to PATH check already performed
+    }
+  }
+
+  logger.debug('[kimi-plugin] Kimi not installed. Install with:');
+  logger.debug('[kimi-plugin]   codemie install kimi');
+
+  return false;
+}
+```
+
+Note: after deletion, check whether `commandExists` is still imported in `kimi.plugin.ts`. It is used in `installNative` indirectly via the base — but the direct `commandExists` import in this file was only used by the deleted override. Remove it from the import line if it is no longer used:
+```typescript
+// BEFORE:
+import { commandExists, exec, getCommandPath } from '../../../utils/processes.js';
+
+// AFTER (if commandExists is unused elsewhere in the file):
+import { exec, getCommandPath } from '../../../utils/processes.js';
+```
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+---
+
+## Task 4: Convert `SessionAdapter` to an abstract class and update all five adapters
+
+Introduces `AbstractBaseSessionAdapter` — an abstract class that owns `processors`, `registerProcessor()`, and calls the abstract `initializeProcessors()` from its constructor. The existing `SessionAdapter` interface is kept for backward compatibility.
+
+**Files:**
+- Modify: `src/agents/core/session/BaseSessionAdapter.ts` — add `AbstractBaseSessionAdapter` abstract class
+- Modify: `src/agents/plugins/claude/claude.session.ts`
+- Modify: `src/agents/plugins/codex/codex.session.ts`
+- Modify: `src/agents/plugins/gemini/gemini.session-adapter.ts`
+- Modify: `src/agents/plugins/kimi/kimi.session.ts`
+- Modify: `src/agents/plugins/opencode/opencode.session.ts`
+
+**Interfaces:**
+- Produces: `AbstractBaseSessionAdapter` — exported from `BaseSessionAdapter.ts`
+- Consumed by: all five session adapter files
+
+- [ ] **Step 1: Add `AbstractBaseSessionAdapter` to `BaseSessionAdapter.ts`**
+
+Append the following to the bottom of `src/agents/core/session/BaseSessionAdapter.ts` (after the existing `SessionAdapter` interface — do not remove anything):
+
+```typescript
+import type { SessionProcessor } from './BaseProcessor.js';
+import type { AgentMetadata } from '../types.js';
+
+/**
+ * Abstract base class for all session adapters.
+ *
+ * Owns the processor registry so each adapter only overrides
+ * initializeProcessors() to register its own processors.
+ * The SessionAdapter interface is kept for external type consumers.
+ */
+export abstract class AbstractBaseSessionAdapter implements SessionAdapter {
+  protected readonly processors: SessionProcessor[] = [];
+
+  constructor(protected readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  /**
+   * Register agent-specific processors. Called once from the constructor.
+   * Subclasses call this.registerProcessor() for each processor they need.
+   */
+  protected abstract initializeProcessors(): void;
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+  }
+
+  abstract readonly agentName: string;
+  abstract parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession>;
+  abstract processSession(
+    filePath: string,
+    sessionId: string,
+    context: import('./BaseProcessor.js').ProcessingContext,
+  ): Promise<AggregatedResult>;
+}
+```
+
+- [ ] **Step 2: Update `claude/claude.session.ts`**
+
+Change the class declaration to extend `AbstractBaseSessionAdapter`:
+
+```typescript
+// ADD to imports:
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+
+// CHANGE class declaration:
+// BEFORE:
+export class ClaudeSessionAdapter implements SessionAdapter {
+  readonly agentName = 'claude';
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new MetricsProcessor());
+    logger.debug(`[claude-adapter] Registered processor: metrics`);
+    this.registerProcessor(new ConversationsProcessor());
+    logger.debug(`[claude-adapter] Registered processor: conversations`);
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+    logger.debug(`[claude-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
+  }
+
+// AFTER:
+export class ClaudeSessionAdapter extends AbstractBaseSessionAdapter {
+  readonly agentName = 'claude';
+
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  protected initializeProcessors(): void {
+    this.registerProcessor(new MetricsProcessor());
+    this.registerProcessor(new ConversationsProcessor());
+  }
+```
+
+Remove the `implements SessionAdapter` (now inherited from the base class), remove the `private processors: SessionProcessor[] = []` field, and remove the `registerProcessor()` method body — it now lives in the base.
+
+Also remove the `SessionAdapter` type import if it is no longer directly referenced in the file (the class no longer needs to name it in its declaration).
+
+- [ ] **Step 3: Update `codex/codex.session.ts`**
+
+```typescript
+// ADD to imports:
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+
+// CHANGE class declaration:
+// BEFORE:
+export class CodexSessionAdapter implements SessionAdapter {
+  ...
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new CodexMetricsProcessor());
+    this.registerProcessor(new CodexConversationsProcessor());
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+    ...
+  }
+
+// AFTER:
+export class CodexSessionAdapter extends AbstractBaseSessionAdapter {
+  ...
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  protected initializeProcessors(): void {
+    this.registerProcessor(new CodexMetricsProcessor());
+    this.registerProcessor(new CodexConversationsProcessor());
+  }
+```
+
+Remove `processors` field, `registerProcessor()` method, `implements SessionAdapter`.
+
+- [ ] **Step 4: Update `gemini/gemini.session-adapter.ts`**
+
+```typescript
+// ADD to imports:
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+
+// CHANGE class declaration:
+// BEFORE:
+export class GeminiSessionAdapter implements SessionAdapter {
+  ...
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new GeminiMetricsProcessor());
+    this.registerProcessor(new GeminiConversationsProcessor());
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+  }
+
+// AFTER:
+export class GeminiSessionAdapter extends AbstractBaseSessionAdapter {
+  ...
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  protected initializeProcessors(): void {
+    this.registerProcessor(new GeminiMetricsProcessor());
+    this.registerProcessor(new GeminiConversationsProcessor());
+  }
+```
+
+Remove `processors` field, `registerProcessor()` method, `implements SessionAdapter`.
+
+- [ ] **Step 5: Update `kimi/kimi.session.ts`**
+
+```typescript
+// ADD to imports:
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+
+// CHANGE class declaration:
+// BEFORE:
+export class KimiSessionAdapter implements SessionAdapter {
+  readonly agentName = 'kimi';
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new KimiMetricsProcessor());
+    logger.debug(`[kimi-adapter] Initialized ${this.processors.length} processors`);
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+    logger.debug(`[kimi-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
+  }
+
+// AFTER:
+export class KimiSessionAdapter extends AbstractBaseSessionAdapter {
+  readonly agentName = 'kimi';
+
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  protected initializeProcessors(): void {
+    this.registerProcessor(new KimiMetricsProcessor());
+  }
+```
+
+Remove `processors` field, `registerProcessor()` method, `implements SessionAdapter`.
+
+- [ ] **Step 6: Update `opencode/opencode.session.ts`**
+
+```typescript
+// ADD to imports:
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+
+// CHANGE class declaration:
+// BEFORE:
+export class OpenCodeSessionAdapter implements SessionAdapter {
+  ...
+  private processors: SessionProcessor[] = [];
+
+  constructor(private readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  private initializeProcessors(): void {
+    this.registerProcessor(new OpenCodeMetricsProcessor());
+    this.registerProcessor(new OpenCodeConversationsProcessor());
+  }
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+  }
+
+// AFTER:
+export class OpenCodeSessionAdapter extends AbstractBaseSessionAdapter {
+  ...
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
+  }
+
+  protected initializeProcessors(): void {
+    this.registerProcessor(new OpenCodeMetricsProcessor());
+    this.registerProcessor(new OpenCodeConversationsProcessor());
+  }
+```
+
+Remove `processors` field, `registerProcessor()` method, `implements SessionAdapter`.
+
+- [ ] **Step 7: Verify build passes**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+---
+
+## Task 5: Add `PLUGIN_GUIDE.md`
+
+**Files:**
+- Create: `src/agents/plugins/PLUGIN_GUIDE.md`
+
+- [ ] **Step 1: Create `src/agents/plugins/PLUGIN_GUIDE.md`**
+
+```markdown
+# Plugin Authoring Guide
+
+Reference for adding a new agent plugin to CodeMie. Read this before touching any plugin file.
+
+---
+
+## Checklist: minimum files for a new plugin
+
+| File | Required | Purpose |
+|---|---|---|
+| `<agent>/<agent>.plugin.ts` | Yes | Metadata object + class extending `BaseAgentAdapter` |
+| `<agent>/<agent>.session.ts` | Yes | Class extending `AbstractBaseSessionAdapter` |
+| `<agent>/session/processors/<agent>.metrics-processor.ts` | Yes | Extracts tool usage to `MetricDelta` JSONL |
+| `<agent>/session/processors/<agent>.conversations-processor.ts` | Yes | Extracts conversation history to JSONL |
+| `<agent>/__tests__/` | Yes | Plugin lifecycle smoke, `enrichArgs` unit, metrics processor fixture |
+
+---
+
+## What the base handles — do not override
+
+| Behaviour | How to enable |
+|---|---|
+| npm install / uninstall | Provided by `BaseAgentAdapter`; set `metadata.npmPackage` |
+| Version compatibility check | Provided by `BaseAgentAdapter`; set `supportedVersion` + `minimumSupportedVersion` |
+| Semver extraction from `--version` output | Set `metadata.dataPaths.binary` for native-path first; base parses `/(\d+\.\d+\.\d+)/` |
+| Native binary path check in `isInstalled` | Set `metadata.dataPaths.binary`; base tries it before PATH |
+| Processor registration + priority sort | Extend `AbstractBaseSessionAdapter`; call `this.registerProcessor()` in `initializeProcessors()` |
+
+---
+
+## When you MUST override
+
+- **Native installer** — override `install()` / `installVersion()` when the agent ships a shell-script installer (not npm). See `claude.plugin.ts` and `kimi.plugin.ts` for examples.
+- **Arg enrichment** — override `lifecycle.enrichArgs` for any transformation beyond the `flagMappings` config (subcommand injection, model provider config, etc.).
+- **Hook transformer** — implement `getHookTransformer()` when the agent emits non-standard hook event names. See `gemini.hook-transformer.ts` and `kimi.hook-transformer.ts`.
+
+---
+
+## Required metadata fields
+
+```typescript
+const metadata: AgentMetadata = {
+  name: 'myagent',                     // snake_case; used as CLI selector and log prefix
+  displayName: 'My Agent CLI',         // human-readable
+  description: 'One-sentence summary',
+  npmPackage: '@vendor/myagent',        // omit if native-only
+  cliCommand: 'myagent',
+
+  supportedVersion: '1.2.3',           // latest version tested with CodeMie backend
+  minimumSupportedVersion: '1.1.0',    // rule: ~10 patch/minor versions below supportedVersion
+
+  dataPaths: {
+    home: '.myagent',                  // required; e.g. ~/.myagent
+    binary: '.myagent/bin/myagent',    // set when agent installs outside PATH on Unix
+  },
+
+  envMapping: {
+    baseUrl: ['MYAGENT_BASE_URL'],     // CODEMIE_BASE_URL is written here
+    apiKey:  ['MYAGENT_API_KEY'],      // CODEMIE_API_KEY is written here
+    model:   ['MYAGENT_MODEL'],        // CODEMIE_MODEL is written here (empty [] = not forwarded)
+  },
+
+  supportedProviders: ['ai-run-sso', 'litellm', 'bearer-auth'],
+  ssoConfig: { enabled: true, clientType: 'codemie-myagent' },
+
+  extensionsConfig: {
+    project: '.myagent',
+    global: '~/.myagent',
+    skillsEntryFile: 'SKILL.md',
+  },
+};
+```
+
+---
+
+## Async rules
+
+### Dynamic imports in lifecycle hooks are intentional
+
+`await import(...)` inside `beforeRun` / `onSessionEnd` avoids circular dependencies at module load time. Do not hoist these to top-level `import` statements.
+
+```typescript
+// Correct — dynamic import inside lifecycle hook
+async beforeRun(env) {
+  const { processEvent } = await import('../../../cli/commands/hook.js');
+  await processEvent(...);
+  return env;
+}
+```
+
+### Fire-and-forget pattern
+
+Use `void promise.catch(err => logger.debug(...))` for non-blocking side effects (e.g. stale session reconciliation, incremental sync start). Never leave a bare `void` with no `.catch()`.
+
+```typescript
+// Correct
+void reconcileStale(env).catch(err => {
+  logger.debug(`[myagent] Reconciliation failed (non-blocking): ${err instanceof Error ? err.message : err}`);
+});
+
+// Wrong — unhandled rejection
+void reconcileStale(env);
+```
+
+### `isInstalled()` must be side-effect free
+
+No writes to stdout, no mutations, no file creation. `logger.debug()` (file-only) is acceptable. This method is called by `codemie doctor` and must not produce output or side effects.
+
+### `onSessionEnd` failures must never throw
+
+Metrics or sync failure must be caught and swallowed — an uncaught error here blocks agent process exit.
+
+```typescript
+async onSessionEnd(exitCode, env) {
+  try {
+    await processMetrics(env);
+  } catch (error) {
+    // Non-fatal — log and continue
+    logger.error(`[myagent] Metrics processing failed (non-blocking): ${error instanceof Error ? error.message : error}`);
+  }
+}
+```
+
+---
+
+## Testing rules
+
+### Unit-test `enrichArgs` and version parsing
+
+These are pure transformations. Test them without any I/O, mocks, or subprocess calls.
+
+```typescript
+// Example: enrichArgs test
+it('prepends --model when config.model is set', () => {
+  const result = metadata.lifecycle!.enrichArgs!(['--task', 'do something'], { model: 'my-model' } as AgentConfig);
+  expect(result[0]).toBe('--model');
+  expect(result[1]).toBe('my-model');
+});
+```
+
+### Use fixture JSONL/JSON files for processor tests
+
+Place fixtures in `__tests__/fixtures/`, named for the scenario they cover — not for dates or versions.
+
+```
+__tests__/fixtures/
+  session-empty.jsonl           # empty session — processor returns no deltas
+  session-single-turn.jsonl     # one user prompt, one assistant response with tool use
+  session-error-response.jsonl  # API error in assistant message
+```
+
+### Mock the filesystem, not the adapter
+
+Pass a fixture file path into the processor under test. Do not mock the session adapter.
+
+```typescript
+it('extracts one delta per assistant turn', async () => {
+  const processor = new MyAgentMetricsProcessor();
+  const session = await adapter.parseSessionFile(
+    path.join(__dirname, 'fixtures/session-single-turn.jsonl'),
+    'test-session-id',
+  );
+  const result = await processor.process(session, mockContext);
+  expect(result.success).toBe(true);
+});
+```
+
+### Don't test lifecycle hooks with real subprocesses
+
+Inject env vars and spy on `processEvent`. No end-to-end agent invocations in unit tests.
+
+```typescript
+it('calls processEvent with SessionStart on session start', async () => {
+  const processEvent = vi.fn().mockResolvedValue(undefined);
+  vi.doMock('../../../cli/commands/hook.js', () => ({ processEvent }));
+  await plugin.metadata.lifecycle!.onSessionStart!('test-id', { CODEMIE_URL: 'http://local' });
+  expect(processEvent).toHaveBeenCalledWith(
+    expect.objectContaining({ hook_event_name: 'SessionStart' }),
+    expect.any(Object),
+  );
+});
+```
+
+### One fixture per edge case
+
+Each fixture covers exactly one scenario. Prefer fewer, named fixtures over large catch-all files.
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+```

--- a/docs/superpowers/specs/2026-08-17-plugins-unification-design.md
+++ b/docs/superpowers/specs/2026-08-17-plugins-unification-design.md
@@ -1,0 +1,171 @@
+# Plugins Unification — Design Spec
+
+**Date:** 2026-08-17  
+**Scope:** `src/agents/plugins/` — Claude, Codex, Gemini, Kimi, OpenCode plugins
+
+---
+
+## Problem
+
+The five agent plugins share structural and behavioural patterns that were copy-pasted rather than shared. This means:
+- Bugs fixed in one plugin stay broken in others.
+- Adding a sixth plugin (e.g. Cursor, Windsurf) requires knowing which boilerplate to copy and which to omit.
+- There is no single place to learn the rules.
+
+---
+
+## Goals
+
+1. Eliminate the four most impactful duplications (see below).
+2. Introduce a `PLUGIN_GUIDE.md` that makes the contract explicit for future plugin authors.
+
+Non-goals: unifying agent-specific session parsing logic (tool formats differ too much), or touching the providers layer.
+
+---
+
+## Unification 1 — Extract `getExplicitModelArg()` utility
+
+**Affected files:** `codex/codex.plugin.ts:429`, `kimi/kimi.plugin.ts:384`
+
+Both files define an identical module-private function that scans CLI args for `-m`/`--model`/`--model=<val>`.
+
+**Design:**
+- Create `src/agents/core/utils/args.ts` exporting `getExplicitModelArg(args: string[]): string | undefined`.
+- Delete the two private copies; import from the shared utility.
+- No behaviour change.
+
+---
+
+## Unification 2 — Abstract `BaseSessionAdapter` class
+
+**Affected files:** all five `*.session.ts` / `*session-adapter.ts` files
+
+`BaseSessionAdapter` is currently only an interface. All five adapters independently declare:
+```ts
+private processors: SessionProcessor[] = [];
+private initializeProcessors(): void { ... }
+registerProcessor(processor: SessionProcessor): void {
+  this.processors.push(processor);
+  this.processors.sort((a, b) => a.priority - b.priority);
+}
+```
+
+**Design:**
+- Convert `BaseSessionAdapter` to an abstract class (keep the interface type for external consumers via a re-export or type alias).
+- The abstract class owns `processors`, `registerProcessor()`, and the sort.
+- Declare `protected abstract initializeProcessors(): void` — each adapter overrides to register its own processors.
+- All five adapters extend the class instead of implementing the interface.
+
+**Estimated reduction:** ~15 lines × 5 adapters = 75 lines eliminated.
+
+---
+
+## Unification 3 — Centralise semver parsing in `BaseAgentAdapter.getVersion()`
+
+**Affected files:** Claude (`:319`), Gemini (`:224`), Kimi (`:292`), Codex (`:497`), OpenCode (bug: returns raw stdout)
+
+All four overriding plugins extract a semver from stdout using `/(\d+\.\d+\.\d+)/`. The base currently returns raw stdout. OpenCode does not override and silently returns raw stdout — a latent compatibility bug.
+
+**Design:**
+- Add an optional `dataPaths.binary` field to `AgentMetadata` (Kimi already has it; Claude will add `'.local/bin/claude'`).
+- Update `BaseAgentAdapter.getVersion()` to:
+  1. On non-win32, if `metadata.dataPaths.binary` is set, try `resolveHomeDir(dataPaths.binary)` first.
+  2. Fall back to `exec(cliCommand)`.
+  3. Extract semver via `/(\d+\.\d+\.\d+)/` from stdout; return raw string if no match.
+- Remove the four plugin overrides (Claude, Gemini, Kimi, Codex).
+- OpenCode gains correct semver parsing for free.
+
+---
+
+## Unification 4 — Centralise native binary `isInstalled()` in base
+
+**Affected files:** `claude/claude.plugin.ts:382`, `kimi/kimi.plugin.ts:139`
+
+Both follow the same pattern: on non-win32, try the native binary full path first; fall back to `commandExists(cliCommand)`.
+
+**Design:**
+- Reuse `dataPaths.binary` from Unification 3 (Claude adds it; Kimi already has it).
+- Update `BaseAgentAdapter.isInstalled()` to check `resolveHomeDir(dataPaths.binary)` before PATH lookup.
+- Remove both plugin overrides.
+
+---
+
+## Addition — `PLUGIN_GUIDE.md`
+
+**Location:** `src/agents/plugins/PLUGIN_GUIDE.md`
+
+### Checklist for a new plugin
+
+Every new agent plugin requires:
+- `<agent>.plugin.ts` — metadata object + class extending `BaseAgentAdapter`
+- `<agent>.session.ts` — class extending `BaseSessionAdapter`
+- `session/processors/<agent>.metrics-processor.ts`
+- `session/processors/<agent>.conversations-processor.ts`
+- `__tests__/` with at least: plugin lifecycle smoke test, enrichArgs unit test, metrics processor fixture test
+
+### What the base handles (do not override)
+
+| Behaviour | Mechanism |
+|---|---|
+| npm install / uninstall | `BaseAgentAdapter.install()` / `uninstall()` |
+| Version compatibility check | `BaseAgentAdapter.checkVersionCompatibility()` |
+| Native binary path check (`isInstalled`) | Set `dataPaths.binary` in metadata |
+| Semver parsing (`getVersion`) | Set `dataPaths.binary` in metadata |
+| Processor registration and priority sort | Extend `BaseSessionAdapter` |
+
+### When you MUST override
+
+- **Native installer** — override `install()` / `installVersion()` if the agent uses a shell script installer rather than npm (e.g. Claude, Kimi).
+- **Custom arg enrichment** — override `lifecycle.enrichArgs` for any arg transformation beyond flag mapping.
+- **Hook transformer** — implement `getHookTransformer()` if the agent emits non-standard hook event names (e.g. Gemini's `AfterAgent` → `Stop`).
+
+### Metadata required fields
+
+```ts
+{
+  name,           // snake_case, used as CLI selector
+  displayName,    // human-readable
+  description,
+  cliCommand,     // binary name
+  supportedVersion,
+  minimumSupportedVersion,  // rule: 10 patch/minor versions below supportedVersion
+  dataPaths: { home },      // e.g. '.claude'
+  envMapping: { baseUrl, apiKey, model },
+  supportedProviders,
+  ssoConfig,
+  extensionsConfig: { project, global, skillsEntryFile },
+}
+```
+
+### Async rules
+
+- **Dynamic imports in lifecycle hooks are intentional.** `await import(...)` inside `beforeRun` / `onSessionEnd` avoids circular dependencies at module load time. Do not hoist to top-level imports.
+- **Fire-and-forget pattern:** use `void promise.catch(err => logger.debug(...))` for non-blocking side effects (e.g. stale session reconciliation). Never leave a bare `void` with no `.catch()`.
+- **`isInstalled()` must be side-effect free.** No stdout writes, no mutations, no logging to the console. Logging to `logger.debug` (file-only) is acceptable.
+- **`onSessionEnd` failures must never throw.** Metrics or sync failure must be caught and swallowed — an uncaught error here blocks agent exit.
+
+### Testing rules
+
+- **Unit-test `enrichArgs` and version parsing** — these are pure transformations; test without any I/O or mocks.
+- **Use fixture JSONL/JSON files for processor tests** — place fixtures in `__tests__/fixtures/`, named for the scenario (`history-multi-clear.jsonl`, not `fixture-2026-05.jsonl`).
+- **Mock the filesystem, not the adapter** — pass a fixture file path to the processor; don't mock the session adapter itself.
+- **Don't test lifecycle hooks with real subprocesses** — inject env vars and spy on `processEvent`; no end-to-end agent invocations in unit tests.
+- **One fixture per edge case** — each fixture covers exactly one scenario (empty session, multi-turn, error recovery, etc.).
+
+---
+
+## Summary of files changed
+
+| File | Change |
+|---|---|
+| `src/agents/core/utils/args.ts` | **new** — `getExplicitModelArg()` |
+| `src/agents/core/session/BaseSessionAdapter.ts` | interface → abstract class |
+| `src/agents/core/BaseAgentAdapter.ts` | update `getVersion()`, `isInstalled()` |
+| `src/agents/core/types.ts` | add optional `dataPaths.binary` |
+| `claude/claude.plugin.ts` | add `dataPaths.binary`, remove `getVersion()` + `isInstalled()` overrides |
+| `codex/codex.plugin.ts` | remove `getExplicitModelArg()`, remove `getVersion()` override |
+| `gemini/gemini.plugin.ts` | remove `getVersion()` override |
+| `kimi/kimi.plugin.ts` | remove `getExplicitModelArg()`, `getVersion()`, `isInstalled()` overrides |
+| `opencode/opencode.plugin.ts` | no change needed (gains fix for free) |
+| All five `*.session.ts` | extend `BaseSessionAdapter` class, remove processor boilerplate |
+| `src/agents/plugins/PLUGIN_GUIDE.md` | **new** |

--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -217,8 +217,33 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       return true; // Built-in agents are always "installed"
     }
 
+    if (process.platform !== 'win32') {
+      if (this.metadata.dataPaths?.binary) {
+        const binaryPath = resolveHomeDir(this.metadata.dataPaths.binary);
+        try {
+          const result = await exec(binaryPath, ['--version']);
+          if (result.code === 0) {
+            return true;
+          }
+        } catch {
+          // Binary path unavailable — try alt
+        }
+      }
+
+      if (this.metadata.dataPaths?.binaryAlt) {
+        const altPath = resolveHomeDir(this.metadata.dataPaths.binaryAlt);
+        try {
+          const result = await exec(altPath, ['--version']);
+          if (result.code === 0) {
+            return true;
+          }
+        } catch {
+          // Alt path unavailable — fall through to PATH check
+        }
+      }
+    }
+
     try {
-      // Use commandExists which handles Windows (where) vs Unix (which)
       const { commandExists } = await import('../../utils/processes.js');
       return await commandExists(this.metadata.cliCommand);
     } catch {
@@ -234,9 +259,36 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       return null;
     }
 
+    const parseVersion = (stdout: string): string | null => {
+      const match = stdout.match(/(\d+\.\d+\.\d+)/);
+      return match ? match[1] : stdout.trim() || null;
+    };
+
+    if (process.platform !== 'win32') {
+      if (this.metadata.dataPaths?.binary) {
+        const binaryPath = resolveHomeDir(this.metadata.dataPaths.binary);
+        try {
+          const result = await exec(binaryPath, ['--version']);
+          return parseVersion(result.stdout);
+        } catch {
+          // Binary path unavailable — try alt
+        }
+      }
+
+      if (this.metadata.dataPaths?.binaryAlt) {
+        const altPath = resolveHomeDir(this.metadata.dataPaths.binaryAlt);
+        try {
+          const result = await exec(altPath, ['--version']);
+          return parseVersion(result.stdout);
+        } catch {
+          // Alt path unavailable — fall through to cliCommand
+        }
+      }
+    }
+
     try {
       const result = await exec(this.metadata.cliCommand, ['--version']);
-      return result.stdout.trim();
+      return parseVersion(result.stdout);
     } catch {
       return null;
     }

--- a/src/agents/core/session/BaseSessionAdapter.ts
+++ b/src/agents/core/session/BaseSessionAdapter.ts
@@ -7,6 +7,8 @@
  */
 
 import type { SessionDiscoveryOptions, SessionDescriptor } from './discovery-types.js';
+import type { SessionProcessor, ProcessingContext } from './BaseProcessor.js';
+import type { AgentMetadata } from '../types.js';
 
 // Re-export for convenience
 export type { SessionDiscoveryOptions, SessionDescriptor };
@@ -146,5 +148,39 @@ export interface SessionAdapter {
     filePath: string,
     sessionId: string,
     context: import('./BaseProcessor.js').ProcessingContext
+  ): Promise<AggregatedResult>;
+}
+
+/**
+ * Abstract base class for all session adapters.
+ *
+ * Owns the processor registry so each adapter only overrides
+ * initializeProcessors() to register its own processors.
+ * The SessionAdapter interface is kept for external type consumers.
+ */
+export abstract class AbstractBaseSessionAdapter implements SessionAdapter {
+  protected readonly processors: SessionProcessor[] = [];
+
+  constructor(protected readonly metadata: AgentMetadata) {
+    this.initializeProcessors();
+  }
+
+  /**
+   * Register agent-specific processors. Called once from the constructor.
+   * Subclasses call this.registerProcessor() for each processor they need.
+   */
+  protected abstract initializeProcessors(): void;
+
+  registerProcessor(processor: SessionProcessor): void {
+    this.processors.push(processor);
+    this.processors.sort((a, b) => a.priority - b.priority);
+  }
+
+  abstract readonly agentName: string;
+  abstract parseSessionFile(filePath: string, sessionId: string): Promise<ParsedSession>;
+  abstract processSession(
+    filePath: string,
+    sessionId: string,
+    context: ProcessingContext,
   ): Promise<AggregatedResult>;
 }

--- a/src/agents/core/types.ts
+++ b/src/agents/core/types.ts
@@ -310,9 +310,10 @@ export interface AgentMetadata {
 
   // === Data Paths ===
   dataPaths?: {
-    home: string;        // Main directory: '~/.gemini', '~/.claude'
-    settings?: string;   // Settings file path (relative to home, agent-specific)
-    binary?: string;     // Optional native binary path relative to home: '.kimi-code/bin/kimi'
+    home: string;           // Main directory: '~/.gemini', '~/.claude'
+    settings?: string;      // Settings file path (relative to home, agent-specific)
+    binary?: string;        // Primary native binary path relative to home: '.kimi-code/bin/kimi'
+    binaryAlt?: string;     // Secondary native binary path (e.g. legacy npm install location)
   };
 
   // === Analytics Support ===

--- a/src/agents/core/utils/args.ts
+++ b/src/agents/core/utils/args.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared CLI argument utilities for agent plugins.
+ */
+
+/**
+ * Returns the value of the first -m / --model / --model=<val> argument found,
+ * or undefined if none is present.
+ */
+export function getExplicitModelArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-m' || arg === '--model') {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--model=')) {
+      return arg.slice('--model='.length);
+    }
+  }
+  return undefined;
+}

--- a/src/agents/plugins/PLUGIN_GUIDE.md
+++ b/src/agents/plugins/PLUGIN_GUIDE.md
@@ -1,0 +1,186 @@
+# Plugin Authoring Guide
+
+Reference for adding a new agent plugin to CodeMie. Read this before touching any plugin file.
+
+---
+
+## Checklist: minimum files for a new plugin
+
+| File | Required | Purpose |
+|---|---|---|
+| `<agent>/<agent>.plugin.ts` | Yes | Metadata object + class extending `BaseAgentAdapter` |
+| `<agent>/<agent>.session.ts` | Yes | Class extending `AbstractBaseSessionAdapter` |
+| `<agent>/session/processors/<agent>.metrics-processor.ts` | Yes | Extracts tool usage to `MetricDelta` JSONL |
+| `<agent>/session/processors/<agent>.conversations-processor.ts` | Yes | Extracts conversation history to JSONL |
+| `<agent>/__tests__/` | Yes | Plugin lifecycle smoke, `enrichArgs` unit, metrics processor fixture |
+
+---
+
+## What the base handles — do not override
+
+| Behaviour | How to enable |
+|---|---|
+| npm install / uninstall | Provided by `BaseAgentAdapter`; set `metadata.npmPackage` |
+| Version compatibility check | Provided by `BaseAgentAdapter`; set `supportedVersion` + `minimumSupportedVersion` |
+| Semver extraction from `--version` output | Set `metadata.dataPaths.binary` for native-path first; base parses `/(\d+\.\d+\.\d+)/` |
+| Native binary path check in `isInstalled` | Set `metadata.dataPaths.binary`; base tries it before PATH |
+| Processor registration + priority sort | Extend `AbstractBaseSessionAdapter`; call `this.registerProcessor()` in `initializeProcessors()` |
+
+---
+
+## When you MUST override
+
+- **Native installer** — override `install()` / `installVersion()` when the agent ships a shell-script installer (not npm). See `claude.plugin.ts` and `kimi.plugin.ts` for examples.
+- **Arg enrichment** — override `lifecycle.enrichArgs` for any transformation beyond the `flagMappings` config (subcommand injection, model provider config, etc.).
+- **Hook transformer** — implement `getHookTransformer()` when the agent emits non-standard hook event names. See `gemini.hook-transformer.ts` and `kimi.hook-transformer.ts`.
+
+---
+
+## Required metadata fields
+
+```typescript
+const metadata: AgentMetadata = {
+  name: 'myagent',                     // snake_case; used as CLI selector and log prefix
+  displayName: 'My Agent CLI',         // human-readable
+  description: 'One-sentence summary',
+  npmPackage: '@vendor/myagent',        // omit if native-only
+  cliCommand: 'myagent',
+
+  supportedVersion: '1.2.3',           // latest version tested with CodeMie backend
+  minimumSupportedVersion: '1.1.0',    // rule: ~10 patch/minor versions below supportedVersion
+
+  dataPaths: {
+    home: '.myagent',                  // required; e.g. ~/.myagent
+    binary: '.myagent/bin/myagent',    // set when agent installs outside PATH on Unix
+  },
+
+  envMapping: {
+    baseUrl: ['MYAGENT_BASE_URL'],     // CODEMIE_BASE_URL is written here
+    apiKey:  ['MYAGENT_API_KEY'],      // CODEMIE_API_KEY is written here
+    model:   ['MYAGENT_MODEL'],        // CODEMIE_MODEL is written here (empty [] = not forwarded)
+  },
+
+  supportedProviders: ['ai-run-sso', 'litellm', 'bearer-auth'],
+  ssoConfig: { enabled: true, clientType: 'codemie-myagent' },
+
+  extensionsConfig: {
+    project: '.myagent',
+    global: '~/.myagent',
+    skillsEntryFile: 'SKILL.md',
+  },
+};
+```
+
+---
+
+## Async rules
+
+### Dynamic imports in lifecycle hooks are intentional
+
+`await import(...)` inside `beforeRun` / `onSessionEnd` avoids circular dependencies at module load time. Do not hoist these to top-level `import` statements.
+
+```typescript
+// Correct — dynamic import inside lifecycle hook
+async beforeRun(env) {
+  const { processEvent } = await import('../../../cli/commands/hook.js');
+  await processEvent(...);
+  return env;
+}
+```
+
+### Fire-and-forget pattern
+
+Use `void promise.catch(err => logger.debug(...))` for non-blocking side effects (e.g. stale session reconciliation, incremental sync start). Never leave a bare `void` with no `.catch()`.
+
+```typescript
+// Correct
+void reconcileStale(env).catch(err => {
+  logger.debug(`[myagent] Reconciliation failed (non-blocking): ${err instanceof Error ? err.message : err}`);
+});
+
+// Wrong — unhandled rejection
+void reconcileStale(env);
+```
+
+### `isInstalled()` must be side-effect free
+
+No writes to stdout, no mutations, no file creation. `logger.debug()` (file-only) is acceptable. This method is called by `codemie doctor` and must not produce output or side effects.
+
+### `onSessionEnd` failures must never throw
+
+Metrics or sync failure must be caught and swallowed — an uncaught error here blocks agent process exit.
+
+```typescript
+async onSessionEnd(exitCode, env) {
+  try {
+    await processMetrics(env);
+  } catch (error) {
+    // Non-fatal — log and continue
+    logger.error(`[myagent] Metrics processing failed (non-blocking): ${error instanceof Error ? error.message : error}`);
+  }
+}
+```
+
+---
+
+## Testing rules
+
+### Unit-test `enrichArgs` and version parsing
+
+These are pure transformations. Test them without any I/O, mocks, or subprocess calls.
+
+```typescript
+// Example: enrichArgs test
+it('prepends --model when config.model is set', () => {
+  const result = metadata.lifecycle!.enrichArgs!(['--task', 'do something'], { model: 'my-model' } as AgentConfig);
+  expect(result[0]).toBe('--model');
+  expect(result[1]).toBe('my-model');
+});
+```
+
+### Use fixture JSONL/JSON files for processor tests
+
+Place fixtures in `__tests__/fixtures/`, named for the scenario they cover — not for dates or versions.
+
+```
+__tests__/fixtures/
+  session-empty.jsonl           # empty session — processor returns no deltas
+  session-single-turn.jsonl     # one user prompt, one assistant response with tool use
+  session-error-response.jsonl  # API error in assistant message
+```
+
+### Mock the filesystem, not the adapter
+
+Pass a fixture file path into the processor under test. Do not mock the session adapter.
+
+```typescript
+it('extracts one delta per assistant turn', async () => {
+  const processor = new MyAgentMetricsProcessor();
+  const session = await adapter.parseSessionFile(
+    path.join(__dirname, 'fixtures/session-single-turn.jsonl'),
+    'test-session-id',
+  );
+  const result = await processor.process(session, mockContext);
+  expect(result.success).toBe(true);
+});
+```
+
+### Don't test lifecycle hooks with real subprocesses
+
+Inject env vars and spy on `processEvent`. No end-to-end agent invocations in unit tests.
+
+```typescript
+it('calls processEvent with SessionStart on session start', async () => {
+  const processEvent = vi.fn().mockResolvedValue(undefined);
+  vi.doMock('../../../cli/commands/hook.js', () => ({ processEvent }));
+  await plugin.metadata.lifecycle!.onSessionStart!('test-id', { CODEMIE_URL: 'http://local' });
+  expect(processEvent).toHaveBeenCalledWith(
+    expect.objectContaining({ hook_event_name: 'SessionStart' }),
+    expect.any(Object),
+  );
+});
+```
+
+### One fixture per edge case
+
+Each fixture covers exactly one scenario. Prefer fewer, named fixtures over large catch-all files.

--- a/src/agents/plugins/claude/__tests__/claude.plugin.statusline.test.ts
+++ b/src/agents/plugins/claude/__tests__/claude.plugin.statusline.test.ts
@@ -7,7 +7,7 @@
  * @group unit
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import type { AgentConfig } from '../../../core/types.js';
 
 vi.mock('fs/promises');
@@ -40,6 +40,40 @@ vi.mock('../../../../utils/security.js', () => ({
   sanitizeLogArgs: vi.fn((...args: unknown[]) => args),
 }));
 
+// Prevent loading claude.plugin.ts's heavy static deps (BaseAgentAdapter → ProviderRegistry →
+// all providers → sso.proxy → module-level plugin auto-registration) — these are not exercised
+// by the statusline lifecycle hooks, but loading them causes the vi.resetModules() + re-import
+// in beforeEach to time out.
+vi.mock('../../../core/BaseAgentAdapter.js', () => ({
+  BaseAgentAdapter: class BaseAgentAdapter {},
+}));
+
+vi.mock('../claude.session.js', () => ({
+  ClaudeSessionAdapter: class ClaudeSessionAdapter {},
+}));
+
+vi.mock('../claude.plugin-installer.js', () => ({
+  ClaudePluginInstaller: class ClaudePluginInstaller {},
+}));
+
+vi.mock('../../../../utils/native-installer.js', () => ({
+  installNativeAgent: vi.fn(),
+}));
+
+vi.mock('../../../../utils/installation-detector.js', () => ({
+  detectInstallationMethod: vi.fn(),
+}));
+
+vi.mock('../../../../utils/version-utils.js', () => ({
+  isValidSemanticVersion: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../../../utils/errors.js', () => ({
+  AgentInstallationError: class AgentInstallationError extends Error {},
+  createErrorContext: vi.fn(() => ({})),
+  getErrorMessage: vi.fn((e: unknown) => String(e)),
+}));
+
 type HookEnv = NodeJS.ProcessEnv;
 type BeforeRunFn = (env: HookEnv, config: AgentConfig) => Promise<HookEnv>;
 type AfterRunFn = (exitCode: number, env: HookEnv) => Promise<void>;
@@ -51,21 +85,27 @@ describe('Claude Plugin – statusline lifecycle hooks', () => {
   let fsp: typeof import('fs/promises');
   let fsMod: typeof import('fs');
   let loggerMod: { logger: Record<string, ReturnType<typeof vi.fn>> };
+  let claudeMod: { ClaudePluginMetadata: import('../../../core/types.js').AgentMetadata; __resetStatuslineForTest: () => void };
 
   const mockConfig: AgentConfig = {};
 
-  beforeEach(async () => {
-    vi.resetModules(); // Reset module cache → resets statuslineManagedThisSession to false
-    vi.resetAllMocks();
-
-    const mod = await import('../claude.plugin.js');
-    beforeRun = mod.ClaudePluginMetadata.lifecycle!.beforeRun!;
-    afterRun = mod.ClaudePluginMetadata.lifecycle!.afterRun!;
-
+  // Import modules once — avoids the 10 s timeout caused by vi.resetModules() re-loading the
+  // full dependency graph on every test. The module-level statuslineManagedThisSession flag is
+  // reset between tests via __resetStatuslineForTest() instead.
+  beforeAll(async () => {
+    claudeMod = (await import('../claude.plugin.js')) as any;
     installerMod = (await import('../statusline-installer.js')) as any;
     fsp = await import('fs/promises');
     fsMod = await import('fs');
     loggerMod = (await import('../../../../utils/logger.js')) as any;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the module-level flag so each test starts with a clean session state.
+    claudeMod.__resetStatuslineForTest();
+    beforeRun = claudeMod.ClaudePluginMetadata.lifecycle!.beforeRun!;
+    afterRun = claudeMod.ClaudePluginMetadata.lifecycle!.afterRun!;
   });
 
   afterEach(() => {

--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -28,6 +28,9 @@ import {
 // Using module scope (not env var) avoids leaking internal state into subprocess environments.
 let statuslineManagedThisSession = false;
 
+/** @internal Reset the statusline session flag between unit tests. Not for production use. */
+export const __resetStatuslineForTest = (): void => { statuslineManagedThisSession = false; };
+
 /**
  * Supported Claude Code version
  * Latest version tested and verified with CodeMie backend
@@ -79,6 +82,7 @@ export const ClaudePluginMetadata: AgentMetadata = {
   // Data paths (used by lifecycle hooks and analytics)
   dataPaths: {
     home: '.claude',
+    binary: '.local/bin/claude',
   },
 
   envMapping: {
@@ -307,58 +311,6 @@ export class ClaudePlugin extends BaseAgentAdapter {
   }
 
   /**
-   * Get Claude version (override from BaseAgentAdapter)
-   * Parses version from 'claude --version' output
-   * Claude outputs: '2.1.23 (Claude Code)' - we need just '2.1.23'
-   *
-   * Checks full path first on Unix systems (for native installations),
-   * then falls back to command in PATH for other installation methods
-   *
-   * @returns Version string or null if not installed
-   */
-  async getVersion(): Promise<string | null> {
-    if (!this.metadata.cliCommand) {
-      return null;
-    }
-
-    const { exec } = await import('../../../utils/processes.js');
-
-    // Try full path first on Unix systems (native installer places binary at ~/.local/bin/claude)
-    if (process.platform !== 'win32') {
-      const fullPath = resolveHomeDir('.local/bin/claude');
-      try {
-        const result = await exec(fullPath, ['--version']);
-
-        // Parse version from output like '2.1.23 (Claude Code)'
-        const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
-        if (versionMatch) {
-          return versionMatch[1];
-        }
-
-        return result.stdout.trim();
-      } catch {
-        // Full path check failed, fall through to PATH check
-      }
-    }
-
-    // Fall back to command in PATH (works for npm installations, Windows, etc.)
-    try {
-      const result = await exec(this.metadata.cliCommand, ['--version']);
-
-      // Parse version from output like '2.1.23 (Claude Code)'
-      // Extract just the version number
-      const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        return versionMatch[1];
-      }
-
-      return result.stdout.trim();
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Detect how Claude was installed (npm vs native)
    * Returns installation method for informational purposes
    *
@@ -370,41 +322,6 @@ export class ClaudePlugin extends BaseAgentAdapter {
     }
 
     return await detectInstallationMethod(this.metadata.cliCommand);
-  }
-
-  /**
-   * Check if Claude is installed (override from BaseAgentAdapter)
-   * Checks full path first (for native installations to ~/.local/bin/claude),
-   * then falls back to PATH check for compatibility with other installation methods
-   *
-   * @returns true if Claude is installed and accessible
-   */
-  async isInstalled(): Promise<boolean> {
-    if (!this.metadata.cliCommand) {
-      return true; // Built-in agents are always "installed"
-    }
-
-    // On Unix systems, check full path first (native installer places binary at ~/.local/bin/claude)
-    // This avoids PATH issues where ~/.local/bin is not in user's PATH
-    if (process.platform !== 'win32') {
-      const fullPath = resolveHomeDir('.local/bin/claude');
-      try {
-        const { exec } = await import('../../../utils/processes.js');
-        const result = await exec(fullPath, ['--version']);
-        if (result.code === 0) {
-          return true;
-        }
-      } catch {
-        // Full path check failed, fall through to PATH check
-      }
-    }
-
-    // Fall back to base implementation (checks if command is in PATH)
-    // This handles:
-    // 1. npm global installations (in PATH)
-    // 2. Windows installations
-    // 3. Other installation methods
-    return super.isInstalled();
   }
 
   /**

--- a/src/agents/plugins/claude/claude.session.ts
+++ b/src/agents/plugins/claude/claude.session.ts
@@ -9,9 +9,10 @@ import { join, dirname, basename } from 'path';
 import { homedir } from 'os';
 import { existsSync } from 'fs';
 import { readdir, readFile, stat } from 'fs/promises';
-import type { SessionAdapter, ParsedSession, AggregatedResult } from '../../core/session/BaseSessionAdapter.js';
+import type { ParsedSession, AggregatedResult } from '../../core/session/BaseSessionAdapter.js';
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
 import type { SessionDiscoveryOptions, SessionDescriptor } from '../../core/session/discovery-types.js';
-import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
+import type { ProcessingContext } from '../../core/session/BaseProcessor.js';
 import type { ClaudeMessage, ContentItem } from './claude-message-types.js';
 import type { AgentMetadata } from '../../core/types.js';
 import { readJSONL } from '../../core/session/utils/jsonl-reader.js';
@@ -37,32 +38,23 @@ function decodeClaudeProjectDir(encoded: string): string {
  *
  * ENCAPSULATION: Processors are managed internally, not exposed to plugin.
  */
-export class ClaudeSessionAdapter implements SessionAdapter {
+export class ClaudeSessionAdapter extends AbstractBaseSessionAdapter {
   readonly agentName = 'claude';
-  private processors: SessionProcessor[] = [];
 
-  constructor(private readonly metadata: AgentMetadata) {
+  constructor(metadata: AgentMetadata) {
     if (!metadata.dataPaths?.home) {
       throw new Error('Agent metadata must provide dataPaths.home');
     }
-
-    // Initialize and register processors internally
-    // Processors run in priority order: metrics (1), conversations (2)
-    this.initializeProcessors();
+    super(metadata);
   }
 
   /**
    * Initialize processors for this adapter.
-   * INTERNAL: Processors are an implementation detail of the adapter.
+   * Processors run in priority order: metrics (1), conversations (2)
    */
-  private initializeProcessors(): void {
-    // Register metrics processor (priority 1)
+  protected initializeProcessors(): void {
     this.registerProcessor(new MetricsProcessor());
-
-    // Register conversations processor (priority 2)
     this.registerProcessor(new ConversationsProcessor());
-
-    logger.debug(`[claude-adapter] Initialized ${this.processors.length} processors`);
   }
 
   /**
@@ -421,16 +413,6 @@ export class ClaudeSessionAdapter implements SessionAdapter {
       logger.debug(`[claude-adapter] Failed to find sub-agent files:`, error);
       return [];
     }
-  }
-
-  /**
-   * Register a processor to run during session processing.
-   * Processors are sorted by priority (lower runs first).
-   */
-  registerProcessor(processor: SessionProcessor): void {
-    this.processors.push(processor);
-    this.processors.sort((a, b) => a.priority - b.priority);
-    logger.debug(`[claude-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
   }
 
   /**

--- a/src/agents/plugins/codex/codex.plugin.ts
+++ b/src/agents/plugins/codex/codex.plugin.ts
@@ -47,7 +47,7 @@ import type { SessionAdapter } from '../../core/session/BaseSessionAdapter.js';
 import type { SessionDescriptor } from '../../core/session/discovery-types.js';
 import type { BaseExtensionInstaller } from '../../core/extension/BaseExtensionInstaller.js';
 import type { HookProcessingConfig } from '../../../cli/commands/hook.js';
-import { commandExists, exec } from '../../../utils/processes.js';
+import { commandExists } from '../../../utils/processes.js';
 import { logger } from '../../../utils/logger.js';
 import { ConfigurationError } from '../../../utils/errors.js';
 import { CodexSessionAdapter } from './codex.session.js';
@@ -63,6 +63,7 @@ import {
 } from './codex.incremental-sync.js';
 import { reconcileStaleCodexSessions } from './codex.reconciliation.js';
 import { mkdir, realpath as fsRealpath } from 'fs/promises';
+import { getExplicitModelArg } from '../../core/utils/args.js';
 
 /**
  * Supported Codex CLI version
@@ -426,20 +427,6 @@ export const CodexPluginMetadata: AgentMetadata = {
   },
 };
 
-function getExplicitModelArg(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '-m' || arg === '--model') {
-      return args[i + 1];
-    }
-    if (arg.startsWith('--model=')) {
-      return arg.slice('--model='.length);
-    }
-  }
-
-  return undefined;
-}
-
 /**
  * Resolve a path through symlinks, falling back to the original path on error.
  * Used so a `cwd` of `/Users/foo` and a rollout's `projectPath` of
@@ -484,29 +471,6 @@ export class CodexPlugin extends BaseAgentAdapter {
     }
 
     return installed;
-  }
-
-  /**
-   * Get Codex version (override from BaseAgentAdapter).
-   * Codex versions can be emitted as plain semver or with a command prefix,
-   * for example: '0.129.0', 'codex 0.129.0', or 'codex-cli 0.129.0'.
-   * Base compatibility checks require just the semantic version.
-   *
-   * @returns Version string or null if not installed
-   */
-  async getVersion(): Promise<string | null> {
-    if (!this.metadata.cliCommand) {
-      return null;
-    }
-
-    try {
-      const result = await exec(this.metadata.cliCommand, ['--version']);
-      const output = result.stdout.trim();
-      const versionMatch = output.match(/(\d+\.\d+\.\d+)/);
-      return versionMatch ? versionMatch[1] : output;
-    } catch {
-      return null;
-    }
   }
 
   /**

--- a/src/agents/plugins/codex/codex.session.ts
+++ b/src/agents/plugins/codex/codex.session.ts
@@ -24,13 +24,13 @@ import { readdir, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import type {
-  SessionAdapter,
   ParsedSession,
   AggregatedResult,
   SessionDiscoveryOptions,
   SessionDescriptor,
 } from '../../core/session/BaseSessionAdapter.js';
-import type { SessionProcessor, ProcessingContext, ProcessingResult } from '../../core/session/BaseProcessor.js';
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+import type { ProcessingContext, ProcessingResult } from '../../core/session/BaseProcessor.js';
 import type { AgentMetadata } from '../../core/types.js';
 import type {
   CodexRolloutRecord,
@@ -50,27 +50,19 @@ import { extractCodexSpawnLinks } from './session/codex-collab-links.js';
 /** Regex to extract UUID from rollout filename: rollout-{ISO8601}-{uuid}.jsonl */
 const ROLLOUT_UUID_REGEX = /rollout-.*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/;
 
-export class CodexSessionAdapter implements SessionAdapter {
+export class CodexSessionAdapter extends AbstractBaseSessionAdapter {
   readonly agentName = 'codex';
-  private processors: SessionProcessor[] = [];
 
-  constructor(private readonly metadata: AgentMetadata) {
+  constructor(metadata: AgentMetadata) {
     if (!metadata.dataPaths?.home) {
       throw new ConfigurationError('Agent metadata must provide dataPaths.home');
     }
-    this.initializeProcessors();
+    super(metadata);
   }
 
-  private initializeProcessors(): void {
+  protected initializeProcessors(): void {
     this.registerProcessor(new CodexMetricsProcessor());
     this.registerProcessor(new CodexConversationsProcessor());
-    logger.debug(`[codex-adapter] Initialized ${this.processors.length} processors`);
-  }
-
-  registerProcessor(processor: SessionProcessor): void {
-    this.processors.push(processor);
-    this.processors.sort((a, b) => a.priority - b.priority);
-    logger.debug(`[codex-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
   }
 
   private async applySyncUpdates(sessionId: string, results: ProcessingResult[]): Promise<void> {

--- a/src/agents/plugins/gemini/gemini.plugin.ts
+++ b/src/agents/plugins/gemini/gemini.plugin.ts
@@ -214,32 +214,4 @@ export class GeminiPlugin extends BaseAgentAdapter {
     return this.extensionInstaller;
   }
 
-  /**
-   * Get Gemini CLI version (override from BaseAgentAdapter)
-   * Parses version from 'gemini --version' output
-   * Extracts just the semver number in case output contains extra text
-   *
-   * @returns Version string or null if not installed
-   */
-  async getVersion(): Promise<string | null> {
-    if (!this.metadata.cliCommand) {
-      return null;
-    }
-
-    try {
-      const { exec } = await import('../../../utils/processes.js');
-      const result = await exec(this.metadata.cliCommand, ['--version']);
-
-      // Parse semver from output (handles both '0.29.5' and '0.29.5 (Gemini CLI)' formats)
-      const versionMatch = result.stdout.trim().match(/^(\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        return versionMatch[1];
-      }
-
-      return result.stdout.trim();
-    } catch {
-      return null;
-    }
-  }
-
 }

--- a/src/agents/plugins/gemini/gemini.session-adapter.ts
+++ b/src/agents/plugins/gemini/gemini.session-adapter.ts
@@ -12,8 +12,9 @@
  */
 
 import { readFile } from 'fs/promises';
-import type { SessionAdapter, ParsedSession, AggregatedResult } from '../../core/session/BaseSessionAdapter.js';
-import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
+import type { ParsedSession, AggregatedResult } from '../../core/session/BaseSessionAdapter.js';
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+import type { ProcessingContext } from '../../core/session/BaseProcessor.js';
 import type { AgentMetadata } from '../../core/types.js';
 import { logger } from '../../../utils/logger.js';
 import { GeminiMetricsProcessor } from './session/processors/gemini.metrics-processor.js';
@@ -79,32 +80,23 @@ interface GeminiToolCall {
  * Parses Gemini-specific JSON format into unified ParsedSession.
  * Orchestrates multiple processors that transform messages.
  */
-export class GeminiSessionAdapter implements SessionAdapter {
+export class GeminiSessionAdapter extends AbstractBaseSessionAdapter {
   readonly agentName = 'gemini';
-  private processors: SessionProcessor[] = [];
 
-  constructor(private readonly metadata: AgentMetadata) {
+  constructor(metadata: AgentMetadata) {
     if (!metadata.dataPaths?.home) {
       throw new Error('Agent metadata must provide dataPaths.home');
     }
-
-    // Initialize and register processors internally
-    // Processors run in priority order: metrics (1), conversations (2)
-    this.initializeProcessors();
+    super(metadata);
   }
 
   /**
    * Initialize processors for this adapter.
    * Uses Gemini-specific processors that understand Gemini's message format
    */
-  private initializeProcessors(): void {
-    // Register Gemini metrics processor (priority 1)
+  protected initializeProcessors(): void {
     this.registerProcessor(new GeminiMetricsProcessor());
-
-    // Register Gemini conversations processor (priority 2)
     this.registerProcessor(new GeminiConversationsProcessor());
-
-    logger.debug(`[gemini-adapter] Initialized ${this.processors.length} processors`);
   }
 
   /**
@@ -238,16 +230,6 @@ export class GeminiSessionAdapter implements SessionAdapter {
     if (opType) {
       operations.push({ type: opType, path: filePath });
     }
-  }
-
-  /**
-   * Register a processor to run during session processing.
-   * Processors are sorted by priority (lower runs first).
-   */
-  registerProcessor(processor: SessionProcessor): void {
-    this.processors.push(processor);
-    this.processors.sort((a, b) => a.priority - b.priority);
-    logger.debug(`[gemini-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
   }
 
   /**

--- a/src/agents/plugins/kimi/kimi.plugin.ts
+++ b/src/agents/plugins/kimi/kimi.plugin.ts
@@ -17,7 +17,8 @@ import {
 import { isValidSemanticVersion } from '../../../utils/version-utils.js';
 import { logger } from '../../../utils/logger.js';
 import { sanitizeLogArgs } from '../../../utils/security.js';
-import { commandExists, exec, getCommandPath } from '../../../utils/processes.js';
+import { getCommandPath } from '../../../utils/processes.js';
+import { getExplicitModelArg } from '../../core/utils/args.js';
 import { resolveHomeDir } from '../../../utils/paths.js';
 
 const KIMI_SUPPORTED_VERSION = '0.16.0';
@@ -42,6 +43,7 @@ export const KimiPluginMetadata: AgentMetadata = {
   dataPaths: {
     home: '.kimi-code',
     binary: KIMI_NATIVE_BINARY_PATH,
+    binaryAlt: '.local/bin/kimi',  // legacy npm install location
   },
   envMapping: {
     baseUrl: ['KIMI_MODEL_BASE_URL'],
@@ -134,43 +136,6 @@ export class KimiPlugin extends BaseAgentAdapter {
       this.hookTransformer = new KimiHookTransformer();
     }
     return this.hookTransformer;
-  }
-
-  override async isInstalled(): Promise<boolean> {
-    if (!this.metadata.cliCommand) {
-      return true;
-    }
-
-    if (await commandExists(this.metadata.cliCommand)) {
-      return true;
-    }
-
-    if (process.platform !== 'win32') {
-      // Native installer location
-      const nativePath = resolveHomeDir(KIMI_NATIVE_BINARY_PATH);
-      try {
-        const result = await exec(nativePath, ['--version']);
-        if (result.code === 0) {
-          return true;
-        }
-      } catch {
-        // Native path check failed, fall through
-      }
-
-      // Legacy / npm location
-      const fullPath = resolveHomeDir('.local/bin/kimi');
-      try {
-        const result = await exec(fullPath, ['--version']);
-        return result.code === 0;
-      } catch {
-        // Full path check failed, fall through to PATH check already performed
-      }
-    }
-
-    logger.debug('[kimi-plugin] Kimi not installed. Install with:');
-    logger.debug('[kimi-plugin]   codemie install kimi');
-
-    return false;
   }
 
   private async installNative(version?: string): Promise<void> {
@@ -282,53 +247,6 @@ export class KimiPlugin extends BaseAgentAdapter {
     await super.uninstall();
   }
 
-  /**
-   * Get Kimi version by parsing 'kimi --version' output.
-   * Extracts the first semantic version found in the output.
-   *
-   * Checks the native installer full path first on Unix systems, then falls
-   * back to the command in PATH for other installation methods.
-   */
-  override async getVersion(): Promise<string | null> {
-    if (!this.metadata.cliCommand) {
-      return null;
-    }
-
-    const parseVersion = (output: string): string | null => {
-      const match = output.match(/(\d+\.\d+\.\d+)/);
-      return match ? match[1] : output.trim() || null;
-    };
-
-    // Try native installer full path first on Unix systems
-    // (native installer places binary at ~/.kimi-code/bin/kimi)
-    if (process.platform !== 'win32') {
-      const nativePath = resolveHomeDir(KIMI_NATIVE_BINARY_PATH);
-      try {
-        const result = await exec(nativePath, ['--version']);
-        return parseVersion(result.stdout);
-      } catch {
-        // Native path check failed, fall through to legacy path
-      }
-
-      // Legacy / npm location
-      const fullPath = resolveHomeDir('.local/bin/kimi');
-      try {
-        const result = await exec(fullPath, ['--version']);
-        return parseVersion(result.stdout);
-      } catch {
-        // Full path check failed, fall through to PATH check
-      }
-    }
-
-    // Fall back to command in PATH
-    try {
-      const result = await exec(this.metadata.cliCommand, ['--version']);
-      return parseVersion(result.stdout);
-    } catch {
-      return null;
-    }
-  }
-
   override async installVersion(version?: string): Promise<void> {
     // Resolve 'supported' to the version from metadata
     let resolvedVersion: string | undefined = version;
@@ -381,16 +299,3 @@ export class KimiPlugin extends BaseAgentAdapter {
   }
 }
 
-function getExplicitModelArg(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '-m' || arg === '--model') {
-      return args[i + 1];
-    }
-    if (arg.startsWith('--model=')) {
-      return arg.slice('--model='.length);
-    }
-  }
-
-  return undefined;
-}

--- a/src/agents/plugins/kimi/kimi.session.ts
+++ b/src/agents/plugins/kimi/kimi.session.ts
@@ -9,38 +9,28 @@
  */
 
 import type {
-  SessionAdapter,
   ParsedSession,
   AggregatedResult,
   SessionDiscoveryOptions,
   SessionDescriptor,
 } from '../../core/session/BaseSessionAdapter.js';
-import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+import type { ProcessingContext } from '../../core/session/BaseProcessor.js';
 import type { AgentMetadata } from '../../core/types.js';
 import { readJSONLTolerant } from '../../core/session/utils/jsonl-reader.js';
 import { logger } from '../../../utils/logger.js';
 import { KimiMetricsProcessor } from './session/processors/kimi.metrics-processor.js';
 import type { KimiWireEvent } from './session/types.js';
 
-export class KimiSessionAdapter implements SessionAdapter {
+export class KimiSessionAdapter extends AbstractBaseSessionAdapter {
   readonly agentName = 'kimi';
-  private processors: SessionProcessor[] = [];
 
-  constructor(private readonly metadata: AgentMetadata) {
-    // Register processors now, but execution is currently orchestrated externally
-    // until processSession is implemented.
-    this.initializeProcessors();
+  constructor(metadata: AgentMetadata) {
+    super(metadata);
   }
 
-  private initializeProcessors(): void {
+  protected initializeProcessors(): void {
     this.registerProcessor(new KimiMetricsProcessor());
-    logger.debug(`[kimi-adapter] Initialized ${this.processors.length} processors`);
-  }
-
-  registerProcessor(processor: SessionProcessor): void {
-    this.processors.push(processor);
-    this.processors.sort((a, b) => a.priority - b.priority);
-    logger.debug(`[kimi-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
   }
 
   /**

--- a/src/agents/plugins/opencode/opencode.session.ts
+++ b/src/agents/plugins/opencode/opencode.session.ts
@@ -2,8 +2,9 @@
 import { readFile, readdir, stat } from 'fs/promises';
 import { join, dirname, sep } from 'path';
 import { existsSync } from 'fs';
-import type { SessionAdapter, ParsedSession, AggregatedResult, SessionDiscoveryOptions, SessionDescriptor } from '../../core/session/BaseSessionAdapter.js';
-import type { SessionProcessor, ProcessingContext } from '../../core/session/BaseProcessor.js';
+import type { ParsedSession, AggregatedResult, SessionDiscoveryOptions, SessionDescriptor } from '../../core/session/BaseSessionAdapter.js';
+import { AbstractBaseSessionAdapter } from '../../core/session/BaseSessionAdapter.js';
+import type { ProcessingContext } from '../../core/session/BaseProcessor.js';
 import type { AgentMetadata } from '../../core/types.js';
 import type {
   OpenCodeSession,
@@ -74,34 +75,23 @@ async function readJsonWithRetry<T>(filePath: string): Promise<T | null> {
  * Parses OpenCode session files from ~/.local/share/opencode/storage/
  * Implements SessionAdapter interface with processor chain pattern.
  */
-export class OpenCodeSessionAdapter implements SessionAdapter {
+export class OpenCodeSessionAdapter extends AbstractBaseSessionAdapter {
   readonly agentName = 'opencode';
-  private processors: SessionProcessor[] = [];
 
-  constructor(private readonly metadata: AgentMetadata) {
+  constructor(metadata: AgentMetadata) {
     if (!metadata.dataPaths?.home) {
       throw new Error('Agent metadata must provide dataPaths.home');
     }
-    this.initializeProcessors();
+    super(metadata);
   }
 
   /**
    * Initialize processors for this adapter.
    * Processors run in priority order: metrics (1), conversations (2)
    */
-  private initializeProcessors(): void {
+  protected initializeProcessors(): void {
     this.registerProcessor(new OpenCodeMetricsProcessor());
     this.registerProcessor(new OpenCodeConversationsProcessor());
-    logger.debug(`[opencode-adapter] Initialized ${this.processors.length} processors`);
-  }
-
-  /**
-   * Register a processor to run during session processing.
-   */
-  registerProcessor(processor: SessionProcessor): void {
-    this.processors.push(processor);
-    this.processors.sort((a, b) => a.priority - b.priority);
-    logger.debug(`[opencode-adapter] Registered processor: ${processor.name} (priority: ${processor.priority})`);
   }
 
   /**

--- a/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
+++ b/src/cli/commands/analytics/cost/__tests__/usage-readers.test.ts
@@ -2,9 +2,26 @@
  * Per-agent token usage reader unit tests
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { buildCostSeries } from '../cost-enricher.js';
+
+// cost-enricher.ts imports AgentRegistry (which loads all 8 plugins) plus ClaudeSessionAdapter
+// and ClaudePluginMetadata. None of those are needed by buildCostSeries (a pure function), but
+// the combined module-loading overhead exceeds the 30 s test timeout in Vitest's transform layer.
+// Mock them so the dynamic import resolves quickly.
+vi.mock('../../../../agents/registry.js', () => ({
+  AgentRegistry: { getAgent: vi.fn(() => null), getAnalyticsAdapter: vi.fn(() => undefined), initialize: vi.fn() },
+}));
+vi.mock('../../../../agents/plugins/claude/claude.session.js', () => ({
+  ClaudeSessionAdapter: class ClaudeSessionAdapter {},
+}));
+vi.mock('../../../../agents/plugins/claude/claude.plugin.js', () => ({
+  ClaudePluginMetadata: { name: 'claude', dataPaths: { home: '.claude' } },
+  __resetStatuslineForTest: () => {},
+  CLAUDE_SUPPORTED_VERSION: '0.0.0',
+}));
 import { readUsageByModel, extractClaudeUsageRecords, gatherDedupedUsageRecords, sumUsageRecords, extractKimiUsageRecords, extractCodexUsageRecords } from '../usage-readers.js';
 
 const claudeParsed = {
@@ -401,8 +418,7 @@ describe('extractCodexUsageRecords', () => {
     expect(u?.total).toBeGreaterThan(1036);
   });
 
-  it('buildCostSeries works from codex per-turn records', async () => {
-    const { buildCostSeries } = await import('../cost-enricher.js');
+  it('buildCostSeries works from codex per-turn records', () => {
     const recs = extractCodexUsageRecords(loadCodex('turn-2.jsonl'));
     const series = buildCostSeries(recs);
     expect(series.length).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## Summary

- **Extract `getExplicitModelArg()`** into `src/agents/core/utils/args.ts` — removes duplicate implementations in Codex and Kimi plugins
- **Centralise `getVersion()` and `isInstalled()`** in `BaseAgentAdapter` — all 5 plugins drop their overrides; adds `dataPaths.binary` (primary native binary) and `dataPaths.binaryAlt` (legacy path, used for Kimi's npm install location) to `AgentMetadata`
- **Add `AbstractBaseSessionAdapter`** in `BaseSessionAdapter.ts` — eliminates duplicated `processors: SessionProcessor[]`, `registerProcessor()`, and constructor pattern across all 5 session adapters
- **Add `PLUGIN_GUIDE.md`** in `src/agents/plugins/` — authoring checklist and base/override contract for plugin authors
- **Fix two pre-existing test failures** exposed when `vitest related` started including these files:
  - `claude.plugin.statusline.test.ts`: `vi.resetModules()` per-test caused a 10s timeout re-loading the full module graph; replaced with a `__resetStatuslineForTest()` export to reset the module-level flag directly
  - `usage-readers.test.ts`: `buildCostSeries` test used a dynamic `import('../cost-enricher.js')` inside the test body; `cost-enricher.ts` statically imports `AgentRegistry` → all 8 plugins → SSO modules, exceeding the 30s test timeout; fixed by mocking the heavy deps and promoting the import to a static top-level import

## Test plan

- [x] Pre-commit hook: ESLint + `vitest related` — all pass
- [x] `claude.plugin.statusline` — 8/8 tests pass in ~3s (was timing out)
- [x] `usage-readers` — 29/29 tests pass, `buildCostSeries` runs in 10ms (was 22s, timeout at 30s)
- [ ] Full unit test suite (`npm run test:unit`) — not run; CI will cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)