### PR TITLE
fix(proxy): default the Claude Desktop OAuth issuer when the backend omits it

### DIFF
--- a/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/desktop.test.ts
@@ -59,6 +59,15 @@ const OAUTH_CONFIG = {
   tokenUrl: 'https://auth.codemie.test/realms/codemie-prod/protocol/openid-connect/token',
 };
 
+// OAUTH_CONFIG mirrors a backend payload that predates `authorizationServer`,
+// so resolveDesktopOAuth fills the gap with its built-in CodeMie issuer. Every
+// expectation built from that fixture has to account for the injected default.
+const DEFAULT_ISSUER = ['https://auth.codemie.lab.epam.com/realms/codemie-prod'];
+
+function withDefaultIssuer<T extends object>(oauth: T): T & { authorizationServer: string[] } {
+  return { ...oauth, authorizationServer: DEFAULT_ISSUER };
+}
+
 describe('buildGatewayConfig', () => {
   it('returns correct gateway config shape', () => {
     expect(buildGatewayConfig('http://localhost:4001', 'codemie-proxy')).toEqual({
@@ -638,7 +647,7 @@ describe('writeDesktopConfig', () => {
     const written = JSON.parse(await readFile(configPath, 'utf-8'));
     const servers = JSON.parse(written.managedMcpServers);
     const onehub = servers.find((s: any) => s.name === 'onehub_core');
-    expect(onehub.oauth).toEqual({ ...OAUTH_CONFIG, audience: 'onehub' });
+    expect(onehub.oauth).toEqual(withDefaultIssuer({ ...OAUTH_CONFIG, audience: 'onehub' }));
   });
 
   it('writes oauth: true for a legacy auth enum entry', async () => {
@@ -1086,7 +1095,7 @@ describe('mapCanonicalToDesktop', () => {
         name: 'onehub_core',
         url: 'https://mcp.example.com/mcp/onehub_core',
         transport: 'http',
-        oauth: OAUTH_CONFIG,
+        oauth: withDefaultIssuer(OAUTH_CONFIG),
       },
     ]);
   });
@@ -1103,13 +1112,15 @@ describe('resolveDesktopOAuth', () => {
   it('forwards a valid oauth object as a copy', () => {
     const entry = { name: 'onehub_core', transport: 'http' as const, url: 'https://x', oauth: OAUTH_CONFIG };
     const resolved = resolveDesktopOAuth(entry);
-    expect(resolved).toEqual(OAUTH_CONFIG);
+    expect(resolved).toEqual(withDefaultIssuer(OAUTH_CONFIG));
     expect(resolved).not.toBe(OAUTH_CONFIG);
   });
 
   it('preserves unknown keys inside the oauth object', () => {
     const oauth = { ...OAUTH_CONFIG, audience: 'onehub', pkce: true };
-    expect(resolveDesktopOAuth({ name: 'a', transport: 'http', url: 'https://x', oauth })).toEqual(oauth);
+    expect(resolveDesktopOAuth({ name: 'a', transport: 'http', url: 'https://x', oauth })).toEqual(
+      withDefaultIssuer(oauth),
+    );
   });
 
   it('passes the boolean shapes through unchanged', () => {
@@ -1129,7 +1140,7 @@ describe('resolveDesktopOAuth', () => {
   it('prefers the oauth object over the legacy enum when both are present', () => {
     expect(resolveDesktopOAuth({
       name: 'a', transport: 'http', url: 'https://x', auth: 'none', oauth: OAUTH_CONFIG,
-    })).toEqual(OAUTH_CONFIG);
+    })).toEqual(withDefaultIssuer(OAUTH_CONFIG));
   });
 
   it('returns false when the entry carries neither field (unchanged behavior)', () => {

--- a/src/cli/commands/proxy/connectors/desktop.ts
+++ b/src/cli/commands/proxy/connectors/desktop.ts
@@ -290,14 +290,65 @@ function isValidMcpServerName(name: string): boolean {
 const DESKTOP_SUPPORTED_TRANSPORTS = new Set(['http', 'sse']);
 
 /**
+ * Issuer written into a structured oauth config that arrives without one.
+ *
+ * This is a deliberate, narrow exception to the courier rule stated throughout
+ * this module (the CLI forwards backend oauth values verbatim). Without an
+ * issuer, Desktop treats the config as "explicit" mode and fabricates one from
+ * the *origin* of `tokenUrl`, which can never equal a Keycloak realm issuer —
+ * so every flow dies with `Issuer mismatch in authorization response
+ * (RFC 9207)`. Forwarding a config we know Desktop cannot complete is worse
+ * than supplying the CodeMie default, and it mirrors DEFAULT_CODEMIE_BASE_URL:
+ * the CLI already ships a CodeMie endpoint as its built-in default.
+ *
+ * A backend that publishes `authorizationServer` always wins — this only fills
+ * the gap, and becomes dead weight once every deployment serves the field.
+ */
+const DEFAULT_AUTHORIZATION_SERVER: readonly string[] = [
+  'https://auth.codemie.lab.epam.com/realms/codemie-prod',
+];
+
+/**
+ * True when the value is an issuer list Desktop can actually use.
+ *
+ * Anything else — absent, null, a bare string, an empty array, or an array with
+ * a blank entry — counts as "not provided" and takes the default. Desktop reads
+ * this field as an array; a malformed value keeps it in explicit mode just as a
+ * missing one does, so treating the two alike is what makes the fallback
+ * effective rather than merely present.
+ */
+function hasUsableAuthorizationServer(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((issuer) => typeof issuer === 'string' && issuer.trim().length > 0)
+  );
+}
+
+/**
  * Normalize the three accepted auth shapes into what Claude Desktop consumes.
  *
  * Precedence: a valid oauth object wins, then the oauth boolean, then the
  * legacy `auth` enum, then `false`. The final fallback preserves the behavior
  * of entries carrying neither field.
+ *
+ * A structured oauth config additionally gains {@link DEFAULT_AUTHORIZATION_SERVER}
+ * when it carries no usable issuer. The boolean and legacy `auth` shapes are
+ * left alone: they tell Desktop to discover the server's own protected-resource
+ * metadata, so an injected issuer would override a working discovery path.
  */
 export function resolveDesktopOAuth(entry: CanonicalMcpEntry): McpOAuthConfig | boolean {
-  if (isValidOAuthConfig(entry.oauth)) return { ...entry.oauth };
+  if (isValidOAuthConfig(entry.oauth)) {
+    const oauth: McpOAuthConfig = { ...entry.oauth };
+    if (!hasUsableAuthorizationServer(oauth.authorizationServer)) {
+      // Fresh array per entry. Assigning the module constant itself would share
+      // one mutable array across every managed entry, and cloneManagedEntry's
+      // shallow oauth copy would not detach it — the same aliasing hazard that
+      // function exists to prevent.
+      oauth.authorizationServer = [...DEFAULT_AUTHORIZATION_SERVER];
+    }
+    return oauth;
+  }
   if (entry.oauth === true) return true;
   if (entry.oauth === false) return false;
   if (entry.auth === 'oauth') return true;

--- a/src/cli/commands/proxy/connectors/managed-mcp-remote.ts
+++ b/src/cli/commands/proxy/connectors/managed-mcp-remote.ts
@@ -23,6 +23,16 @@ export interface McpOAuthConfig {
   scope?: string;
   callbackHost?: string;
   callbackPort?: number;
+  /**
+   * RFC 9207 issuer identifier(s). Its presence is what switches Claude Desktop
+   * out of "explicit" OAuth mode — where Desktop fabricates the issuer from the
+   * *origin* of {@link tokenUrl}, discarding the path — into "issuer" mode,
+   * where it discovers real metadata from
+   * `<issuer>/.well-known/openid-configuration`. A Keycloak issuer is the realm
+   * URL, so the fabricated value never matches the `iss` returned on the
+   * callback and Desktop aborts the flow.
+   */
+  authorizationServer?: string[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Claude Desktop cannot complete OAuth against any CodeMie managed MCP server whose `oauth` block carries no `authorizationServer`. Desktop reads such a config as **"explicit" mode**: it skips discovery entirely and fabricates the authorization-server metadata by deriving `issuer` from the **origin** of `tokenUrl`, discarding the path. A Keycloak issuer is the realm URL, so the fabricated value can never match the `iss` returned on the callback, and every sign-in dies with `Issuer mismatch in authorization response (RFC 9207)`.

`resolveDesktopOAuth` now fills that gap with the CodeMie issuer when a structured config arrives without a usable one, which switches Desktop into **issuer mode** where it discovers real metadata from `<issuer>/.well-known/openid-configuration`.

The backend gained the same field in `codemie!4051` (merged), with the EPAM catalog following in `codemie!4052`. This PR is the client-side floor: it makes Desktop work *before* those roll out, and stays correct after, because a backend-published value always wins.

## Changes

- `desktop.ts` — `DEFAULT_AUTHORIZATION_SERVER` plus `hasUsableAuthorizationServer()`; `resolveDesktopOAuth` injects the default into a structured oauth config that has no usable issuer.
- `managed-mcp-remote.ts` — declare `authorizationServer?: string[]` on `McpOAuthConfig` (it already passed through via the index signature; this documents and type-checks it).
- `__tests__/desktop.test.ts` — five existing tests pinned the old forward-verbatim contract; a `withDefaultIssuer()` helper updates the expectations without touching the `OAUTH_CONFIG` fixture, so they still assert nothing else is dropped or rewritten.

Production change is 62 insertions / 1 deletion, most of it comments.

## Impact

**Before**: every EPAM managed MCP server failed to connect from Claude Desktop with an RFC 9207 issuer mismatch.
**After**: Desktop discovers real Keycloak metadata and completes the flow.

Three judgment calls reviewers should weigh:

- **Only the structured-object shape is touched.** `oauth: true` and the legacy `auth: 'oauth'` enum are left alone — those tell Desktop to discover the server's *own* protected-resource metadata, so an injected issuer would override a working discovery path. All seven bundled public defaults (Notion, Linear, Box, …) use the boolean form and are unaffected.
- **Malformed counts as absent.** A bare string, `[]`, or an array with a blank entry all take the default, since any of those leaves Desktop in explicit mode exactly as a missing field does.
- **This is a deliberate exception to the courier rule** stated throughout `desktop.ts` and `managed-mcp-remote.ts` ("the CLI is a courier, not a policy layer, so no oauth value is ever rewritten"). The code comment says so and names its own expiry: it becomes dead weight once every deployment serves the field. Forwarding a config we know Desktop cannot complete was judged worse than supplying a default, and it mirrors `DEFAULT_CODEMIE_BASE_URL` — the CLI already ships a CodeMie endpoint as a built-in default.

**Known limitation, accepted deliberately:** the default is a literal, not derived from the entry's own `tokenUrl`. For a non-EPAM on-prem CodeMie deployment whose backend does not yet publish `authorizationServer`, Desktop in issuer mode uses the *discovered* endpoints and ignores that tenant's own `authorizationUrl`/`tokenUrl`. Deploying the backend field is what retires this.

## Testing

- [x] Tests added/updated — five existing assertions updated to the new contract; no new test files
- [x] Manual testing done — `npx vitest run src/cli/commands/proxy`: **275 passed**, 13 files

Not covered by tests: the "a backend-published `authorizationServer` wins over the default" path. Per this repo's tests-on-request-only rule I did not add one; happy to if a reviewer wants it.

## Checklist

- [x] Code follows project standards — `npm run lint` (`--max-warnings=0`) clean, `npm run typecheck` clean, `npm run build` succeeds
- [x] **CRITICAL attribution check — not applicable.** The diff touches no `X-CodeMie-*` header, no Responses API `user` field, no JWT `sub`/`email` override, and no derivation source of any of them.
- [x] No secrets, no `console.log`, no generic `Error` — gitleaks clean on the commit
- [x] Architecture boundaries respected — change is confined to the proxy connector layer
- [ ] CI is green (`npm run ci`) — pending on this PR
- [ ] No merge conflicts with `main`

## Related

- `codemie!4051` — backend `authorization_server` model field (merged as `a909f0ec8`)
- `codemie!4052` — EPAM catalog populated with the field (open)
- EPMCDME-14305
