### PR TITLE
feat(analytics): add auth status gate for metrics sync

### DIFF
--- a/.ai-run/guides/security/security-practices.md
+++ b/.ai-run/guides/security/security-practices.md
@@ -15,6 +15,69 @@ Security patterns for CodeMie Code: credential storage, data sanitization, input
 | Data sanitization | Auto-redact sensitive data in logs |
 | Secure storage | Encrypted credential storage (keytar + fallback) |
 | Least privilege | File permissions, scoped access |
+| **Request header integrity (project & user attribution)** | **Any add/remove/rewrite of project- or user-attribution headers is a CRITICAL change — security review required before merge** |
+
+---
+
+## CRITICAL: Project & User Attribution Headers
+
+Any change that adds, removes, renames, or rewrites a header carrying **project identity**, **user identity**, or **session attribution** on outbound requests is a **CRITICAL, security-reviewed change**. This applies to headers, to fields that stand in for them (e.g. the Responses API `user` body field, JWT `sub` overrides), and to any derivation source that feeds them.
+
+These identifiers back audit trails, tenant isolation, per-user budget accounting, abuse tracing, and analytics attribution. A silent rewrite — even a "harmless" hash, prefix, or normalization — can:
+
+- break audit correlation between CLI action and server-side event,
+- misattribute usage or billing across tenants/users,
+- hide abuse behind an unreachable identifier,
+- cross-attribute analytics between repositories/branches.
+
+### Headers and identifier fields in scope
+
+Injected today by `src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts`:
+
+| Header | Meaning |
+|---|---|
+| `X-CodeMie-Request-ID` | Per-request correlation ID |
+| `X-CodeMie-Session-ID` (+ `x-litellm-session-id`) | Session attribution |
+| `X-CodeMie-CLI` / `X-CodeMie-CLI-Model` / `X-CodeMie-CLI-Timeout` | Client attribution |
+| `X-CodeMie-Client` | Agent client type |
+| `X-CodeMie-Integration` | Integration/tenant identity |
+| `X-CodeMie-Repository` / `X-CodeMie-Branch` / `X-CodeMie-Project` | Repository/branch/project attribution |
+
+Also in scope even though they are body fields, not headers: the Responses API `user` field, JWT `sub` / `email` overrides, and any other identifier the server treats as authoritative for attribution.
+
+### Rules for changes that touch any of the above
+
+1. **Do not add, remove, rename, or rewrite** any project/user attribution header (or standin field) without an explicit security-review sign-off on the PR.
+2. **Do not derive the value from a new source** (process introspection, environment guesswork, filesystem heuristics) without security review — the derivation is part of the surface.
+3. **Do not silently normalize** (hash, truncate, hex-prefix) an identifier the server may treat as authoritative — normalization must be an intentional, documented protocol change agreed with the server side.
+4. **Header injection lives in exactly one layer**: the proxy plugin `header-injection.plugin.ts`. Do not add a second injection path (telemetry runtime, adapter, CLI) that competes with it.
+5. **Never log full header values** without `sanitizeHeaders()` — attribution headers carry PII (email, repository path).
+
+### Bad vs. Good
+
+| Bad | Good |
+|-----|------|
+| Rewriting `user` body field to `sha256(user).slice(0,32)` inside a proxy plugin, silently, for all clients | Route the change through security review; if the server can't accept the raw identifier, agree on a protocol with the server team and document it |
+| Adding a second code path that sets `X-CodeMie-Repository` from `lsof` output outside `header-injection.plugin.ts` | Extend the single canonical injector with an audited derivation, or expose a typed contract the injector reads from |
+| Reading `.git/HEAD` and stuffing the result into `X-CodeMie-Branch` with no worktree handling | Use `detectGitBranch()` from `src/utils/processes.ts` and treat any failure as "no attribution", not a guess |
+| `logger.info('outbound headers', headers)` | `logger.debug('outbound headers', ...sanitizeLogArgs({ headers }))` |
+
+### Reviewer checklist for header-touching PRs
+
+Copy this into the PR review when the diff touches any attribution header, the `user` body field, JWT claim overrides, or the derivation source of any of them:
+
+- [ ] Change is called out as **CRITICAL** in the PR description with the security-review sign-off recorded.
+- [ ] Header injection stays in `header-injection.plugin.ts` — no competing injector added elsewhere.
+- [ ] Derivation source is auditable and does not depend on unbounded OS introspection (`lsof`, process tree walks) unless explicitly approved.
+- [ ] No silent normalization (hash/truncate/prefix) of an authoritative identifier without documented server-side agreement.
+- [ ] Values are sanitized on every log path (`sanitizeHeaders`, `sanitizeLogArgs`).
+- [ ] Tests cover: header present with expected value, header absent when attribution unknown (not a guessed default), header not leaked to logs.
+- [ ] No new PII surface in URL query strings or filenames derived from the identifier.
+
+References:
+- `src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts` — canonical injection point
+- `src/utils/security.ts` — `sanitizeHeaders`, `sanitizeLogArgs`
+- `.ai-run/guides/standards/git-workflow.md` — Code Review Checklist
 
 ---
 
@@ -214,6 +277,8 @@ Checked patterns: API keys (`sk-`, `sk-ant-`), private keys (`-----BEGIN PRIVATE
 | `fs.readFile(userPath)` | `validateFilePath(userPath, workingDir); fs.readFile(userPath)` |
 | `console.log(headers)` | `logger.debug('Headers', ...sanitizeLogArgs(headers))` |
 | Store tokens in plaintext file | Use `CredentialStore` |
+| **Add/rewrite an `X-CodeMie-*` attribution header (or the Responses `user` field) without security review** | **Route the change through security review; keep injection in `header-injection.plugin.ts`; document any normalization** |
+| **Add a second competing header-injection path (telemetry runtime, adapter, CLI)** | **Extend the single canonical injector or expose a typed contract it reads from** |
 
 ---
 
@@ -228,6 +293,7 @@ Checked patterns: API keys (`sk-`, `sk-ant-`), private keys (`-----BEGIN PRIVATE
 - [ ] `.env` in `.gitignore`
 - [ ] No secrets in test fixtures
 - [ ] No `console.log()` of sensitive data
+- [ ] **No add/remove/rename/rewrite of project or user attribution headers (or the Responses `user` body field) without security-review sign-off** — see "CRITICAL: Project & User Attribution Headers" above
 
 ### Production
 - [ ] Use `CredentialStore` for persistent secrets

--- a/.ai-run/guides/standards/git-workflow.md
+++ b/.ai-run/guides/standards/git-workflow.md
@@ -143,9 +143,15 @@ The repository ships a template at `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ### Code Review Checklist
 
+> ⚠ **CRITICAL — project & user attribution headers**
+>
+> If the diff adds, removes, renames, or rewrites any `X-CodeMie-*` attribution header (Repository / Branch / Project / Session / Client / Integration / …), the Responses API `user` body field, JWT `sub` / `email` overrides, or the derivation source of any of them — mark the PR as a **CRITICAL change** and require security-review sign-off before merge. This applies even to "harmless" hashes, truncations, or normalizations. Use the reviewer checklist in `.ai-run/guides/security/security-practices.md` → "CRITICAL: Project & User Attribution Headers".
+
+- [ ] **CRITICAL check first**: does the diff touch project/user attribution headers, the Responses `user` field, JWT claim overrides, or their derivation source? If yes, apply the security-practices reviewer checklist and require sign-off.
 - [ ] Logic is correct and matches the linked ticket / story.
 - [ ] Architecture boundaries respected (`CLI → Registry → Plugin → Core → Utils`). See `.ai-run/guides/architecture/architecture.md`.
 - [ ] No secrets, no `console.log`, no generic `Error` (see `.ai-run/guides/security/security-practices.md` and `.ai-run/guides/development/development-practices.md`).
+- [ ] No competing header-injection path added — canonical injector is `src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts`.
 - [ ] Tests adequate (`.ai-run/guides/testing/testing-patterns.md`).
 - [ ] Lint clean (`npm run lint`) and types check (`npm run typecheck`).
 - [ ] Public docs / READMEs updated when behavior changes.

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -292,6 +292,41 @@ export class AgentCLI {
         process.exit(1);
       }
 
+      // Analytics auth validation for providers where CodeMie auth is analytics-only
+      // (e.g. anthropic-subscription, moonshot-subscription). ai-run-sso already
+      // validated these same credentials via its own validateAuth above.
+      // Enabled only when analytics sync is configured (codeMieUrl → CODEMIE_URL +
+      // CODEMIE_SYNC_API_URL) — same condition the UserPromptSubmit hook gate uses.
+      // Non-fatal: the hook gate enforces auth at prompt level; here we only offer
+      // an early interactive re-auth.
+      if (config.provider !== ProviderName.AI_RUN_SSO && config.codeMieUrl) {
+        try {
+          const ssoSetupSteps = ProviderRegistry.getSetupSteps(ProviderName.AI_RUN_SSO);
+
+          if (ssoSetupSteps?.validateAuth) {
+            const analyticsAuth = await ssoSetupSteps.validateAuth(config);
+
+            if (!analyticsAuth.valid) {
+              const { handleAuthValidationFailure } = await import('../../providers/core/auth-validation.js');
+              const reauthed = await handleAuthValidationFailure(analyticsAuth, ssoSetupSteps, config);
+
+              if (!reauthed) {
+                console.log(chalk.yellow('⚠️  CodeMie analytics authentication is invalid — session metrics will not be uploaded.'));
+                console.log(chalk.white(`  Re-authenticate later with: codemie profile login --url ${config.codeMieUrl}\n`));
+                logger.warn(`Analytics auth invalid for ${config.codeMieUrl}: ${analyticsAuth.error}`);
+              }
+            } else {
+              // Credentials verified against the API — clear any stale invalid-auth marker
+              const { clearAnalyticsAuthStatus } = await import('../../utils/analytics-auth-status.js');
+              await clearAnalyticsAuthStatus();
+            }
+          }
+        } catch (error) {
+          // Analytics auth is auxiliary — never block agent launch on check errors
+          logger.error('Analytics auth validation failed:', error);
+        }
+      }
+
       // Validate provider and model compatibility
       if (!this.validateCompatibility(config)) {
         process.exit(1);

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -495,9 +495,86 @@ async function accumulateActiveDuration(sessionId: string): Promise<number> {
  * Handle UserPromptSubmit event
  * Starts activity tracking to measure active session time
  */
-async function handleUserPromptSubmit(event: BaseHookEvent, sessionId: string, _config?: HookProcessingConfig): Promise<void> {
+async function handleUserPromptSubmit(event: BaseHookEvent, sessionId: string, config?: HookProcessingConfig): Promise<void> {
   logger.info(`[hook:UserPromptSubmit] ${JSON.stringify(event)}`);
+  await enforceAnalyticsAuthGate(config);
   await startActivityTracking(sessionId);
+}
+
+/**
+ * Analytics auth gate (generic for all agents using the unified hook handler).
+ *
+ * Blocks the prompt (exit code 2, stderr fed back to the agent) when CodeMie
+ * analytics sync is configured but authentication is known to be broken:
+ * - no valid stored SSO credentials (and no CODEMIE_API_KEY), or
+ * - the metrics endpoint previously rejected the credentials (invalid-auth
+ *   marker written by MetricsApiClient on 401/403 or HTML SSO login page).
+ *
+ * Without this gate, expired analytics credentials fail silently and sessions
+ * disappear from metrics. The marker is cleared by `codemie profile login`
+ * and by any successful metrics send.
+ */
+async function enforceAnalyticsAuthGate(config?: HookProcessingConfig): Promise<void> {
+  try {
+    const provider = getConfigValue('CODEMIE_PROVIDER', config);
+    const ssoUrl = getConfigValue('CODEMIE_URL', config);
+    const syncApiUrl = getConfigValue('CODEMIE_SYNC_API_URL', config);
+
+    const analyticsConfigured = provider === 'ai-run-sso' || Boolean(ssoUrl && syncApiUrl);
+    if (!analyticsConfigured) {
+      return;
+    }
+
+    let hasValidAuth = Boolean(getConfigValue('CODEMIE_API_KEY', config));
+    if (!hasValidAuth && ssoUrl) {
+      try {
+        const { CodeMieSSO } = await import('../../providers/plugins/sso/sso.auth.js');
+        const credentials = await new CodeMieSSO().getStoredCredentials(ssoUrl);
+        hasValidAuth = Boolean(credentials?.cookies);
+      } catch (error) {
+        logger.debug('[hook:UserPromptSubmit] Auth gate: failed to load SSO credentials:', error);
+      }
+    }
+
+    const { getAnalyticsAuthStatus } = await import('../../utils/analytics-auth-status.js');
+    const authStatus = await getAnalyticsAuthStatus();
+
+    if (hasValidAuth && !authStatus) {
+      return;
+    }
+
+    const reason = !hasValidAuth
+      ? 'no valid CodeMie SSO credentials found'
+      : `CodeMie metrics endpoint rejected the stored credentials (${authStatus?.reason || 'unknown reason'})`;
+    const loginCommand = ssoUrl
+      ? `codemie profile login --url ${ssoUrl}`
+      : 'codemie profile login';
+
+    const message = [
+      'CodeMie analytics authentication is invalid — session metrics are NOT being uploaded.',
+      `Reason: ${reason}.`,
+      `Re-authenticate by running: ${loginCommand}`,
+      'Then re-send your prompt.'
+    ].join('\n');
+
+    logger.warn(`[hook:UserPromptSubmit] Blocking prompt: ${reason}`);
+
+    if (config) {
+      // Programmatic mode (e.g. VSCode extension): let the host decide how to
+      // surface the failure instead of exiting its process
+      throw new Error(message);
+    }
+
+    await logger.close();
+    console.error(message);
+    process.exit(2); // Blocking: stderr is fed back to the agent
+  } catch (error) {
+    if (config) {
+      throw error;
+    }
+    // The gate itself must never break the prompt flow
+    logger.debug('[hook:UserPromptSubmit] Auth gate check failed (non-blocking):', error);
+  }
 }
 
 /**

--- a/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
+++ b/src/providers/plugins/sso/session/processors/metrics/metrics-api-client.ts
@@ -27,12 +27,15 @@ import type { MCPConfigSummary, ExtensionsScanSummary } from '../../../../../../
 import { logger } from '../../../../../../utils/logger.js';
 import { detectGitBranch } from '../../../../../../utils/processes.js';
 import { extractRepository } from '../../../../../../utils/paths.js';
+import { markAnalyticsAuthInvalid, clearAnalyticsAuthStatus } from '../../../../../../utils/analytics-auth-status.js';
 import { CODEMIE_ENDPOINTS } from '../../../sso.http-client.js';
 
 interface MetricsRequestError extends Error {
   statusCode?: number;
   response?: unknown;
   responseText?: string;
+  /** True when the server rejected the provided credentials (401/403 or an HTML SSO login page) */
+  isAuthFailure?: boolean;
 }
 
 /**
@@ -70,13 +73,25 @@ class MetricsApiClient {
           await this.sleep(delay);
         }
 
-        return await this.sendRequest(metric);
+        const response = await this.sendRequest(metric);
+        // Server accepted our credentials — clear any stale invalid-auth marker
+        await clearAnalyticsAuthStatus();
+        return response;
 
       } catch (error) {
         lastError = error as Error;
         const errorMessage = error instanceof Error ? error.message : String(error);
         const errorName = error instanceof Error ? error.name : 'Unknown';
         const statusCode = (error as MetricsRequestError).statusCode;
+
+        // Record credential rejections (401/403 or HTML SSO login page) so the
+        // hook auth gate can prompt the user to re-authenticate
+        if ((error as MetricsRequestError).isAuthFailure) {
+          await markAnalyticsAuthInvalid(
+            statusCode ? `HTTP ${statusCode}: ${errorMessage}` : errorMessage,
+            this.config.baseUrl
+          );
+        }
 
         if (!this.isRetryable(error as Error)) {
           logger.error(`[MetricsApiClient] Non-retryable error [${errorName}]: ${errorMessage}${statusCode ? ` (HTTP ${statusCode})` : ''}`);
@@ -174,6 +189,7 @@ class MetricsApiClient {
           const error = new Error(errorMessage) as MetricsRequestError;
           error.statusCode = response.status;
           error.response = data;
+          error.isAuthFailure = response.status === 401 || response.status === 403;
           throw error;
         }
 
@@ -181,6 +197,7 @@ class MetricsApiClient {
         const error = new Error(`API returned ${response.status}: ${errorMessage}`) as MetricsRequestError;
         error.statusCode = response.status;
         error.response = data;
+        error.isAuthFailure = response.status === 401 || response.status === 403;
         throw error;
       }
 
@@ -239,6 +256,9 @@ function parseMetricsResponse(
     ) as MetricsRequestError;
     error.statusCode = statusCode;
     error.responseText = excerpt;
+    // An HTML page instead of JSON means the request was redirected to the SSO
+    // login page (e.g. Keycloak answers HTTP 200 + login HTML for expired cookies)
+    error.isAuthFailure = Boolean(contentType?.includes('text/html'));
     throw error;
   }
 }

--- a/src/providers/plugins/sso/sso.auth.ts
+++ b/src/providers/plugins/sso/sso.auth.ts
@@ -12,6 +12,7 @@ import open from 'open';
 import chalk from 'chalk';
 import type { SSOAuthConfig, SSOAuthResult, SSOCredentials } from '../../core/types.js';
 import { CredentialStore } from '../../../utils/security.js';
+import { clearAnalyticsAuthStatus } from '../../../utils/analytics-auth-status.js';
 import { ensureApiBase } from '../../core/codemie-auth-helpers.js';
 
 function escapeHtml(str: string): string {
@@ -133,6 +134,8 @@ export class CodeMieSSO {
 
         const store = CredentialStore.getInstance();
         await store.storeSSOCredentials(credentials, this.codeMieUrl);
+        // Fresh credentials — analytics auth is healthy again
+        await clearAnalyticsAuthStatus();
       }
 
       return result;

--- a/src/utils/analytics-auth-status.ts
+++ b/src/utils/analytics-auth-status.ts
@@ -1,0 +1,100 @@
+/**
+ * Analytics Auth Status Marker
+ *
+ * File-based marker used to propagate CodeMie analytics (metrics endpoint)
+ * authentication failures across processes.
+ *
+ * Problem: when SSO cookies expire, the metrics endpoint (fronted by Keycloak)
+ * answers POSTs with HTTP 200 + an HTML login page instead of 401. Sync code
+ * only sees a generic non-JSON failure logged at debug level, so sessions
+ * silently disappear from analytics.
+ *
+ * Writers:
+ * - MetricsApiClient marks the status invalid when the server rejects the
+ *   provided credentials (401/403 or an HTML login page response).
+ * - MetricsApiClient and the SSO login flow clear the marker when auth is
+ *   known to work again.
+ *
+ * Readers:
+ * - The unified `codemie hook` UserPromptSubmit gate blocks the prompt when
+ *   analytics auth is configured but known-broken, instructing the user to
+ *   re-authenticate via `codemie profile login`.
+ *
+ * All functions are best-effort and never throw: auth-status bookkeeping must
+ * never break metrics sending or hook processing.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { getCodemiePath } from './paths.js';
+import { logger } from './logger.js';
+
+export interface AnalyticsAuthStatus {
+  status: 'invalid';
+  /** Human-readable failure description (e.g. HTTP status or response shape) */
+  reason: string;
+  /** Metrics API base URL that rejected the credentials */
+  baseUrl: string;
+  /** Epoch millis when the failure was first detected */
+  detectedAt: number;
+}
+
+function getStatusPath(): string {
+  return getCodemiePath('analytics-auth-status.json');
+}
+
+/**
+ * Mark analytics authentication as invalid.
+ * Preserves the original detectedAt if a marker already exists.
+ */
+export async function markAnalyticsAuthInvalid(reason: string, baseUrl: string): Promise<void> {
+  try {
+    const existing = await getAnalyticsAuthStatus();
+    const status: AnalyticsAuthStatus = {
+      status: 'invalid',
+      reason,
+      baseUrl,
+      detectedAt: existing?.detectedAt ?? Date.now()
+    };
+    await writeFile(getStatusPath(), JSON.stringify(status, null, 2), 'utf-8');
+    logger.debug('[analytics-auth] Marked analytics auth as invalid:', { reason, baseUrl });
+  } catch (error) {
+    logger.debug('[analytics-auth] Failed to write auth status marker:', error);
+  }
+}
+
+/**
+ * Clear the invalid-auth marker (after successful login or successful send).
+ */
+export async function clearAnalyticsAuthStatus(): Promise<void> {
+  try {
+    const statusPath = getStatusPath();
+    if (!existsSync(statusPath)) {
+      return;
+    }
+    await unlink(statusPath);
+    logger.debug('[analytics-auth] Cleared analytics auth status marker');
+  } catch (error) {
+    logger.debug('[analytics-auth] Failed to clear auth status marker:', error);
+  }
+}
+
+/**
+ * Read the current auth status marker, or null when auth is not known-broken.
+ */
+export async function getAnalyticsAuthStatus(): Promise<AnalyticsAuthStatus | null> {
+  try {
+    const statusPath = getStatusPath();
+    if (!existsSync(statusPath)) {
+      return null;
+    }
+    const parsed = JSON.parse(await readFile(statusPath, 'utf-8')) as AnalyticsAuthStatus;
+    if (parsed?.status !== 'invalid') {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    logger.debug('[analytics-auth] Failed to read auth status marker:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Expired CodeMie SSO cookies caused the metrics endpoint (fronted by Keycloak) to answer POSTs with HTTP 200 + HTML login page instead of 401. Analytics auth failures were completely silent — sessions vanished from the metrics dashboard while local JSONL deltas looked healthy. This adds a three-layer auth status gate so broken analytics auth is detected and surfaced immediately.

## Changes
- `src/utils/analytics-auth-status.ts` (new): file-based marker recording metrics-endpoint credential rejections (`~/.codemie/analytics-auth-status.json`); best-effort, never throws
- `metrics-api-client.ts`: classify HTTP 401/403 and non-JSON HTML responses (Keycloak login page) as auth failures; write marker on rejection, clear on successful send
- `sso.auth.ts`: clear the marker on successful `codemie profile login`
- `hook.ts`: generic `UserPromptSubmit` gate (all agents via unified `codemie hook`) — blocks the prompt with `codemie profile login` instructions when analytics auth is missing or was server-rejected; active only when analytics sync is configured
- `AgentCLI.ts`: launch-time analytics auth check for non-SSO providers when analytics is enabled (`codeMieUrl` set); reuses SSO `validateAuth` (stored creds + live API test) with interactive re-auth prompt; non-fatal on decline; clears stale marker on success

## Impact
Before: expired analytics credentials → silent metrics loss for days (observed 08-12 → 08-14 locally; data recovered only after manual re-login + session resumes).
After: launch-time warning with re-auth prompt; hard block at prompt level with exact re-login command if still unresolved; marker cleared automatically by login or any successful send.

## Testing
- [ ] Tests added/updated
- [x] Manual testing done (typecheck, ESLint zero-warning, build, lint-staged + related vitest via pre-commit)

## Checklist
- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`