### PR TITLE
fix(agents): hide async hook console window on Windows

### DIFF
--- a/src/agents/plugins/codemie-code-hooks/__tests__/shell-hooks-source.test.ts
+++ b/src/agents/plugins/codemie-code-hooks/__tests__/shell-hooks-source.test.ts
@@ -90,6 +90,12 @@ beforeEach(() => {
 });
 
 describe('SHELL_HOOKS_PLUGIN_SOURCE', () => {
+  it('hides the console window for asynchronous hook commands', () => {
+    expect(SHELL_HOOKS_PLUGIN_SOURCE).toMatch(
+      /spawn\("sh",\s*\["-c", command\],[\s\S]*?windowsHide:\s*true/,
+    );
+  });
+
   it('exports an async factory returning flat dotted-key handlers', async () => {
     const hooks = await loadHooks(['UserPromptSubmit']);
 

--- a/src/agents/plugins/codemie-code-hooks/shell-hooks-source.ts
+++ b/src/agents/plugins/codemie-code-hooks/shell-hooks-source.ts
@@ -235,6 +235,7 @@ function execCommandAsync(
     env: { ...process.env, ...env },
     stdio: ["pipe", "ignore", "ignore"],
     detached: true,
+    windowsHide: true,
   });
   // A ChildProcess or stdin 'error' with no listener is an UNHANDLED error
   // event, which throws inside the host OpenCode process. Stop is configured


### PR DESCRIPTION
## Summary

Prevent asynchronous shell hooks from briefly opening a `sh.exe` console window on Windows.

## Motivation

`execCommandAsync()` starts asynchronous hook commands using a detached `sh` process. On Windows, `detached: true` does not suppress the console window created for the child process, causing `sh.exe` to briefly flash during normal `codemie-opencode` usage.

## Changes

* Add `windowsHide: true` to the `spawn()` options used by asynchronous shell hooks.
* Add regression coverage to ensure asynchronous hook processes continue to use the hidden-window option.

## Testing

* `npm run lint` — passed
* `npm run build` — passed
* `npm run commitlint:last` — passed
* Regression test for `windowsHide: true` — passed
* `npm run ci` — completed with 6 pre-existing failures in `shell-hooks-source.test.ts` on native Windows
* The same 6 tests also fail on the unmodified baseline, confirming they are unrelated to this change

## Breaking Changes

None.

## Related Issues

Fixes #494
