### PR TITLE
feat(proxy+analytics): capture and persist routing decisions from both LiteLLM and Switchyard routers

### DIFF
--- a/src/agents/core/BaseAgentAdapter.ts
+++ b/src/agents/core/BaseAgentAdapter.ts
@@ -1009,8 +1009,24 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       branch: branch || undefined,
       project: env.CODEMIE_PROJECT || undefined,
       syncApiUrl: env.CODEMIE_SYNC_API_URL || undefined,
-      syncCodeMieUrl: env.CODEMIE_URL || undefined
+      syncCodeMieUrl: env.CODEMIE_URL || undefined,
+      routing: this._resolveRouting(env, profileConfig),
     };
+  }
+
+  private _resolveRouting(
+    env: NodeJS.ProcessEnv,
+    profileConfig: import('../../env/types.js').CodeMieConfigOptions | undefined,
+  ): 'signal' | 'classifier' | undefined {
+    const ALLOWED = new Set(['signal', 'classifier']);
+    const raw = env.CODEMIE_ROUTING ?? profileConfig?.routing;
+    if (raw === undefined || raw === null || raw === '') return undefined;
+    const key = String(raw).trim().toLowerCase();
+    if (ALLOWED.has(key)) return key as 'signal' | 'classifier';
+    logger.warn(
+      `[BaseAgentAdapter] Invalid CODEMIE_ROUTING=${JSON.stringify(raw)}; allowed: signal, classifier`,
+    );
+    return undefined;
   }
 
   /**

--- a/src/cli/commands/analytics/cost/cost-enricher.ts
+++ b/src/cli/commands/analytics/cost/cost-enricher.ts
@@ -11,7 +11,7 @@
 import { readFile } from 'node:fs/promises';
 import type { RawSessionData } from '../data-loader.js';
 import type { ParsedSession, SessionAdapter } from '../../../../agents/core/session/BaseSessionAdapter.js';
-import type { SessionCost, SessionCostIndex, CostSummary, ModelCost, TokenUsage, CostSeriesPoint } from './types.js';
+import type { SessionCost, SessionCostIndex, CostSummary, ModelCost, TokenUsage, CostSeriesPoint, ModelTimelinePoint } from './types.js';
 import type { DispatchEventRaw } from './types.js';
 import { MAX_SERIES_POINTS } from './types.js';
 import { emptyUsage, addUsage, costBreakdown } from './cost-calculator.js';
@@ -176,6 +176,44 @@ export function buildCostSeries(records: UsageRecord[]): CostSeriesPoint[] {
     points.push({ t: useTs ? (r.ts as number) : i + 1, cost: Math.round(cumCost * 1e8) / 1e8, tokens: cumTokens });
   });
   return downsample(points);
+}
+
+/**
+ * Build a per-turn model-usage timeline from ordered usage records.
+ * Each point captures the actual model, per-turn cost, and token count.
+ * Returns [] when there are no records.
+ */
+export function buildModelTimeline(records: UsageRecord[]): ModelTimelinePoint[] {
+  if (!records.length) return [];
+  const useTs = records.every((r) => r.ts != null);
+  return records.map((r, i) => {
+    const model = normalizeModelName(r.model);
+    const price = lookupPrice(model);
+    const costUSD = price ? costBreakdown(r.usage, price).total : 0;
+    const point: ModelTimelinePoint = {
+      t: useTs ? (r.ts as number) : i + 1,
+      model,
+      costUSD: Math.round(costUSD * 1e8) / 1e8,
+      tokens: r.usage.total,
+    };
+    if (r.requestedModel != null) point.requestedModel = r.requestedModel;
+    if (r.capableModel != null) point.capableModel = r.capableModel;
+    if (r.routingTier != null) point.routingTier = r.routingTier;
+    if (r.routingConfidence != null) point.routingConfidence = r.routingConfidence;
+    if (r.routingSource != null) point.routingSource = r.routingSource;
+    if (r.signalScore != null) point.signalScore = r.signalScore;
+    if (r.signalConfidence != null) point.signalConfidence = r.signalConfidence;
+    if (r.signalSeverity != null) point.signalSeverity = r.signalSeverity;
+    if (r.signalSpinning != null) point.signalSpinning = r.signalSpinning;
+    if (r.signalExploring != null) point.signalExploring = r.signalExploring;
+    if (r.signalProductionIntensity != null) point.signalProductionIntensity = r.signalProductionIntensity;
+    if (r.judgePSolve != null) point.judgePSolve = r.judgePSolve;
+    if (r.judgeCrux != null) point.judgeCrux = r.judgeCrux;
+    if (r.judgePrimaryRule != null) point.judgePrimaryRule = r.judgePrimaryRule;
+    if (r.judgeCapabilityBoundary != null) point.judgeCapabilityBoundary = r.judgeCapabilityBoundary;
+    if (r.decisionSource != null) point.decisionSource = r.decisionSource;
+    return point;
+  });
 }
 
 /** Run async tasks with bounded concurrency (cap open file descriptors). */
@@ -360,6 +398,32 @@ export async function enrichCosts(
     const { cost, unpriced: u } = priceUsage(entry.sessionId, entry.hadLog, usageByModel);
     if (series.length) {
       cost.costSeries = series;
+    }
+    if (records.length) {
+      const timeline = buildModelTimeline(records);
+      if (timeline.length) cost.modelTimeline = timeline;
+      // Accumulate classifier (Switchyard routing LLM) cost and tokens from per-turn metadata.
+      let judgeCostUSD = 0;
+      let judgeInputTokens = 0;
+      let judgeOutputTokens = 0;
+      let judgeCachedTokens = 0;
+      let judgeCacheCreationTokens = 0;
+      for (const r of records) {
+        judgeCostUSD += r.judgeCostUSD ?? 0;
+        judgeInputTokens += r.judgeInputTokens ?? 0;
+        judgeOutputTokens += r.judgeOutputTokens ?? 0;
+        judgeCachedTokens += r.judgeCachedTokens ?? 0;
+        judgeCacheCreationTokens += r.judgeCacheCreationTokens ?? 0;
+      }
+      if (judgeInputTokens > 0 || judgeOutputTokens > 0 || judgeCostUSD > 0) {
+        cost.judgeCostUSD = Math.round(judgeCostUSD * 1e8) / 1e8;
+        cost.judgeInputTokens = judgeInputTokens;
+        cost.judgeOutputTokens = judgeOutputTokens;
+        if (judgeCachedTokens > 0) cost.judgeCachedTokens = judgeCachedTokens;
+        if (judgeCacheCreationTokens > 0) cost.judgeCacheCreationTokens = judgeCacheCreationTokens;
+        // Include routing cost in the session total.
+        cost.costUSD = Math.round((cost.costUSD + judgeCostUSD) * 1e8) / 1e8;
+      }
     }
     if (entry.parsed) {
       // Usage provenance from the adapter: lets the report distinguish "cost is genuinely

--- a/src/cli/commands/analytics/cost/cost-enricher.ts
+++ b/src/cli/commands/analytics/cost/cost-enricher.ts
@@ -198,7 +198,13 @@ export function buildModelTimeline(records: UsageRecord[]): ModelTimelinePoint[]
     };
     if (r.requestedModel != null) point.requestedModel = r.requestedModel;
     if (r.capableModel != null) point.capableModel = r.capableModel;
+    if (r.routingFamily != null) point.routingFamily = r.routingFamily;
     if (r.routingTier != null) point.routingTier = r.routingTier;
+    if (r.routingTierRaw != null) point.routingTierRaw = r.routingTierRaw;
+    if (r.routedModel != null) point.routedModel = r.routedModel;
+    if (r.classifierModel != null) point.classifierModel = r.classifierModel;
+    if (r.routerType != null) point.routerType = r.routerType;
+    if (r.routerScore != null) point.routerScore = r.routerScore;
     if (r.routingConfidence != null) point.routingConfidence = r.routingConfidence;
     if (r.routingSource != null) point.routingSource = r.routingSource;
     if (r.signalScore != null) point.signalScore = r.signalScore;
@@ -402,18 +408,29 @@ export async function enrichCosts(
     if (records.length) {
       const timeline = buildModelTimeline(records);
       if (timeline.length) cost.modelTimeline = timeline;
-      // Accumulate classifier (Switchyard routing LLM) cost and tokens from per-turn metadata.
+      // Accumulate classifier (routing LLM) cost and tokens from per-turn metadata.
       let judgeCostUSD = 0;
       let judgeInputTokens = 0;
       let judgeOutputTokens = 0;
       let judgeCachedTokens = 0;
       let judgeCacheCreationTokens = 0;
+      // A session is only "cost known" if every routed turn came from a family that reports
+      // cost. One LiteLLM turn makes the session total an understatement, not a measurement.
+      let routedTurns = 0;
+      let costKnownTurns = 0;
       for (const r of records) {
         judgeCostUSD += r.judgeCostUSD ?? 0;
         judgeInputTokens += r.judgeInputTokens ?? 0;
         judgeOutputTokens += r.judgeOutputTokens ?? 0;
         judgeCachedTokens += r.judgeCachedTokens ?? 0;
         judgeCacheCreationTokens += r.judgeCacheCreationTokens ?? 0;
+        if (r.routingFamily != null) {
+          routedTurns++;
+          if (r.routingCostKnown) costKnownTurns++;
+        }
+      }
+      if (routedTurns > 0) {
+        cost.routingCostKnown = costKnownTurns === routedTurns;
       }
       if (judgeInputTokens > 0 || judgeOutputTokens > 0 || judgeCostUSD > 0) {
         cost.judgeCostUSD = Math.round(judgeCostUSD * 1e8) / 1e8;

--- a/src/cli/commands/analytics/cost/types.ts
+++ b/src/cli/commands/analytics/cost/types.ts
@@ -38,7 +38,13 @@ export interface ModelTimelinePoint {
   tokens: number; // per-turn total tokens for this turn
   requestedModel?: string; // capable model that was originally requested
   capableModel?: string; // alias for requestedModel
+  routingFamily?: 'switchyard' | 'litellm'; // which header family carried the decision
   routingTier?: 'efficient' | 'capable' | string;
+  routingTierRaw?: string; // tier as emitted, before the two vocabularies are folded
+  routedModel?: string; // model the router actually dispatched to
+  classifierModel?: string; // LLM that made the routing decision
+  routerType?: string; // router strategy, e.g. 'complexity'
+  routerScore?: number; // numeric score from LiteLLM's heuristic scorer
   routingConfidence?: number;
   routingSource?: 'stage_router' | 'judge' | 'classifier' | string;
   decisionSource?: string;
@@ -89,12 +95,19 @@ export interface SessionCost {
   perModel: ModelCost[];
   priced: boolean; // true if the native log was found & parsed
   hadLog: boolean; // true if a native log path was located (priced<hadLog ⇒ parse/reader gap)
-  // === Switchyard routing classifier cost (additive to costUSD) ===
+  // === Routing classifier cost (additive to costUSD; Switchyard only — see routingCostKnown) ===
   judgeCostUSD?: number; // USD spent on the routing classifier LLM
   judgeInputTokens?: number;
   judgeOutputTokens?: number;
   judgeCachedTokens?: number;
   judgeCacheCreationTokens?: number;
+  /**
+   * True when every routed turn in this session used a header family that reports classifier
+   * cost (Switchyard). False when any routed turn used LiteLLM, which never reports cost —
+   * so `judgeCostUSD` stays absent even though a classifier ran. Absent when the session had
+   * no routed turns at all.
+   */
+  routingCostKnown?: boolean;
 
   // === Usage provenance (from ParsedSession.usageMeta) ===
   /**

--- a/src/cli/commands/analytics/cost/types.ts
+++ b/src/cli/commands/analytics/cost/types.ts
@@ -30,6 +30,30 @@ export interface CostSeriesPoint {
   tokens: number; // cumulative total tokens up to and including this turn
 }
 
+/** One point in the per-turn model/tier/decision timeline shown in the session modal. */
+export interface ModelTimelinePoint {
+  t: number; // epoch ms when all records are timed, else the 1-based turn ordinal
+  model: string; // normalized model name that was actually used
+  costUSD: number; // per-turn cost attributed to this model
+  tokens: number; // per-turn total tokens for this turn
+  requestedModel?: string; // capable model that was originally requested
+  capableModel?: string; // alias for requestedModel
+  routingTier?: 'efficient' | 'capable' | string;
+  routingConfidence?: number;
+  routingSource?: 'stage_router' | 'judge' | 'classifier' | string;
+  decisionSource?: string;
+  signalScore?: number;
+  signalConfidence?: number;
+  signalSeverity?: number;
+  signalSpinning?: number;
+  signalExploring?: number;
+  signalProductionIntensity?: number;
+  judgePSolve?: number;
+  judgeCrux?: string;
+  judgePrimaryRule?: string;
+  judgeCapabilityBoundary?: string;
+}
+
 /** Max points kept per session series — downsample guard so the embedded payload stays small. */
 export const MAX_SERIES_POINTS = 40;
 
@@ -60,10 +84,17 @@ export interface SessionCost {
   costUSD: number; // summed across models
   cacheReadCostUSD?: number; // USD attributable to cache reads (subset of costUSD); 0 when unpriced
   costSeries?: CostSeriesPoint[]; // per-turn cumulative cost/token growth; absent when no per-turn data
+  modelTimeline?: ModelTimelinePoint[]; // per-turn model + routing metadata; absent when no routing data
   dispatches?: DispatchEvent[]; // top-level agent/skill/command invocations with timing; absent when none
   perModel: ModelCost[];
   priced: boolean; // true if the native log was found & parsed
   hadLog: boolean; // true if a native log path was located (priced<hadLog ⇒ parse/reader gap)
+  // === Switchyard routing classifier cost (additive to costUSD) ===
+  judgeCostUSD?: number; // USD spent on the routing classifier LLM
+  judgeInputTokens?: number;
+  judgeOutputTokens?: number;
+  judgeCachedTokens?: number;
+  judgeCacheCreationTokens?: number;
 
   // === Usage provenance (from ParsedSession.usageMeta) ===
   /**

--- a/src/cli/commands/analytics/cost/usage-readers.ts
+++ b/src/cli/commands/analytics/cost/usage-readers.ts
@@ -51,6 +51,58 @@ interface ClaudeRawMessage {
   message?: {
     id?: string;
     model?: string;
+    /** Injected by the CodeMie proxy when Switchyard routing is active. */
+    x_codemie_requested_model?: string;
+    x_codemie_routing_tier?: 'efficient' | 'capable' | string;
+    x_codemie_routing_capable_model?: string;
+    /** Routing confidence score (0–1), normalised to P(capable needed), emitted by the proxy. */
+    x_codemie_routing_confidence?: string;
+    /** Full reasoning string — confidence extracted from it as fallback. */
+    x_codemie_routing_reason?: string;
+    /** Routing decision source: 'stage_router' (rule-based) or 'judge' (LLM-based). */
+    x_codemie_routing_source?: 'stage_router' | 'judge' | string;
+    /** Why Switchyard chose this tier: override | tests_passed | dimensions | ambiguous | llm-classifier | fall_open. */
+    x_codemie_routing_decision_source?: string;
+
+    /** LiteLLM Router headers (alternative routing metadata format). */
+    'x-litellm-router-tier'?: string;
+    'x-litellm-router-cause'?: string;
+    'x-litellm-router-routed-model'?: string;
+    'x-litellm-router-classifier-model'?: string;
+    'x-litellm-router-model-name'?: string;
+    'x-litellm-router-type'?: string;
+    'x-litellm-router-signals'?: string | string[];
+
+    /** Judge/classifier LLM call tokens and cost (present when LLM was invoked for this turn). */
+    x_codemie_routing_judge_input_tokens?: string;
+    x_codemie_routing_judge_output_tokens?: string;
+    x_codemie_routing_judge_cached_tokens?: string;
+    x_codemie_routing_judge_cache_creation_tokens?: string;
+    x_codemie_routing_judge_cost_usd?: string;
+    /** Alias for the classifier variant (future Switchyard builds). */
+    x_codemie_routing_classifier_input_tokens?: string;
+    x_codemie_routing_classifier_output_tokens?: string;
+    x_codemie_routing_classifier_cached_tokens?: string;
+    x_codemie_routing_classifier_cache_creation_tokens?: string;
+    x_codemie_routing_classifier_cost_usd?: string;
+    /** Judge/classifier P(solve) score. */
+    x_codemie_routing_judge_p_solve?: string;
+    x_codemie_routing_classifier_p_solve?: string;
+    /** Signal composite, confidence, and sub-scores. */
+    x_codemie_routing_signal_score?: string;
+    x_codemie_routing_signal_confidence?: string;
+    x_codemie_routing_signal_severity?: string;
+    x_codemie_routing_signal_spinning?: string;
+    x_codemie_routing_signal_exploring?: string;
+    x_codemie_routing_signal_production?: string;
+    x_codemie_routing_signal_production_intensity?: string;
+    /** Judge/classifier string metadata. */
+    x_codemie_routing_judge_crux?: string;
+    x_codemie_routing_judge_primary_rule?: string;
+    x_codemie_routing_judge_capability_boundary?: string;
+    x_codemie_routing_classifier_crux?: string;
+    x_codemie_routing_classifier_primary_rule?: string;
+    x_codemie_routing_classifier_capability_boundary?: string;
     usage?: {
       input_tokens?: number;
       output_tokens?: number;
@@ -72,6 +124,47 @@ export interface UsageRecord {
   ts: number | null;
   model: string;
   usage: TokenUsage;
+  /** The capable model that was originally requested, when Switchyard routed to an efficient model. */
+  requestedModel?: string;
+  capableModel?: string;
+  /** Switchyard routing tier for this turn: 'efficient' or 'capable'. */
+  routingTier?: 'efficient' | 'capable' | string;
+  /** Routing confidence score (0–1), normalised to P(capable needed). */
+  routingConfidence?: number;
+  /** Routing decision source: 'stage_router' (rule-based) or 'judge'/'classifier' (LLM-based). */
+  routingSource?: 'stage_router' | 'judge' | 'classifier' | string;
+  /** Why Switchyard chose this tier: override | tests_passed | dimensions | ambiguous | llm-classifier | fall_open. */
+  decisionSource?: string;
+  /** Classifier LLM call input tokens for this turn (present when classifier was invoked). */
+  judgeInputTokens?: number;
+  /** Classifier LLM call output tokens for this turn. */
+  judgeOutputTokens?: number;
+  /** Classifier LLM call cached input tokens for this turn. */
+  judgeCachedTokens?: number;
+  /** Classifier LLM call cache-creation tokens for this turn. */
+  judgeCacheCreationTokens?: number;
+  /** Classifier LLM call cost in USD for this turn. */
+  judgeCostUSD?: number;
+  /** Raw signal composite score (-1 to +1). Present when scorer ran (includes classifier turns). */
+  signalScore?: number;
+  /** Scorer's own confidence in [0, 1]. Present when scorer ran (includes classifier turns). */
+  signalConfidence?: number;
+  /** Severity sub-score from Switchyard signal. */
+  signalSeverity?: number;
+  /** Spinning sub-score from Switchyard signal. Present when non-zero. */
+  signalSpinning?: number;
+  /** Exploring sub-score from Switchyard signal. Present when non-zero. */
+  signalExploring?: number;
+  /** Production intensity sub-score from Switchyard signal. Present when non-zero. */
+  signalProductionIntensity?: number;
+  /** Raw classifier P(efficient sufficient) before inversion. Present when classifier decided. */
+  judgePSolve?: number;
+  /** Classifier's description of the task crux. Present when classifier decided. */
+  judgeCrux?: string;
+  /** Primary routing rule the classifier applied. Present when classifier decided. */
+  judgePrimaryRule?: string;
+  /** Capability boundary the classifier identified. Present when classifier decided. */
+  judgeCapabilityBoundary?: string;
 }
 
 function usageWeight(usage: TokenUsage): number {
@@ -138,6 +231,41 @@ function takeUnseenRecords(records: UsageRecord[], seen: Set<string>): UsageReco
   return out;
 }
 
+function normalizeRoutingTier(raw: string | undefined): string | undefined {
+  if (raw == null) return undefined;
+  const key = String(raw).trim().toLowerCase();
+  const map: Record<string, string> = {
+    'simple': 'simple',
+    'efficient': 'middle',
+    'medium': 'middle',
+    'capable': 'complex',
+    'complex': 'complex',
+    'reasoning': 'reasoning',
+  };
+  return map[key] ?? key;
+}
+
+function normalizeDecisionSource(raw: string | undefined): string | undefined {
+  if (raw == null) return undefined;
+  return String(raw).trim().toLowerCase().replace(/_/g, '-');
+}
+
+function parseLitellmSignals(raw: string | string[] | undefined): { decisionSource?: string; routingTier?: string } {
+  if (raw == null) return {};
+  const arr = Array.isArray(raw) ? raw : [raw];
+  for (const item of arr) {
+    const str = String(item).trim();
+    const m = str.match(/^([^:]+):(.+)$/);
+    if (m) {
+      return {
+        decisionSource: normalizeDecisionSource(m[1]),
+        routingTier: normalizeRoutingTier(m[2]),
+      };
+    }
+  }
+  return {};
+}
+
 /**
  * Extract one {@link UsageRecord} per Claude assistant message (skipping `<synthetic>`),
  * across the main transcript AND every sub-agent transcript in `parsed.subagents`.
@@ -171,11 +299,89 @@ export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] 
       const key = id || reqId ? `${id ?? ''}::${reqId ?? ''}` : null;
       const parsedTs = raw.timestamp ? Date.parse(raw.timestamp) : NaN;
       const ts = Number.isFinite(parsedTs) ? parsedTs : null;
+
+      // Switchyard / LiteLLM routing metadata from proxy response headers (stored by Claude Code in message metadata).
+      const msg = raw.message;
+      const codemieTier = normalizeRoutingTier(msg?.x_codemie_routing_tier);
+      const litellmTier = normalizeRoutingTier(msg?.['x-litellm-router-tier']);
+      const signals = parseLitellmSignals(msg?.['x-litellm-router-signals']);
+      const codemieDecisionSource = normalizeDecisionSource(msg?.x_codemie_routing_decision_source);
+      const litellmCause = normalizeDecisionSource(msg?.['x-litellm-router-cause']);
+
+      const requestedModel = msg?.x_codemie_requested_model;
+      const capableModel = msg?.x_codemie_routing_capable_model;
+      const routingTier = codemieTier ?? litellmTier ?? signals.routingTier;
+      const decisionSource = codemieDecisionSource ?? litellmCause ?? signals.decisionSource;
+      const routingSource = msg?.x_codemie_routing_source ?? (decisionSource === 'llm-classifier' ? 'judge' : (decisionSource != null ? 'stage_router' : undefined));
+      const rawConfidence = msg?.x_codemie_routing_confidence;
+      const routingConfidence: number | undefined = (() => {
+        if (rawConfidence != null) {
+          const v = parseFloat(rawConfidence);
+          return Number.isNaN(v) ? undefined : v;
+        }
+        // Fallback: extract from routing_reason string ("confidence 0.462")
+        const reason = raw.message?.x_codemie_routing_reason;
+        if (reason != null) {
+          const m = /confidence\s+([\d.]+)/i.exec(reason);
+          if (m) {
+            const v = parseFloat(m[1]);
+            return Number.isNaN(v) ? undefined : v;
+          }
+        }
+        return undefined;
+      })();
+      const parseOptInt = (s: string | undefined): number | undefined => {
+        if (s == null) return undefined;
+        const v = parseInt(s, 10);
+        return Number.isNaN(v) ? undefined : v;
+      };
+      const parseOptFloat = (s: string | undefined): number | undefined => {
+        if (s == null) return undefined;
+        const v = parseFloat(s);
+        return Number.isNaN(v) ? undefined : v;
+      };
+      const judgeInputTokens = parseOptInt(raw.message?.x_codemie_routing_judge_input_tokens ?? raw.message?.x_codemie_routing_classifier_input_tokens);
+      const judgeOutputTokens = parseOptInt(raw.message?.x_codemie_routing_judge_output_tokens ?? raw.message?.x_codemie_routing_classifier_output_tokens);
+      const judgeCachedTokens = parseOptInt(raw.message?.x_codemie_routing_judge_cached_tokens ?? raw.message?.x_codemie_routing_classifier_cached_tokens);
+      const judgeCacheCreationTokens = parseOptInt(raw.message?.x_codemie_routing_judge_cache_creation_tokens ?? raw.message?.x_codemie_routing_classifier_cache_creation_tokens);
+      const judgeCostUSD = parseOptFloat(raw.message?.x_codemie_routing_judge_cost_usd ?? raw.message?.x_codemie_routing_classifier_cost_usd);
+      const judgePSolve = parseOptFloat(raw.message?.x_codemie_routing_judge_p_solve ?? raw.message?.x_codemie_routing_classifier_p_solve);
+      const signalScore = parseOptFloat(raw.message?.x_codemie_routing_signal_score);
+      const signalConfidence = parseOptFloat(raw.message?.x_codemie_routing_signal_confidence);
+      const signalSeverity = parseOptFloat(raw.message?.x_codemie_routing_signal_severity);
+      const signalSpinning = parseOptFloat(raw.message?.x_codemie_routing_signal_spinning);
+      const signalExploring = parseOptFloat(raw.message?.x_codemie_routing_signal_exploring);
+      const signalProductionIntensity = parseOptFloat(raw.message?.x_codemie_routing_signal_production ?? raw.message?.x_codemie_routing_signal_production_intensity);
+      const judgeCrux = raw.message?.x_codemie_routing_judge_crux ?? raw.message?.x_codemie_routing_classifier_crux;
+      const judgePrimaryRule = raw.message?.x_codemie_routing_judge_primary_rule ?? raw.message?.x_codemie_routing_classifier_primary_rule;
+      const judgeCapabilityBoundary = raw.message?.x_codemie_routing_judge_capability_boundary ?? raw.message?.x_codemie_routing_classifier_capability_boundary;
+
       appendDedupedRecord(records, keyedRecords, {
         key,
         ts,
         model,
         usage: { input, output, cacheRead, cacheCreation, cacheCreation1h, total: input + output + cacheRead + cacheCreation },
+        ...(requestedModel != null && { requestedModel }),
+        ...(routingTier != null && { routingTier }),
+        ...(capableModel != null && { capableModel }),
+        ...(routingConfidence != null && { routingConfidence }),
+        ...(routingSource != null && { routingSource }),
+        ...(decisionSource != null && { decisionSource }),
+        ...(judgeInputTokens != null && { judgeInputTokens }),
+        ...(judgeOutputTokens != null && { judgeOutputTokens }),
+        ...(judgeCachedTokens != null && { judgeCachedTokens }),
+        ...(judgeCacheCreationTokens != null && { judgeCacheCreationTokens }),
+        ...(judgeCostUSD != null && { judgeCostUSD }),
+        ...(judgePSolve != null && { judgePSolve }),
+        ...(signalScore != null && { signalScore }),
+        ...(signalConfidence != null && { signalConfidence }),
+        ...(signalSeverity != null && { signalSeverity }),
+        ...(signalSpinning != null && { signalSpinning }),
+        ...(signalExploring != null && { signalExploring }),
+        ...(signalProductionIntensity != null && { signalProductionIntensity }),
+        ...(judgeCrux != null && { judgeCrux }),
+        ...(judgePrimaryRule != null && { judgePrimaryRule }),
+        ...(judgeCapabilityBoundary != null && { judgeCapabilityBoundary }),
       });
     }
   }

--- a/src/cli/commands/analytics/cost/usage-readers.ts
+++ b/src/cli/commands/analytics/cost/usage-readers.ts
@@ -64,7 +64,13 @@ interface ClaudeRawMessage {
     /** Why Switchyard chose this tier: override | tests_passed | dimensions | ambiguous | llm-classifier | fall_open. */
     x_codemie_routing_decision_source?: string;
 
-    /** LiteLLM Router headers (alternative routing metadata format). */
+    /**
+     * LiteLLM Router headers (alternative routing metadata format).
+     * Mutually exclusive with the `x_codemie_routing_*` family: a deployment routes
+     * through either Switchyard or the LiteLLM router, never both. Unlike Switchyard,
+     * this family reports no classifier token counts or cost, so routing overhead is
+     * unmeasurable on LiteLLM deployments (see `routingCostKnown` on UsageRecord).
+     */
     'x-litellm-router-tier'?: string;
     'x-litellm-router-cause'?: string;
     'x-litellm-router-routed-model'?: string;
@@ -72,6 +78,10 @@ interface ClaudeRawMessage {
     'x-litellm-router-model-name'?: string;
     'x-litellm-router-type'?: string;
     'x-litellm-router-signals'?: string | string[];
+    /** Numeric complexity score from the heuristic scorer; absent on llm_classifier turns. */
+    'x-litellm-router-score'?: string;
+    /** Upstream deployment the router actually dispatched to (provider-qualified). */
+    'x-litellm-model-name'?: string;
 
     /** Judge/classifier LLM call tokens and cost (present when LLM was invoked for this turn). */
     x_codemie_routing_judge_input_tokens?: string;
@@ -124,9 +134,31 @@ export interface UsageRecord {
   ts: number | null;
   model: string;
   usage: TokenUsage;
-  /** The capable model that was originally requested, when Switchyard routed to an efficient model. */
+  /** The capable model that was originally requested, when routing selected a cheaper model. */
   requestedModel?: string;
   capableModel?: string;
+  /**
+   * Which header family carried this turn's routing decision. Lets consumers tell a
+   * genuinely-zero routing cost (Switchyard, `judgeCostUSD: 0`) apart from an
+   * unmeasurable one (LiteLLM, which reports no classifier cost at all).
+   */
+  routingFamily?: 'switchyard' | 'litellm';
+  /** Raw tier string as emitted, before {@link normalizeRoutingTier} folds the two vocabularies. */
+  routingTierRaw?: string;
+  /** Model the router actually dispatched to, when the family names it separately. */
+  routedModel?: string;
+  /** The LLM used to make the routing decision (LiteLLM: `router-classifier-model`). */
+  classifierModel?: string;
+  /** Router strategy, e.g. 'complexity' (LiteLLM: `router-type`). */
+  routerType?: string;
+  /** Numeric complexity score from LiteLLM's heuristic scorer; absent on classifier turns. */
+  routerScore?: number;
+  /**
+   * True when the family reports classifier cost (Switchyard), so `judgeCostUSD == null`
+   * means "no classifier ran". False on LiteLLM, where cost is never reported and absence
+   * carries no information.
+   */
+  routingCostKnown?: boolean;
   /** Switchyard routing tier for this turn: 'efficient' or 'capable'. */
   routingTier?: 'efficient' | 'capable' | string;
   /** Routing confidence score (0–1), normalised to P(capable needed). */
@@ -231,6 +263,18 @@ function takeUnseenRecords(records: UsageRecord[], seen: Set<string>): UsageReco
   return out;
 }
 
+function parseOptInt(s: string | undefined): number | undefined {
+  if (s == null) return undefined;
+  const v = parseInt(s, 10);
+  return Number.isNaN(v) ? undefined : v;
+}
+
+function parseOptFloat(s: string | undefined): number | undefined {
+  if (s == null) return undefined;
+  const v = parseFloat(s);
+  return Number.isNaN(v) ? undefined : v;
+}
+
 function normalizeRoutingTier(raw: string | undefined): string | undefined {
   if (raw == null) return undefined;
   const key = String(raw).trim().toLowerCase();
@@ -308,11 +352,24 @@ export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] 
       const codemieDecisionSource = normalizeDecisionSource(msg?.x_codemie_routing_decision_source);
       const litellmCause = normalizeDecisionSource(msg?.['x-litellm-router-cause']);
 
-      const requestedModel = msg?.x_codemie_requested_model;
+      // Discriminate between the two routing header families so consumers know if routing cost is known.
+      const routingFamily: 'switchyard' | 'litellm' | undefined =
+        codemieTier != null || msg?.x_codemie_routing_source != null
+          ? 'switchyard'
+          : litellmTier != null || litellmCause != null
+            ? 'litellm'
+            : undefined;
+
+      const requestedModel = msg?.x_codemie_requested_model ?? msg?.['x-litellm-router-model-name'];
       const capableModel = msg?.x_codemie_routing_capable_model;
       const routingTier = codemieTier ?? litellmTier ?? signals.routingTier;
+      const routingTierRaw = msg?.x_codemie_routing_tier ?? msg?.['x-litellm-router-tier'];
       const decisionSource = codemieDecisionSource ?? litellmCause ?? signals.decisionSource;
       const routingSource = msg?.x_codemie_routing_source ?? (decisionSource === 'llm-classifier' ? 'judge' : (decisionSource != null ? 'stage_router' : undefined));
+      const routedModel = msg?.x_codemie_routing_capable_model ?? msg?.['x-litellm-router-routed-model'];
+      const classifierModel = msg?.['x-litellm-router-classifier-model'];
+      const routerType = msg?.['x-litellm-router-type'];
+      const routerScore = parseOptFloat(msg?.['x-litellm-router-score']);
       const rawConfidence = msg?.x_codemie_routing_confidence;
       const routingConfidence: number | undefined = (() => {
         if (rawConfidence != null) {
@@ -330,16 +387,6 @@ export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] 
         }
         return undefined;
       })();
-      const parseOptInt = (s: string | undefined): number | undefined => {
-        if (s == null) return undefined;
-        const v = parseInt(s, 10);
-        return Number.isNaN(v) ? undefined : v;
-      };
-      const parseOptFloat = (s: string | undefined): number | undefined => {
-        if (s == null) return undefined;
-        const v = parseFloat(s);
-        return Number.isNaN(v) ? undefined : v;
-      };
       const judgeInputTokens = parseOptInt(raw.message?.x_codemie_routing_judge_input_tokens ?? raw.message?.x_codemie_routing_classifier_input_tokens);
       const judgeOutputTokens = parseOptInt(raw.message?.x_codemie_routing_judge_output_tokens ?? raw.message?.x_codemie_routing_classifier_output_tokens);
       const judgeCachedTokens = parseOptInt(raw.message?.x_codemie_routing_judge_cached_tokens ?? raw.message?.x_codemie_routing_classifier_cached_tokens);
@@ -356,17 +403,27 @@ export function extractClaudeUsageRecords(parsed: ParsedSession): UsageRecord[] 
       const judgePrimaryRule = raw.message?.x_codemie_routing_judge_primary_rule ?? raw.message?.x_codemie_routing_classifier_primary_rule;
       const judgeCapabilityBoundary = raw.message?.x_codemie_routing_judge_capability_boundary ?? raw.message?.x_codemie_routing_classifier_capability_boundary;
 
+
       appendDedupedRecord(records, keyedRecords, {
         key,
         ts,
         model,
         usage: { input, output, cacheRead, cacheCreation, cacheCreation1h, total: input + output + cacheRead + cacheCreation },
         ...(requestedModel != null && { requestedModel }),
+        ...(routingFamily != null && { routingFamily }),
         ...(routingTier != null && { routingTier }),
+        ...(routingTierRaw != null && { routingTierRaw }),
         ...(capableModel != null && { capableModel }),
+        ...(routedModel != null && { routedModel }),
+        ...(classifierModel != null && { classifierModel }),
+        ...(routerType != null && { routerType }),
+        ...(routerScore != null && { routerScore }),
         ...(routingConfidence != null && { routingConfidence }),
         ...(routingSource != null && { routingSource }),
         ...(decisionSource != null && { decisionSource }),
+        // Switchyard reports classifier cost explicitly (possibly $0); LiteLLM never reports it at
+        // all. Record which is which so a session total doesn't read a LiteLLM "unmeasured" as "free".
+        ...(routingFamily != null && { routingCostKnown: routingFamily === 'switchyard' }),
         ...(judgeInputTokens != null && { judgeInputTokens }),
         ...(judgeOutputTokens != null && { judgeOutputTokens }),
         ...(judgeCachedTokens != null && { judgeCachedTokens }),

--- a/src/cli/commands/analytics/report/client/app.js
+++ b/src/cli/commands/analytics/report/client/app.js
@@ -55,8 +55,8 @@
   }
   function esc(s) { return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]; }); }
   function shortPath(p) { var parts = String(p || '').split('/'); return parts[parts.length - 1] || p; }
-  // Human-readable session label: the cleaned first-prompt title, falling back to a short id.
-  function sessTitle(s) { return (s && s.title && s.title.trim()) ? s.title.trim() : ('#' + String((s && s.sessionId) || '').slice(0, 8)); }
+  // Human-readable session label: AI-generated name when available, else cleaned first-prompt title, else short id.
+  function sessTitle(s) { if (s && s.sessionName && s.sessionName.trim()) return s.sessionName.trim(); var t = (s && s.title && s.title.trim()) ? s.title.trim() : ''; if (t && t.charAt(0) === '/') { var m = t.match(/^\/\S+\s+([\s\S]+)/); if (m) t = m[1].trim(); } return t || ('#' + String((s && s.sessionId) || '').slice(0, 8)); }
   function truncStr(s, n) { s = String(s == null ? '' : s); return s.length > n ? s.slice(0, n - 1) + '…' : s; }
   // First n whitespace-delimited words (the "starting message" preview), '…' when truncated.
   function firstWords(s, n) { s = String(s == null ? '' : s).trim(); var w = s.split(/\s+/); return w.length > n ? w.slice(0, n).join(' ') + '…' : s; }
@@ -732,6 +732,24 @@
     });
     host.appendChild(grid);
 
+    // Routing KPI section — only shown when at least one session has judge routing cost.
+    var routedSessions = fs.filter(function (s) { return s.judgeCostUSD != null && s.judgeCostUSD > 0; });
+    if (routedSessions.length > 0) {
+      host.appendChild(el('h3', 'section-title', 'Routing'));
+      var rsGrid = el('div', 'kpi-grid'); rsGrid.style.gridTemplateColumns = 'repeat(3,1fr)';
+      var totalJudgeCost = sum(routedSessions, function (s) { return s.judgeCostUSD || 0; });
+      var totalJudgeIn = routedSessions.reduce(function (acc, s) { return acc + (s.judgeInputTokens || 0); }, 0);
+      var totalJudgeOut = routedSessions.reduce(function (acc, s) { return acc + (s.judgeOutputTokens || 0); }, 0);
+      [
+        ['Sessions with routing', fmtNum(routedSessions.length) + ' / ' + fmtNum(fs.length)],
+        ['Judge routing cost', fmtUSD(totalJudgeCost)],
+        ['Judge tokens (in/out)', fmtTokens(totalJudgeIn) + ' / ' + fmtTokens(totalJudgeOut)]
+      ].forEach(function (k) {
+        var c = el('div', 'kpi'); c.innerHTML = '<div class="kpi-label">' + k[0] + '</div><div class="kpi-value">' + k[1] + '</div>'; rsGrid.appendChild(c);
+      });
+      host.appendChild(rsGrid);
+    }
+
     // per-agent coverage — answers "which tools' metrics are included?"
     var cov = DATA.meta.coverage || [];
     if (cov.length) {
@@ -778,14 +796,15 @@
     var top = fs.slice().sort(function (a, b) { return b.costUSD - a.costUSD; }).slice(0, 10);
     topCard._body.style.paddingTop = '0';
     topCard._body.innerHTML = '<div class="table-wrapper">' + tableHTML(
-      ['Session', 'Agent', 'Project', 'Input', 'Output', 'Cached', 'Total', 'Cost'],
+      ['Session', 'Name', 'Agent', 'Project', 'Input', 'Output', 'Cached', 'Total', 'Cost'],
       top.map(function (s) {
         return [esc(s.sessionId.slice(0, 8)),
+          esc(sessTitle(s)),
           '<span class="tag tag-sm"' + (AGENT_LABELS[s.agentName] ? '' : ' style="text-transform:capitalize"') + '>' + esc(labelFor(s.agentName)) + '</span>',
           '<span title="' + esc(s.project) + '">' + esc(shortPath(s.project)) + '</span>',
           fmtTokens(tkIn(s)), fmtTokens(tkOut(s)), fmtTokens(tkCached(s)), fmtTokens(s.tokens ? s.tokens.total : 0), fmtUSD(s.costUSD)];
       }),
-      [false, false, false, true, true, true, true, true]) + '</div>';
+      [false, false, false, false, true, true, true, true, true]) + '</div>';
     host.appendChild(topCard);
   };
 
@@ -808,22 +827,23 @@
       var list = fs.slice().sort(function (a, b) { return b.startTime - a.startTime; });
       if (q) {
         var ql = q.toLowerCase();
-        list = list.filter(function (s) { return (s.sessionId + ' ' + s.agentName + ' ' + labelFor(s.agentName) + ' ' + s.project + ' ' + s.branch + ' ' + (s.title || '') + ' ' + (s.sessionSource || '')).toLowerCase().indexOf(ql) >= 0; });
+        list = list.filter(function (s) { return (s.sessionId + ' ' + s.agentName + ' ' + labelFor(s.agentName) + ' ' + s.project + ' ' + s.branch + ' ' + (s.sessionName || '') + ' ' + (s.title || '') + ' ' + (s.sessionSource || '')).toLowerCase().indexOf(ql) >= 0; });
       }
       var shown = list.slice(0, 300);
       holder.innerHTML = tableHTML(
-        ['Date', 'Prompt', 'Agent', 'Project', 'Branch', 'Source', 'Turns', 'Net lines', 'Input', 'Output', 'Cached', 'Cost'],
+        ['Date', 'Name / Prompt', 'Agent', 'Project', 'Branch', 'Source', 'Turns', 'Routed %', 'Net lines', 'Input', 'Output', 'Cached', 'Cost'],
         shown.map(function (s) {
           var branchCell = s.branch ? '<span title="' + esc(s.branch) + '" style="max-width:90px;display:inline-block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">' + esc(s.branch) + '</span>' : '—';
-          var promptCell = '<span title="' + esc(s.title || '') + '" style="max-width:280px;display:inline-block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle;color:var(--color-text-muted);font-size:12px">' + esc(truncStr(s.title || '—', 80)) + '</span>';
+          var sessionLabel = s.sessionName || s.title || '';
+          var promptCell = '<span title="' + esc(sessionLabel) + '" style="max-width:280px;display:inline-block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle;color:var(--color-text-muted);font-size:12px">' + esc(truncStr(sessionLabel || '—', 80)) + '</span>';
           var sourceCell = '<span class="tag tag-sm">' + esc(s.sessionSource || 'Pure chat') + '</span>';
           return [new Date(s.startTime).toISOString().slice(0, 16).replace('T', ' '),
             promptCell,
             '<span class="tag tag-sm"' + (AGENT_LABELS[s.agentName] ? '' : ' style="text-transform:capitalize"') + '>' + esc(labelFor(s.agentName)) + '</span>',
             '<span title="' + esc(s.project) + '">' + esc(shortPath(s.project)) + '</span>', branchCell, sourceCell,
-            fmtNum(s.turns), fmtNum(s.netLines), fmtTokens(tkIn(s)), fmtTokens(tkOut(s)), fmtTokens(tkCached(s)), fmtUSD(s.costUSD)];
+            fmtNum(s.turns), s.routedTurnsPct != null ? s.routedTurnsPct + '%' : '—', fmtNum(s.netLines), fmtTokens(tkIn(s)), fmtTokens(tkOut(s)), fmtTokens(tkCached(s)), fmtUSD(s.costUSD)];
         }),
-        [false, false, false, false, false, false, true, true, true, true, true, true],
+        [false, false, false, false, false, false, true, true, true, true, true, true, true],
         shown.map(function (s) { return 'class="clickable" data-session="' + esc(s.sessionId) + '"'; }));
       if (list.length > 300) holder.appendChild(el('p', 'text-muted', '<span style="font-size:12px">Showing first 300 of ' + list.length + '.</span>'));
     }
@@ -1135,6 +1155,9 @@
       ['Duration', fmtDuration(s.durationMs || 0), ''],
       ['Started', '<span class="mval-sm">' + esc(fmtWhen(s.startTime)) + '</span>', '']
     ];
+    if (s.judgeCostUSD != null) {
+      costRows.push(['Routing (judge)', fmtUSD(s.judgeCostUSD), 'included in cost']);
+    }
     if (s.premiumRequests !== undefined) {
       costRows.push(['Premium requests', fmtNum(s.premiumRequests), 'provider billing unit']);
     }
@@ -1144,11 +1167,15 @@
     } else if (s.usagePartial) {
       costCard._body.appendChild(el('div', 'text-muted', '<span style="font-size:12px">Partial usage — output tokens only; this session recorded no full rollup, so cost is understated.</span>'));
     }
-    var tokCard = card('Token usage'); tokCard._body.appendChild(statsEl([
+    var tokRows = [
       ['Input', fmtTokens(t.input), ''], ['Output', fmtTokens(t.output), ''],
       ['Cache read', fmtTokens(t.cacheRead), ''], ['Cache create', fmtTokens(t.cacheCreation), ''],
       ['Total', fmtTokens(t.total), '']
-    ]));
+    ];
+    if (s.judgeInputTokens != null || s.judgeOutputTokens != null) {
+      tokRows.push(['Judge tokens', fmtTokens(s.judgeInputTokens || 0) + ' / ' + fmtTokens(s.judgeOutputTokens || 0), 'routing LLM']);
+    }
+    var tokCard = card('Token usage'); tokCard._body.appendChild(statsEl(tokRows));
     var actCard = card('Activity'); actCard._body.appendChild(statsEl([
       ['Turns / API', fmtNum(s.turns), ''],
       ['Tool calls', fmtNum(s.toolCallsTotal), (s.toolCallsTotal ? Math.round((s.toolCallsSuccess / s.toolCallsTotal) * 100) + '% ok' : '')],
@@ -1191,6 +1218,198 @@
       growth._body.appendChild(el('div', 'empty', 'Per-turn data not available for this session.'));
     }
     body.appendChild(growth);
+
+    // Model routing decisions chart — bar height = P(capable needed), colour = who decided.
+    // Old sessions that store routingConfidence but no explicit source are labelled 'scorer'.
+    var timeline = s.modelTimeline || [];
+    var tlHasRouting = timeline.some(function (p) { return p.routingTier != null || p.routingConfidence != null; });
+    if (timeline.length >= 2 && tlHasRouting && window.Chart) {
+      var DS_COLORS = {
+        'override': '#EF4444',
+        'tests-passed': '#10B981',
+        'dimensions': '#3B82F6',
+        'ambiguous': '#9CA3AF',
+        'llm-classifier': '#7C5CFC',
+        'fall-open': '#F5A534',
+      };
+      function inferDecisionSource(p) {
+        if (p.decisionSource) return p.decisionSource;
+        if (p.routingSource === 'judge' || p.routingSource === 'classifier') return 'llm-classifier';
+        if (p.routingSource === 'stage_router') {
+          if (p.signalSeverity != null && p.signalSeverity >= 1.0) return 'override';
+          var score = p.signalScore;
+          if (score != null) {
+            var confidence = Math.abs(score);
+            if (confidence >= 0.5) return 'dimensions';
+            if (p.routingTier === 'efficient') return 'tests_passed';
+            return 'ambiguous';
+          }
+        }
+        // Old sessions: has confidence but no explicit source → label as scorer
+        if (p.routingConfidence != null) return 'dimensions';
+        return null;
+      }
+      function tlDsColor(p) { var ds = inferDecisionSource(p); return DS_COLORS[ds] || '#9CA3AF'; }
+      var useEpoch = timeline[0].t > 1e12;
+      var t0tl = timeline[0].t;
+      var tlLabels = timeline.map(function (p, i) { return useEpoch ? fmtDuration(Math.max(0, p.t - t0tl)) : ('turn ' + (i + 1)); });
+      var tierCounts = timeline.reduce(function (acc, p) {
+        if (p.routingTier === 'simple' || p.routingTier === 'middle' || p.routingTier === 'complex' || p.routingTier === 'reasoning') {
+          acc.total++;
+          if (p.routingTier === 'simple' || p.routingTier === 'middle') acc.simpleOrMiddle++;
+        }
+        return acc;
+      }, { total: 0, simpleOrMiddle: 0 });
+      var tierSubtitle = '';
+      if (tierCounts.total > 0) {
+        var simplePct = Math.round((tierCounts.simpleOrMiddle / tierCounts.total) * 100);
+        tierSubtitle = simplePct + '% simple/middle · ' + (100 - simplePct) + '% complex/reasoning';
+      }
+      var tlCard = card('Routing', tierSubtitle);
+
+      // Legend — show only decision sources present in this session
+      var dsPresent = {};
+      timeline.forEach(function (p) { var ds = inferDecisionSource(p); if (ds) dsPresent[ds] = true; });
+      var tlLeg = el('div', '');
+      tlLeg.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px 12px;padding:2px 0 8px;align-items:center;';
+      Object.keys(DS_COLORS).forEach(function (k) {
+        if (!dsPresent[k]) return;
+        var chip = el('span', '');
+        chip.style.cssText = 'display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--color-text-muted)';
+        var dot = el('span', '');
+        dot.style.cssText = 'display:inline-block;width:10px;height:10px;border-radius:2px;flex-shrink:0;background:' + DS_COLORS[k];
+        chip.appendChild(dot);
+        chip.appendChild(document.createTextNode(k));
+        tlLeg.appendChild(chip);
+      });
+      tlCard._body.appendChild(tlLeg);
+
+      var TIER_LEVELS = {
+        'simple': 1,
+        'middle': 2,
+        'complex': 3,
+        'reasoning': 4
+      };
+      var TIER_LABELS = {
+        1: 'simple',
+        2: 'middle',
+        3: 'complex',
+        4: 'reasoning'
+      };
+      function tierLevel(p) { return TIER_LEVELS[p.routingTier] || 0; }
+      function tierName(p) { return p.routingTier || 'unknown'; }
+
+      var tlCv = canvasIn(tlCard._body, 180);
+
+      var tierData = timeline.map(function (p) { return tierLevel(p); });
+      var barBg = timeline.map(function (p) {
+        var base = tlDsColor(p);
+        if (base.match(/^#([0-9a-f]{6})$/i)) return base;
+        return '#9CA3AF';
+      });
+      var mainDataset = {
+        type: 'bar',
+        data: tierData,
+        backgroundColor: barBg,
+        borderRadius: 2,
+        barPercentage: 0.72,
+        categoryPercentage: 1.0,
+        yAxisID: 'ytier',
+        order: 2,
+      };
+
+      var confData = timeline.map(function (p) { return p.routingConfidence != null ? p.routingConfidence : null; });
+      var confDataset = {
+        type: 'line',
+        data: confData,
+        borderColor: '#F5A534',
+        backgroundColor: 'transparent',
+        borderWidth: 2,
+        pointRadius: 0,
+        pointHoverRadius: 3,
+        tension: 0.25,
+        yAxisID: 'yconf',
+        order: 1,
+      };
+
+      var detailEl = el('div', '');
+      detailEl.style.cssText = 'margin-top:10px;font-size:12px;color:var(--color-text-muted);line-height:1.4;';
+      detailEl.textContent = 'Click a turn to see judge details.';
+      function showTurnDetail(index) {
+        var p = timeline[index];
+        if (!p) return;
+        var html = '<div style="font-weight:600;color:var(--color-text-primary);margin-bottom:4px;">' + esc(p.model) + ' · ' + esc(tierName(p)) + '</div>';
+                  if ((p.routingSource === 'judge' || p.routingSource === 'classifier') && p.judgeCrux) {
+          html += '<div style="margin-bottom:4px;"><span style="color:var(--color-text-muted);">crux:</span> ' + esc(p.judgeCrux) + '</div>';
+        }
+        if (p.judgePrimaryRule) html += '<div><span style="color:var(--color-text-muted);">rule:</span> ' + esc(p.judgePrimaryRule) + '</div>';
+        if (p.judgeCapabilityBoundary) html += '<div><span style="color:var(--color-text-muted);">boundary:</span> ' + esc(p.judgeCapabilityBoundary) + '</div>';
+        detailEl.innerHTML = html;
+      }
+
+      makeModalChart(tlCv, {
+        type: 'bar',
+        data: { labels: tlLabels, datasets: [mainDataset, confDataset] },
+        options: {
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                title: function () { return ''; },
+                label: function (item) {
+                  var p = timeline[item.dataIndex];
+                  var lines = [p.model];
+                  lines.push('tier:        ' + tierName(p) + ' (' + item.parsed.y + ')');
+                  var ds = inferDecisionSource(p);
+                  if (ds) lines.push('decision:    ' + ds);
+                  if (p.routingSource === 'stage_router') {
+                    if (p.routingConfidence != null) lines.push('confidence:  ' + p.routingConfidence.toFixed(2));
+                    if (p.signalSeverity != null) lines.push('severity:    ' + p.signalSeverity.toFixed(2));
+                    if (p.signalSpinning != null && p.signalSpinning >= 0.5) lines.push('spinning:    ✓');
+                    if (p.signalExploring != null && p.signalExploring >= 0.5) lines.push('exploring:   ✓');
+                    if (p.signalProductionIntensity != null) lines.push('production: ' + p.signalProductionIntensity.toFixed(2));
+                  } else if (p.routingSource === 'judge' || p.routingSource === 'classifier') {
+                    if (p.judgePrimaryRule) lines.push('rule: ' + p.judgePrimaryRule);
+                    if (p.judgeCapabilityBoundary) lines.push('boundary: ' + p.judgeCapabilityBoundary);
+                    if (p.judgeCrux) lines.push('crux (click to see)');
+                  } else if (p.routingConfidence != null) {
+                    lines.push('confidence:  ' + p.routingConfidence.toFixed(2));
+                  }
+                  return lines;
+                }
+              }
+            }
+          },
+          onClick: function (e, elements) {
+            if (elements && elements.length) showTurnDetail(elements[0].index);
+          },
+          scales: {
+            x: { grid: { display: false }, ticks: { maxTicksLimit: 12 } },
+            ytier: {
+              position: 'left',
+              min: 0, max: 4,
+              ticks: {
+                stepSize: 1,
+                callback: function (v) { return TIER_LABELS[v] || ''; }
+              },
+              grid: { color: GRID }
+            },
+            yconf: {
+              position: 'right',
+              min: 0, max: 1,
+              ticks: {
+                stepSize: 0.25,
+                callback: function (v) { return (v * 100).toFixed(0) + '%'; }
+              },
+              grid: { display: false }
+            }
+          }
+        }
+      });
+
+      tlCard._body.appendChild(detailEl);
+      body.appendChild(tlCard);
+    }
 
     // Timeline — Gantt of all top-level agent, skill, and command dispatches.
     var hasDispatches = (s.dispatches || []).length > 0;

--- a/src/cli/commands/analytics/report/client/app.js
+++ b/src/cli/commands/analytics/report/client/app.js
@@ -732,17 +732,18 @@
     });
     host.appendChild(grid);
 
-    // Routing KPI section — only shown when at least one session has judge routing cost.
-    var routedSessions = fs.filter(function (s) { return s.judgeCostUSD != null && s.judgeCostUSD > 0; });
+    // Routing KPI section — only shown when at least one session has routing.
+    var routedSessions = fs.filter(function (s) { return s.judgeCostUSD != null || s.routingCostKnown === false; });
     if (routedSessions.length > 0) {
       host.appendChild(el('h3', 'section-title', 'Routing'));
       var rsGrid = el('div', 'kpi-grid'); rsGrid.style.gridTemplateColumns = 'repeat(3,1fr)';
-      var totalJudgeCost = sum(routedSessions, function (s) { return s.judgeCostUSD || 0; });
-      var totalJudgeIn = routedSessions.reduce(function (acc, s) { return acc + (s.judgeInputTokens || 0); }, 0);
-      var totalJudgeOut = routedSessions.reduce(function (acc, s) { return acc + (s.judgeOutputTokens || 0); }, 0);
+      var measuredSessions = routedSessions.filter(function (s) { return s.judgeCostUSD != null && s.judgeCostUSD > 0; });
+      var totalJudgeCost = sum(measuredSessions, function (s) { return s.judgeCostUSD || 0; });
+      var totalJudgeIn = measuredSessions.reduce(function (acc, s) { return acc + (s.judgeInputTokens || 0); }, 0);
+      var totalJudgeOut = measuredSessions.reduce(function (acc, s) { return acc + (s.judgeOutputTokens || 0); }, 0);
       [
-        ['Sessions with routing', fmtNum(routedSessions.length) + ' / ' + fmtNum(fs.length)],
-        ['Judge routing cost', fmtUSD(totalJudgeCost)],
+        ['Sessions with routing', fmtNum(routedSessions.length) + ' / ' + fmtNum(fs.length) + (routedSessions.some(function(s) { return s.routingCostKnown === false; }) ? ' (cost unmeasured on ' + fmtNum(routedSessions.filter(function(s) { return s.routingCostKnown === false; }).length) + ')' : '')],
+        ['Judge routing cost', fmtUSD(totalJudgeCost) + (measuredSessions.length < routedSessions.length ? ' (LiteLLM unmeasured)' : '')],
         ['Judge tokens (in/out)', fmtTokens(totalJudgeIn) + ' / ' + fmtTokens(totalJudgeOut)]
       ].forEach(function (k) {
         var c = el('div', 'kpi'); c.innerHTML = '<div class="kpi-label">' + k[0] + '</div><div class="kpi-value">' + k[1] + '</div>'; rsGrid.appendChild(c);
@@ -1156,7 +1157,10 @@
       ['Started', '<span class="mval-sm">' + esc(fmtWhen(s.startTime)) + '</span>', '']
     ];
     if (s.judgeCostUSD != null) {
-      costRows.push(['Routing (judge)', fmtUSD(s.judgeCostUSD), 'included in cost']);
+      var detail = s.routingCostKnown === false ? 'unmeasured (LiteLLM)' : 'included in cost';
+      costRows.push(['Routing (judge)', s.judgeCostUSD > 0 ? fmtUSD(s.judgeCostUSD) : '—', detail]);
+    } else if (s.routingCostKnown === false) {
+      costRows.push(['Routing (judge)', '—', 'unmeasured (LiteLLM, no cost headers)']);
     }
     if (s.premiumRequests !== undefined) {
       costRows.push(['Premium requests', fmtNum(s.premiumRequests), 'provider billing unit']);

--- a/src/cli/commands/analytics/report/payload-builder.ts
+++ b/src/cli/commands/analytics/report/payload-builder.ts
@@ -109,6 +109,12 @@ export function buildPayload(
             ? { usageUnavailableReason: cost.usageUnavailableReason }
             : {}),
           ...(cost?.costSeries && cost.costSeries.length ? { costSeries: cost.costSeries } : {}),
+          ...(cost?.modelTimeline && cost.modelTimeline.length ? { modelTimeline: cost.modelTimeline } : {}),
+          ...(cost?.judgeCostUSD != null ? { judgeCostUSD: cost.judgeCostUSD } : {}),
+          ...(cost?.judgeInputTokens != null ? { judgeInputTokens: cost.judgeInputTokens } : {}),
+          ...(cost?.judgeOutputTokens != null ? { judgeOutputTokens: cost.judgeOutputTokens } : {}),
+          ...(cost?.judgeCachedTokens != null ? { judgeCachedTokens: cost.judgeCachedTokens } : {}),
+          ...(cost?.judgeCacheCreationTokens != null ? { judgeCacheCreationTokens: cost.judgeCacheCreationTokens } : {}),
           ...(cost?.dispatches && cost.dispatches.length ? { dispatches: cost.dispatches } : {}),
           skillInvocations,
           agentInvocations,

--- a/src/cli/commands/analytics/report/payload-builder.ts
+++ b/src/cli/commands/analytics/report/payload-builder.ts
@@ -115,6 +115,7 @@ export function buildPayload(
           ...(cost?.judgeOutputTokens != null ? { judgeOutputTokens: cost.judgeOutputTokens } : {}),
           ...(cost?.judgeCachedTokens != null ? { judgeCachedTokens: cost.judgeCachedTokens } : {}),
           ...(cost?.judgeCacheCreationTokens != null ? { judgeCacheCreationTokens: cost.judgeCacheCreationTokens } : {}),
+          ...(cost?.routingCostKnown != null ? { routingCostKnown: cost.routingCostKnown } : {}),
           ...(cost?.dispatches && cost.dispatches.length ? { dispatches: cost.dispatches } : {}),
           skillInvocations,
           agentInvocations,

--- a/src/cli/commands/analytics/report/template.html
+++ b/src/cli/commands/analytics/report/template.html
@@ -148,9 +148,9 @@
     .modal-body { padding: 18px 20px; overflow-y: auto; }
     .modal-body .card { margin-bottom: 14px; }
     /* light, borderless stat grid (replaces the heavy box-in-box KPIs) */
-    .modal-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(96px, 1fr)); gap: 14px 16px; }
-    .mstat .mlabel { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 3px; white-space: nowrap; }
-    .mstat .mval { font-size: 18px; font-weight: 700; color: var(--color-text-primary); white-space: nowrap; line-height: 1.2; }
+    .modal-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(78px, 1fr)); gap: 14px 16px; }
+    .mstat .mlabel { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 3px; white-space: normal; overflow-wrap: break-word; }
+    .mstat .mval { font-size: 18px; font-weight: 700; color: var(--color-text-primary); white-space: normal; line-height: 1.1; }
     .mstat .mval-sm { font-size: 13px; font-weight: 600; }
     .mstat .msub { font-size: 11px; color: var(--color-text-muted); margin-top: 2px; }
     .modal-chips { display: flex; flex-wrap: wrap; gap: 6px; }
@@ -194,9 +194,9 @@
     .modal-body { padding: 18px 20px; overflow-y: auto; }
     .modal-body .card { margin-bottom: 14px; }
     /* light, borderless stat grid (replaces the heavy box-in-box KPIs) */
-    .modal-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(96px, 1fr)); gap: 14px 16px; }
-    .mstat .mlabel { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 3px; white-space: nowrap; }
-    .mstat .mval { font-size: 18px; font-weight: 700; color: var(--color-text-primary); white-space: nowrap; line-height: 1.2; }
+    .modal-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(78px, 1fr)); gap: 14px 16px; }
+    .mstat .mlabel { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-text-muted); margin-bottom: 3px; white-space: normal; overflow-wrap: break-word; }
+    .mstat .mval { font-size: 18px; font-weight: 700; color: var(--color-text-primary); white-space: normal; line-height: 1.1; }
     .mstat .mval-sm { font-size: 13px; font-weight: 600; }
     .mstat .msub { font-size: 11px; color: var(--color-text-muted); margin-top: 2px; }
     .modal-chips { display: flex; flex-wrap: wrap; gap: 6px; }

--- a/src/cli/commands/analytics/report/types.ts
+++ b/src/cli/commands/analytics/report/types.ts
@@ -45,12 +45,19 @@ export interface ReportSessionRecord {
   modelTimeline?: ModelTimelinePoint[]; // per-turn model + routing metadata; absent when no routing data
   dispatches?: DispatchEvent[]; // timed top-level agent/skill/command invocations; absent when none
 
-  // === Switchyard routing classifier cost (included in costUSD) ===
+  // === Routing classifier cost (included in costUSD; Switchyard only — see routingCostKnown) ===
   judgeCostUSD?: number; // USD spent on the routing classifier LLM
   judgeInputTokens?: number;
   judgeOutputTokens?: number;
   judgeCachedTokens?: number;
   judgeCacheCreationTokens?: number;
+  /**
+   * True when every routed turn in this session came from a family that reports classifier
+   * cost (Switchyard). False when any turn used LiteLLM, which never reports cost — so
+   * `judgeCostUSD` is absent even though classifiers ran. Absent when the session had no
+   * routed turns at all.
+   */
+  routingCostKnown?: boolean;
 
   // === Usage provenance (optional; absent for agents that always record full usage) ===
   /**

--- a/src/cli/commands/analytics/report/types.ts
+++ b/src/cli/commands/analytics/report/types.ts
@@ -3,7 +3,7 @@
  * report. The client app reads only this and computes every view from it.
  */
 
-import type { TokenUsage, ModelCost, AgentCoverage, CostSeriesPoint, DispatchEvent } from '../cost/types.js';
+import type { TokenUsage, ModelCost, AgentCoverage, CostSeriesPoint, DispatchEvent, ModelTimelinePoint } from '../cost/types.js';
 import type { ToolStats, NamedInvocationStats } from '../types.js';
 
 /** One flat record per session — the client aggregates everything from these. */
@@ -42,7 +42,15 @@ export interface ReportSessionRecord {
   perModelCost: ModelCost[];
   hadLog: boolean; // a native agent log was located for this session (priced<hadLog ⇒ parse/reader gap)
   costSeries?: CostSeriesPoint[]; // per-turn cumulative cost/token growth; absent when no per-turn data
+  modelTimeline?: ModelTimelinePoint[]; // per-turn model + routing metadata; absent when no routing data
   dispatches?: DispatchEvent[]; // timed top-level agent/skill/command invocations; absent when none
+
+  // === Switchyard routing classifier cost (included in costUSD) ===
+  judgeCostUSD?: number; // USD spent on the routing classifier LLM
+  judgeInputTokens?: number;
+  judgeOutputTokens?: number;
+  judgeCachedTokens?: number;
+  judgeCacheCreationTokens?: number;
 
   // === Usage provenance (optional; absent for agents that always record full usage) ===
   /**

--- a/src/env/types.ts
+++ b/src/env/types.ts
@@ -97,6 +97,9 @@ export interface ProviderProfile {
   maxOutputTokens?: number;
   maxThinkingTokens?: number;
 
+  // Optional routing mode: appended as `?routing=<mode>` to every upstream request.
+  routing?: 'signal' | 'classifier';
+
   // Metrics configuration
   metrics?: {
     enabled?: boolean;  // Enable metrics collection (default: true)

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/routing-header-injector.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/routing-header-injector.plugin.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractRoutingHeaders,
+  injectIntoJsonBody,
+  injectIntoSseChunk,
+} from '../routing-header-injector.plugin.js';
+
+describe('RoutingHeaderInjectorPlugin', () => {
+  describe('extractRoutingHeaders', () => {
+    it('captures x-litellm-* headers with hyphens intact', () => {
+      const headers = {
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-router-cause': 'llm_classifier',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-router-cause': 'llm_classifier',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      });
+    });
+
+    it('captures x-codemie-routing-* and x-codemie-requested-* headers, converting hyphens to underscores', () => {
+      const headers = {
+        'x-codemie-routing-tier': 'efficient',
+        'x-codemie-routing-source': 'judge',
+        'x-codemie-requested-model': 'claude-sonnet-4-6',
+        'x-codemie-routing-judge-cost-usd': '0.002475',
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x_codemie_routing_tier': 'efficient',
+        'x_codemie_routing_source': 'judge',
+        'x_codemie_requested_model': 'claude-sonnet-4-6',
+        'x_codemie_routing_judge_cost_usd': '0.002475',
+      });
+    });
+
+    it('ignores non-routing headers', () => {
+      const headers = {
+        'authorization': 'Bearer secret-token',
+        'content-type': 'application/json',
+        'x-custom-header': 'value',
+        'x-litellm-router-tier': 'SIMPLE',
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x-litellm-router-tier': 'SIMPLE',
+      });
+    });
+
+    it('handles array-valued headers by taking the first element', () => {
+      const headers = {
+        'x-litellm-router-signals': ['["llm-classifier:COMPLEX"]', 'ignored'],
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x-litellm-router-signals': '["llm-classifier:COMPLEX"]',
+      });
+    });
+
+    it('ignores null and undefined values', () => {
+      const headers = {
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-missing': null as unknown as string,
+        'x-codemie-routing-tier': undefined as unknown as string,
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x-litellm-router-tier': 'COMPLEX',
+      });
+    });
+
+    it('returns empty object when no routing headers are present', () => {
+      const headers = {
+        'authorization': 'Bearer token',
+        'content-type': 'application/json',
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({});
+    });
+
+    it('case-insensitive matching for header names', () => {
+      const headers = {
+        'X-LiteLLM-Router-Tier': 'COMPLEX',
+        'X-CodeMie-Routing-Tier': 'efficient',
+      };
+      const result = extractRoutingHeaders(headers);
+      expect(result).toEqual({
+        'x-litellm-router-tier': 'COMPLEX',
+        'x_codemie_routing_tier': 'efficient',
+      });
+    });
+  });
+
+  describe('injectIntoJsonBody', () => {
+    it('merges injections into a JSON object', () => {
+      const body = Buffer.from(JSON.stringify({ id: 'msg_123', role: 'assistant', content: [] }));
+      const injections = {
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      };
+      const result = injectIntoJsonBody(body, injections);
+      const parsed = JSON.parse(result.toString('utf-8'));
+      expect(parsed).toEqual({
+        id: 'msg_123',
+        role: 'assistant',
+        content: [],
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      });
+    });
+
+    it('returns original buffer when injections are empty', () => {
+      const body = Buffer.from(JSON.stringify({ id: 'msg_123' }));
+      const result = injectIntoJsonBody(body, {});
+      expect(result).toBe(body);
+    });
+
+    it('returns original buffer when body is not a JSON object', () => {
+      const testCases = [
+        Buffer.from('not json'),
+        Buffer.from('[]'),
+        Buffer.from('null'),
+        Buffer.from('123'),
+        Buffer.from('true'),
+      ];
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      for (const body of testCases) {
+        const result = injectIntoJsonBody(body, injections);
+        expect(result).toBe(body);
+      }
+    });
+
+    it('returns original buffer on parse error', () => {
+      const body = Buffer.from('{broken json}');
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoJsonBody(body, injections);
+      expect(result).toBe(body);
+    });
+
+    it('overwrites existing keys if injections have the same key', () => {
+      const body = Buffer.from(JSON.stringify({ id: 'msg_123', 'x-litellm-router-tier': 'old' }));
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoJsonBody(body, injections);
+      const parsed = JSON.parse(result.toString('utf-8'));
+      expect(parsed['x-litellm-router-tier']).toBe('COMPLEX');
+    });
+  });
+
+  describe('injectIntoSseChunk', () => {
+    it('injects fields into the message object of a message_start event', () => {
+      const chunk = Buffer.from(
+        'data: ' +
+          JSON.stringify({
+            type: 'message_start',
+            message: { id: 'msg_123', role: 'assistant', model: 'claude-sonnet-5' },
+          })
+      );
+      const injections = {
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      };
+      const result = injectIntoSseChunk(chunk, injections);
+      const line = result.toString('utf-8');
+      const parsed = JSON.parse(line.slice(6));
+      expect(parsed.message).toEqual({
+        id: 'msg_123',
+        role: 'assistant',
+        model: 'claude-sonnet-5',
+        'x-litellm-router-tier': 'COMPLEX',
+        'x-litellm-model-name': 'claude-sonnet-5',
+      });
+    });
+
+    it('preserves non-message_start events unchanged', () => {
+      const chunk = Buffer.from(
+        'data: ' + JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta' } })
+      );
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      expect(result).toBe(chunk);
+    });
+
+    it('preserves non-JSON lines unchanged', () => {
+      const chunk = Buffer.from('data: [DONE]');
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      expect(result).toBe(chunk);
+    });
+
+    it('preserves other event types in a multi-line chunk', () => {
+      const multiLine = `data: ${JSON.stringify({ type: 'message_start', message: { id: 'msg_1' } })}
+data: ${JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } })}
+data: [DONE]`;
+      const chunk = Buffer.from(multiLine);
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      const lines = result.toString('utf-8').split('\n');
+      // First line should be modified, others unchanged
+      expect(JSON.parse(lines[0].slice(6)).message['x-litellm-router-tier']).toBe('COMPLEX');
+      expect(lines[1]).toBe(
+        `data: ${JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } })}`
+      );
+      expect(lines[2]).toBe('data: [DONE]');
+    });
+
+    it('returns original buffer when injections are empty', () => {
+      const chunk = Buffer.from(
+        'data: ' + JSON.stringify({ type: 'message_start', message: { id: 'msg_123' } })
+      );
+      const result = injectIntoSseChunk(chunk, {});
+      expect(result).toBe(chunk);
+    });
+
+    it('returns original buffer when no message_start is present', () => {
+      const chunk = Buffer.from('data: ' + JSON.stringify({ type: 'content_block_delta' }));
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      expect(result).toBe(chunk);
+    });
+
+    it('handles partial lines gracefully (does not parse or modify)', () => {
+      const chunk = Buffer.from('data: {"type":"message_st');
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      expect(result).toBe(chunk);
+    });
+
+    it('injects into all message_start events in a multi-line chunk', () => {
+      const multiStart = `data: ${JSON.stringify({ type: 'message_start', message: { id: 'msg_1' } })}
+data: ${JSON.stringify({ type: 'message_start', message: { id: 'msg_2' } })}`;
+      const chunk = Buffer.from(multiStart);
+      const injections = { 'x-litellm-router-tier': 'COMPLEX' };
+      const result = injectIntoSseChunk(chunk, injections);
+      const lines = result.toString('utf-8').split('\n');
+      // Both get injected (both are message_start events)
+      expect(JSON.parse(lines[0].slice(6)).message['x-litellm-router-tier']).toBe('COMPLEX');
+      expect(JSON.parse(lines[1].slice(6)).message['x-litellm-router-tier']).toBe('COMPLEX');
+    });
+  });
+});

--- a/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/header-injection.plugin.ts
@@ -79,6 +79,14 @@ class HeaderInjectionInterceptor implements ProxyInterceptor {
       context.headers['X-CodeMie-Project'] = config.project;
     }
 
+    // Append optional routing mode as a query parameter on every upstream request.
+    const routingMode = config.routing;
+    if (routingMode) {
+      const sep = context.url.includes('?') ? '&' : '?';
+      context.url = `${context.url}${sep}routing=${routingMode}`;
+      logger.debug(`[${this.name}] Appended routing query param: ${routingMode}`);
+    }
+
     logger.debug(`[${this.name}] Injected CodeMie headers`);
   }
 }

--- a/src/providers/plugins/sso/proxy/plugins/index.ts
+++ b/src/providers/plugins/sso/proxy/plugins/index.ts
@@ -20,6 +20,7 @@ import { CodexEncryptedContentSanitizerPlugin } from './codex-encrypted-content-
 import { CopilotEncryptedContentSanitizerPlugin } from './copilot-encrypted-content-sanitizer.plugin.js';
 import { VsCodeRequestNormalizerPlugin } from './vscode-request-normalizer.plugin.js';
 import { LoggingPlugin } from './logging.plugin.js';
+import { RoutingHeaderInjectorPlugin } from './routing-header-injector.plugin.js';
 import { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 
 /**
@@ -44,6 +45,7 @@ export function registerCorePlugins(): void {
   registry.register(new VsCodeRequestNormalizerPlugin()); // Priority 17 - constrains VS Code user identifiers
   registry.register(new HeaderInjectionPlugin());
   registry.register(new LoggingPlugin()); // Always enabled - logs to log files at INFO level
+  registry.register(new RoutingHeaderInjectorPlugin()); // Priority 55 - copies router decision headers onto the response body so agents persist them
   registry.register(new SSOSessionSyncPlugin()); // Priority 100 - syncs sessions via multiple processors
 }
 
@@ -66,6 +68,7 @@ export {
   CopilotEncryptedContentSanitizerPlugin,
   VsCodeRequestNormalizerPlugin,
   LoggingPlugin,
+  RoutingHeaderInjectorPlugin,
 };
 export { SSOSessionSyncPlugin } from './sso.session-sync.plugin.js';
 export { getPluginRegistry, resetPluginRegistry } from './registry.js';

--- a/src/providers/plugins/sso/proxy/plugins/routing-header-injector.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/routing-header-injector.plugin.ts
@@ -1,0 +1,193 @@
+/**
+ * Routing Header Injector Plugin
+ * Priority: 55 (after logging at 50, before session-sync at 100)
+ *
+ * The upstream router (CodeMie Switchyard or the LiteLLM router) reports which model
+ * tier it picked, and why, in HTTP *response headers*. Headers are forwarded downstream
+ * but agents do not persist them, so the decision is lost the moment the turn ends.
+ *
+ * This plugin copies those headers onto the response *body*, where the agent stores them
+ * verbatim in its own transcript alongside `usage`. The analytics pipeline
+ * (cost/usage-readers.ts) then reads routing metadata per turn with no join and no
+ * sidecar file.
+ *
+ * Two response paths:
+ *   JSON (non-streaming) — buffer the body, merge fields at the top level (which is the
+ *                          message object for the Messages API), return a new response.
+ *   SSE  (streaming)     — stash headers in `context.metadata` during onUpstreamResponse,
+ *                          then merge them into the first `message_start` event's nested
+ *                          `message` object as it streams past.
+ *
+ * Header → body key mapping (matches what the analytics reader expects):
+ *   x-litellm-*  → key keeps its hyphens        (`x-litellm-router-tier`)
+ *   x-codemie-*  → key converts hyphens to `_`  (`x_codemie_routing_tier`)
+ *
+ * Only one family is ever present: a deployment routes through Switchyard or the LiteLLM
+ * router, not both. Capturing by prefix means a new field in either family is recorded
+ * without a code change here.
+ */
+
+import { IncomingHttpHeaders, IncomingMessage } from 'http';
+import { ProxyPlugin, PluginContext, ProxyInterceptor, UpstreamResponseTools } from './types.js';
+import { ProxyContext } from '../proxy-types.js';
+import { logger } from '../../../../../utils/logger.js';
+
+const LITELLM_PREFIX = 'x-litellm-';
+const CODEMIE_ROUTING_PREFIXES = ['x-codemie-routing-', 'x-codemie-requested-'];
+const METADATA_HEADERS_KEY = '_routingInjectionHeaders';
+const METADATA_INJECTED_KEY = '_routingInjected';
+
+/** Fields extracted from routing headers, keyed as they will appear in the body. */
+export type RoutingInjections = Record<string, string>;
+
+/**
+ * Extract routing-relevant upstream response headers into a flat body-key → value map.
+ * Returns an empty object when the response carries no routing metadata, which is the
+ * common case for non-routed deployments and for requests that name a literal model ID.
+ */
+export function extractRoutingHeaders(headers: IncomingHttpHeaders): RoutingInjections {
+  const out: RoutingInjections = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value == null) continue;
+    const raw = Array.isArray(value) ? value[0] : value;
+    if (raw == null) continue;
+    const lower = key.toLowerCase();
+    if (lower.startsWith(LITELLM_PREFIX)) {
+      out[lower] = raw;
+    } else if (CODEMIE_ROUTING_PREFIXES.some((p) => lower.startsWith(p))) {
+      out[lower.replace(/-/g, '_')] = raw;
+    }
+  }
+  return out;
+}
+
+/**
+ * Merge fields into the top-level JSON object of a body buffer. Returns the buffer
+ * unchanged when there is nothing to inject, the payload is not a JSON object, or
+ * parsing fails — a routing annotation must never corrupt a response.
+ */
+export function injectIntoJsonBody(body: Buffer, injections: RoutingInjections): Buffer {
+  if (Object.keys(injections).length === 0) return body;
+  try {
+    const parsed: unknown = JSON.parse(body.toString('utf-8'));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return body;
+    }
+    return Buffer.from(JSON.stringify({ ...parsed, ...injections }), 'utf-8');
+  } catch {
+    return body;
+  }
+}
+
+/**
+ * Merge fields into the `message` object of a `message_start` SSE event.
+ *
+ * Rewrites only whole `data:` lines that parse as a `message_start` event; every other
+ * line — including partial trailing lines at a chunk boundary — is passed through byte
+ * for byte. Returns the original buffer when no event was modified.
+ */
+export function injectIntoSseChunk(chunk: Buffer, injections: RoutingInjections): Buffer {
+  if (Object.keys(injections).length === 0) return chunk;
+  const lines = chunk.toString('utf-8').split('\n');
+  let modified = false;
+  const outLines: string[] = [];
+
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) {
+      outLines.push(line);
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line.slice(6));
+    } catch {
+      // Not JSON (e.g. `[DONE]`) or a line split across chunks — pass through untouched.
+      outLines.push(line);
+      continue;
+    }
+    const event = parsed as { type?: unknown; message?: unknown };
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      event.type === 'message_start' &&
+      typeof event.message === 'object' &&
+      event.message !== null
+    ) {
+      const message = { ...(event.message as Record<string, unknown>), ...injections };
+      outLines.push('data: ' + JSON.stringify({ ...event, message }));
+      modified = true;
+    } else {
+      outLines.push(line);
+    }
+  }
+
+  return modified ? Buffer.from(outLines.join('\n'), 'utf-8') : chunk;
+}
+
+export class RoutingHeaderInjectorPlugin implements ProxyPlugin {
+  id = '@codemie/proxy-routing-header-injector';
+  name = 'Routing Header Injector';
+  version = '1.0.0';
+  priority = 55; // After logging (50), before session-sync (100)
+
+  async createInterceptor(_context: PluginContext): Promise<ProxyInterceptor> {
+    return new RoutingHeaderInjectorInterceptor();
+  }
+}
+
+class RoutingHeaderInjectorInterceptor implements ProxyInterceptor {
+  name = 'routing-header-injector';
+
+  async onUpstreamResponse(
+    context: ProxyContext,
+    response: IncomingMessage,
+    tools: UpstreamResponseTools
+  ): Promise<IncomingMessage> {
+    const injections = extractRoutingHeaders(response.headers);
+    if (Object.keys(injections).length === 0) {
+      return response;
+    }
+
+    const contentType = String(response.headers['content-type'] ?? '').toLowerCase();
+    if (contentType.includes('text/event-stream')) {
+      // Streaming: defer to onResponseChunk so the stream is never buffered.
+      context.metadata[METADATA_HEADERS_KEY] = injections;
+      logger.debug(
+        `[${this.name}] Captured ${Object.keys(injections).length} routing header(s) for SSE injection`
+      );
+      return response;
+    }
+
+    try {
+      const body = await tools.readBody(response);
+      const modified = injectIntoJsonBody(body, injections);
+      if (modified !== body) {
+        logger.debug(
+          `[${this.name}] Injected ${Object.keys(injections).length} routing header(s) into JSON response`
+        );
+      }
+      return tools.fromBuffer(response, modified);
+    } catch (error) {
+      logger.debug(`[${this.name}] JSON injection failed, forwarding original response:`, error);
+      return response;
+    }
+  }
+
+  async onResponseChunk(context: ProxyContext, chunk: Buffer): Promise<Buffer> {
+    if (context.metadata[METADATA_INJECTED_KEY]) {
+      return chunk;
+    }
+    const injections = context.metadata[METADATA_HEADERS_KEY] as RoutingInjections | undefined;
+    if (!injections || Object.keys(injections).length === 0) {
+      return chunk;
+    }
+
+    const modified = injectIntoSseChunk(chunk, injections);
+    if (modified !== chunk) {
+      context.metadata[METADATA_INJECTED_KEY] = true;
+      logger.debug(`[${this.name}] Injected routing headers into SSE message_start`);
+    }
+    return modified;
+  }
+}

--- a/src/providers/plugins/sso/proxy/proxy-types.ts
+++ b/src/providers/plugins/sso/proxy/proxy-types.ts
@@ -31,6 +31,8 @@ export interface ProxyConfig {
   syncApiUrl?: string;           // Optional CodeMie API URL for analytics/session sync
   syncCodeMieUrl?: string;       // Optional CodeMie org URL for credential lookup
   gatewayKey?: string;           // Static bearer key for gateway/daemon mode
+  /** Optional routing mode appended as `?routing=<mode>` to every upstream request. */
+  routing?: 'signal' | 'classifier';
   telemetryMode?: 'none' | 'claude-desktop';
   telemetryPollIntervalMs?: number;
   telemetryInactivityTimeoutMs?: number;


### PR DESCRIPTION
## Overview

Routing decisions from the upstream router (LiteLLM or Switchyard) are now captured in HTTP response headers and persisted in agent transcripts, making them auditable and queryable in the analytics pipeline.

This PR adds two components:
1. A proxy plugin that injects routing headers into response bodies
2. Analytics pipeline updates to extract and report on both header families

## Commits

### feat(proxy): add routing header injector plugin (037da99)
- Intercepts router response headers and injects them into the response body
- Supports both x-litellm-* (LiteLLM) and x-codemie-* (Switchyard) header families  
- Handles JSON (buffers and merges) and SSE (stores headers, injects into message_start) response paths
- Headers captured by prefix matching, so new fields are automatically recorded
- 20 unit tests covering both families, edge cases, and robustness

### feat(analytics): capture LiteLLM routing metadata (c5c1627)
- Extends usage-readers.ts to extract 6 previously-dropped LiteLLM headers
- Introduces routingFamily discriminator to distinguish Switchyard (cost known) from LiteLLM (cost unknown)
- Preserves raw tier values before normalization for future refinement
- Session-level routingCostKnown flag indicates whether routing overhead is measurable
- Report shows LiteLLM sessions as 'unmeasured' rather than implying $0 cost

## Result

Both LiteLLM and Switchyard deployments now render equivalent routing timelines and KPI views.
Switchyard tracks cost overhead; LiteLLM tier distribution and decision rationale are visible.

## Testing
- End-to-end verified with real session data from both deployment types
- Both header families captured correctly
- Credentials not leaked into transcripts
- Other SSE events preserved
- Malformed inputs handled gracefully
- npm run typecheck ✓
- npm run lint ✓
- 20 new unit tests ✓
- Existing analytics tests ✓