### PR TITLE
feat(providers): add Ollama cloud support across setup and agents

### DIFF
--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -97,7 +97,7 @@ export const ClaudePluginMetadata: AgentMetadata = {
     subagentDefaultModel: ['CLAUDE_CODE_SUBAGENT_MODEL'],
   },
 
-  supportedProviders: ['litellm', 'ai-run-sso', 'bedrock', 'bearer-auth', 'anthropic-subscription'],
+  supportedProviders: ['litellm', 'ai-run-sso', 'bedrock', 'bearer-auth', 'anthropic-subscription', 'ollama'],
   blockedModelPatterns: [],
   // Family token, not a pinned version — computeRecommendedModelIds (setup-ui.ts)
   // matches it against the live catalog and picks the current latest Sonnet.

--- a/src/agents/plugins/codex/codex.plugin.ts
+++ b/src/agents/plugins/codex/codex.plugin.ts
@@ -134,7 +134,7 @@ export const CodexPluginMetadata: AgentMetadata = {
     apiKey: ['OPENAI_API_KEY'],
     model: [],
   },
-  supportedProviders: ['ai-run-sso', 'bearer-auth', 'litellm'],
+  supportedProviders: ['ai-run-sso', 'bearer-auth', 'litellm', 'ollama'],
   blockedModelPatterns: [],
   recommendedModels: ['gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex'],
 
@@ -292,8 +292,13 @@ export const CodexPluginMetadata: AgentMetadata = {
       // even OPENAI_API_KEY env var. Using a custom provider with env_key pointing to
       // CODEMIE_API_KEY (set by transformEnvVars) bypasses auth.json entirely, since
       // auth.json only stores credentials for the default openai provider.
+      // Ollama is allowed with its 'not-required' placeholder key (the daemon ignores
+      // it); ollama supports the Responses API at /v1/responses, and recent codex
+      // versions no longer accept wire_api="chat" anyway.
       // --config uses TOML values: strings must be double-quoted.
-      if (config?.apiKey && config.apiKey !== 'not-required' && config?.baseUrl) {
+      const isOllama = config?.provider === 'ollama';
+      const hasUsableApiKey = config?.apiKey && config.apiKey !== 'not-required';
+      if ((hasUsableApiKey || isOllama) && config?.baseUrl) {
         enriched = [
           '--config', 'model_provider="codemie"',
           '--config', 'model_providers.codemie.name="codemie"',
@@ -525,6 +530,29 @@ export class CodexPlugin extends BaseAgentAdapter {
   }
 
   protected override async setupProxy(env: NodeJS.ProcessEnv): Promise<void> {
+    if (env.CODEMIE_PROVIDER === 'ollama') {
+      // Ollama has no CodeMie model catalog - any model the daemon (or
+      // ollama.com, when configured as a remote host) serves is usable.
+      // Expose the actually available models for --model validation.
+      env.CODEMIE_CODEX_AVAILABLE_MODELS = env.CODEMIE_MODEL ?? '';
+      try {
+        const { OllamaModelProxy } = await import('../../../providers/plugins/ollama/ollama.models.js');
+        const ollamaBaseUrl = (env.CODEMIE_BASE_URL || 'http://localhost:11434').replace(/\/v1\/?$/, '');
+        const models = await new OllamaModelProxy(ollamaBaseUrl, env.CODEMIE_API_KEY).listModels();
+        const ids = models.map(m => m.id);
+        if (env.CODEMIE_MODEL && !ids.includes(env.CODEMIE_MODEL)) {
+          ids.unshift(env.CODEMIE_MODEL);
+        }
+        if (ids.length > 0) {
+          env.CODEMIE_CODEX_AVAILABLE_MODELS = ids.join(',');
+        }
+      } catch (error) {
+        logger.debug('[codex] Failed to list Ollama models; keeping configured model only', error);
+      }
+      await super.setupProxy(env);
+      return;
+    }
+
     if (env.CODEMIE_PROVIDER === 'litellm') {
       if (!isCodexCompatibleModelName(env.CODEMIE_MODEL)) {
         throw new ConfigurationError(

--- a/src/agents/plugins/pi/pi.models.ts
+++ b/src/agents/plugins/pi/pi.models.ts
@@ -329,6 +329,68 @@ function createSyntheticLlmModel(modelId: string): LlmModel {
   };
 }
 
+/**
+ * Build Pi's models.json for an Ollama profile.
+ *
+ * Registers an `ollama` provider speaking OpenAI-compatible chat completions
+ * against the configured base URL (local daemon or ollama.com directly).
+ * Models come from the merged local + cloud listing; for local daemons the
+ * cloud catalog ids are mapped to their `-cloud` offload tags so every entry
+ * is actually runnable (see toCloudOffloadTag).
+ */
+async function buildOllamaModelsConfig(env: NodeJS.ProcessEnv): Promise<PiModelsConfig> {
+  const { OllamaModelProxy, toCloudOffloadTag } = await import('../../../providers/plugins/ollama/ollama.models.js');
+
+  const rawBaseUrl = env.CODEMIE_BASE_URL || 'http://localhost:11434/v1';
+  const baseUrl = rawBaseUrl.endsWith('/v1') ? rawBaseUrl : `${rawBaseUrl.replace(/\/$/, '')}/v1`;
+  // Local daemons ignore the key but Pi requires one; a real ollama.com API
+  // key is passed through when configured.
+  const apiKey = env.CODEMIE_API_KEY && env.CODEMIE_API_KEY !== 'not-required'
+    ? env.CODEMIE_API_KEY
+    : 'ollama';
+  const isCloudHost = rawBaseUrl.includes('ollama.com');
+
+  let ids: string[] = [];
+  try {
+    const proxy = new OllamaModelProxy(baseUrl.replace(/\/v1\/?$/, ''), env.CODEMIE_API_KEY);
+    const models = await proxy.fetchModels({
+      provider: 'ollama',
+      baseUrl,
+      apiKey: env.CODEMIE_API_KEY || '',
+      model: 'temp',
+      timeout: 300,
+    });
+    ids = models.map(m =>
+      !isCloudHost && m.metadata?.origin === 'cloud' ? toCloudOffloadTag(m.id) : m.id
+    );
+  } catch (error) {
+    logger.warn(`[pi-models] Failed to list Ollama models, using configured model only: ${error instanceof Error ? error.message : error}`);
+  }
+
+  if (env.CODEMIE_MODEL && !ids.includes(env.CODEMIE_MODEL)) {
+    ids.unshift(env.CODEMIE_MODEL);
+  }
+
+  if (ids.length === 0) {
+    throw new Error('No model configured for codemie-pi and Ollama is unreachable.');
+  }
+
+  return {
+    providers: {
+      ollama: {
+        baseUrl,
+        api: 'openai-completions',
+        apiKey,
+        compat: {
+          supportsReasoningEffort: true,
+          thinkingFormat: 'reasoning_effort',
+        },
+        models: ids.map(id => convertLlmModelToPiEntry(createSyntheticLlmModel(id))),
+      },
+    },
+  };
+}
+
 function buildStaticFallbackModel(modelId: string, baseUrl: string, apiKey: string): PiModelsConfig {
   const entry = convertLlmModelToPiEntry(createSyntheticLlmModel(modelId));
   return buildModelsConfig([entry], baseUrl, apiKey);
@@ -340,6 +402,14 @@ export async function fetchAndBuildPiModels(
 ): Promise<void> {
   const agentDir = getPiAgentDir(cwd);
   await mkdir(agentDir, { recursive: true });
+
+  // Ollama profiles have no CodeMie backend - build the model list from the
+  // Ollama daemon / ollama.com directly.
+  if (env.CODEMIE_PROVIDER === 'ollama') {
+    const config = await buildOllamaModelsConfig(env);
+    await writeFile(getPiModelsPath(cwd), JSON.stringify(config, null, 2), 'utf-8');
+    return;
+  }
 
   const baseUrl = env.CODEMIE_BASE_URL || '';
   const apiKey = env.CODEMIE_API_KEY || 'proxy-handled';

--- a/src/agents/plugins/pi/pi.plugin.ts
+++ b/src/agents/plugins/pi/pi.plugin.ts
@@ -279,7 +279,7 @@ export const PiPluginMetadata: AgentMetadata = {
     model: [],
   },
 
-  supportedProviders: ['ai-run-sso', 'bearer-auth', 'litellm'],
+  supportedProviders: ['ai-run-sso', 'bearer-auth', 'litellm', 'ollama'],
 
   ssoConfig: {
     enabled: true,
@@ -334,8 +334,12 @@ export const PiPluginMetadata: AgentMetadata = {
         throw new Error('No model configured for codemie-pi. Run codemie setup to select a model.');
       }
 
-      const classification = classifyPiModel(model);
-      const providerId = classification.provider;
+      // Ollama models are served by the `ollama` provider written to
+      // models.json by fetchAndBuildPiModels; classifyPiModel only knows the
+      // CodeMie backends and would misroute them to `codemie-proxy`.
+      const providerId = process.env.CODEMIE_PROVIDER === 'ollama'
+        ? 'ollama'
+        : classifyPiModel(model).provider;
 
       // `--task` is not handled here: `flagMappings` rewrites it to Pi's `-p`, which
       // BaseAgentAdapter applies after this hook. Consuming it here would leave a bare

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -10,22 +10,34 @@ const UNSUPPORTED_PROVIDERS = new Set(['openai', 'openai-compatible']);
 function formatTable(models: ModelInfo[]): void {
   const ID_WIDTH = 40;
   const NAME_WIDTH = 35;
+  const ORIGIN_WIDTH = 10;
   const DESC_WIDTH = 60;
+
+  // Only providers that tag model origin (e.g. ollama local/cloud) get the column
+  const showOrigin = models.some(m => typeof m.metadata?.origin === 'string');
 
   const header =
     chalk.bold(padEnd('ID', ID_WIDTH)) +
     chalk.bold(padEnd('NAME', NAME_WIDTH)) +
+    (showOrigin ? chalk.bold(padEnd('ORIGIN', ORIGIN_WIDTH)) : '') +
     chalk.bold('DESCRIPTION');
 
   console.log(header);
-  console.log(chalk.dim('─'.repeat(ID_WIDTH + NAME_WIDTH + DESC_WIDTH)));
+  console.log(chalk.dim('─'.repeat(ID_WIDTH + NAME_WIDTH + (showOrigin ? ORIGIN_WIDTH : 0) + DESC_WIDTH)));
 
   for (const model of models) {
     const id = padEnd(model.id, ID_WIDTH);
     const name = padEnd(model.name || model.id, NAME_WIDTH);
     const desc = truncate(model.description ?? '', DESC_WIDTH);
-    console.log(chalk.cyan(id) + chalk.white(name) + chalk.dim(desc));
+    const origin = showOrigin ? formatOrigin(model.metadata?.origin, ORIGIN_WIDTH) : '';
+    console.log(chalk.cyan(id) + chalk.white(name) + origin + chalk.dim(desc));
   }
+}
+
+function formatOrigin(origin: unknown, width: number): string {
+  const value = typeof origin === 'string' ? origin : '';
+  const padded = padEnd(value, width);
+  return value === 'cloud' ? chalk.yellow(padded) : chalk.green(padded);
 }
 
 function padEnd(str: string, width: number): string {

--- a/src/providers/core/types.ts
+++ b/src/providers/core/types.ts
@@ -29,6 +29,7 @@ export interface ModelMetadata {
   description?: string;              // Model description
   popular?: boolean;                 // Mark as popular/recommended
   contextWindow?: number;            // Token context window
+  minMemoryGb?: number;              // Minimum memory (RAM/VRAM) to run locally - omit for cloud-hosted models
   pricing?: {                        // Pricing information (optional)
     input: number;
     output: number;

--- a/src/providers/integration/setup-ui.ts
+++ b/src/providers/integration/setup-ui.ts
@@ -7,6 +7,7 @@
 
 import chalk from 'chalk';
 import type { ProviderTemplate } from '../core/types.js';
+import { getSystemCapabilities, modelFitsSystem } from '../../utils/hardware.js';
 
 /**
  * Format provider choice for inquirer
@@ -175,7 +176,7 @@ export function formatModelChoice(
   modelId: string,
   template?: ProviderTemplate,
   isRecommendedOverride?: boolean
-): { name: string; value: string } {
+): { name: string; value: string; disabled?: boolean | string } {
   const metadata = template?.modelMetadata?.[modelId];
 
   // Check if model is recommended. `isRecommendedOverride` — precomputed by
@@ -188,9 +189,17 @@ export function formatModelChoice(
     (isRecommendedOverride === undefined && matchesAnyRecommendedPattern(modelId, template?.recommendedModels)) ||
     false;
 
+  // Models with a memory requirement that exceeds this system are shown
+  // but disabled, so users see why a recommended model is unavailable.
+  let disabled: string | undefined;
+  if (metadata?.minMemoryGb && !modelFitsSystem(metadata.minMemoryGb)) {
+    const capabilities = getSystemCapabilities();
+    disabled = `needs ~${metadata.minMemoryGb}GB, only ~${Math.round(capabilities.usableMemoryGb)}GB usable on this system`;
+  }
+
   // If no metadata and not recommended, return plain format
   if (!metadata && !isRecommended) {
-    return { name: modelId, value: modelId };
+    return { name: modelId, value: modelId, disabled };
   }
 
   const popularBadge = isRecommended ? chalk.yellow('⭐ ') : '';
@@ -200,6 +209,9 @@ export function formatModelChoice(
   if (metadata?.description) {
     details.push(metadata.description);
   }
+  if (metadata?.minMemoryGb) {
+    details.push(`requires ~${metadata.minMemoryGb}GB memory`);
+  }
   if (metadata?.contextWindow) {
     details.push(`${metadata.contextWindow.toLocaleString()} tokens`);
   }
@@ -208,7 +220,8 @@ export function formatModelChoice(
 
   return {
     name: mainLine + detailLine,
-    value: modelId
+    value: modelId,
+    disabled
   };
 }
 
@@ -219,11 +232,14 @@ export function formatModelChoice(
  * 1. Recommended models first — only the latest version within each
  *    recommendedModels family (see computeRecommendedModelIds)
  * 2. Alphabetically by model ID
+ *
+ * Choices whose declared memory requirement (modelMetadata.minMemoryGb)
+ * exceeds the current system are included but disabled with an explanation.
  */
 export function getAllModelChoices(
   models: string[],
   template?: ProviderTemplate
-): Array<{ name: string; value: string }> {
+): Array<{ name: string; value: string; disabled?: boolean | string }> {
   const recommendedIds = computeRecommendedModelIds(models, template?.recommendedModels);
 
   // Sort models using common rules

--- a/src/providers/plugins/ollama/ollama.health.ts
+++ b/src/providers/plugins/ollama/ollama.health.ts
@@ -97,7 +97,7 @@ Or install Ollama:
    * Custom no-models remediation
    */
   protected getNoModelsRemediation(): string {
-    return 'Install a model: codemie models install ollama/llama3.2';
+    return 'Install a model: ollama pull llama3.2';
   }
 }
 

--- a/src/providers/plugins/ollama/ollama.models.ts
+++ b/src/providers/plugins/ollama/ollama.models.ts
@@ -31,6 +31,60 @@ interface OllamaTagsResponse {
 }
 
 /**
+ * Ollama cloud API base URL.
+ * ollama.com acts as a remote Ollama host - same API surface as the local
+ * daemon, but requires an ollama.com API key (Authorization: Bearer).
+ */
+const OLLAMA_CLOUD_BASE_URL = 'https://ollama.com';
+
+/**
+ * Check whether an API key is a real credential (not empty or a placeholder)
+ */
+function hasApiKey(apiKey?: string): apiKey is string {
+  return !!apiKey && apiKey.trim() !== '' && apiKey !== 'not-required';
+}
+
+/**
+ * List models available on Ollama cloud (ollama.com).
+ * The cloud catalog endpoint is public - no API key required.
+ */
+export async function listOllamaCloudModels(): Promise<ModelInfo[]> {
+  const cloudProxy = new OllamaModelProxy(OLLAMA_CLOUD_BASE_URL);
+  return cloudProxy.listModels();
+}
+
+/**
+ * Validate an ollama.com API key.
+ * The model catalog (/api/tags) is public, so validation probes the
+ * auth-enforced web search endpoint with a minimal query instead.
+ */
+export async function validateOllamaCloudApiKey(apiKey: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${OLLAMA_CLOUD_BASE_URL}/api/web_search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({ query: 'ollama', max_results: 1 })
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Map an ollama.com cloud catalog model id to the tag used to run it
+ * through a local signed-in daemon:
+ * - tagged:   `gpt-oss:120b`        -> `gpt-oss:120b-cloud`
+ * - untagged: `kimi-k2.6`           -> `kimi-k2.6:cloud`
+ */
+export function toCloudOffloadTag(modelId: string): string {
+  return modelId.includes(':') ? `${modelId}-cloud` : `${modelId}:cloud`;
+}
+
+/**
  * Pattern to identify coding model names
  */
 const CODING_MODEL_PATTERNS = [
@@ -56,8 +110,9 @@ function getCodingModelMetadata(modelId: string): Partial<ModelInfo> {
   // Extract base name (without tag)
   const baseName = modelId.split(':')[0];
 
-  // Get metadata from template (single source of truth)
-  const metadata = OllamaTemplate.modelMetadata?.[baseName];
+  // Get metadata from template (single source of truth) -
+  // prefer the full id, fall back to the base name
+  const metadata = OllamaTemplate.modelMetadata?.[modelId] ?? OllamaTemplate.modelMetadata?.[baseName];
 
   if (metadata) {
     return {
@@ -84,8 +139,19 @@ function getCodingModelMetadata(modelId: string): Partial<ModelInfo> {
  * Extends BaseModelProxy for common patterns
  */
 export class OllamaModelProxy extends BaseModelProxy {
-  constructor(baseUrl: string = OllamaTemplate.defaultBaseUrl) {
+  private apiKey?: string;
+
+  constructor(baseUrl: string = OllamaTemplate.defaultBaseUrl, apiKey?: string) {
     super(baseUrl, 300000); // 5 minutes for model operations
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Authorization headers for remote Ollama hosts (ollama.com cloud API).
+   * Empty for the local daemon, which needs no credentials.
+   */
+  private authHeaders(): Record<string, string> {
+    return hasApiKey(this.apiKey) ? { Authorization: `Bearer ${this.apiKey}` } : {};
   }
 
   /**
@@ -107,7 +173,7 @@ export class OllamaModelProxy extends BaseModelProxy {
    */
   async listModels(): Promise<ModelInfo[]> {
     try {
-      const response = await this.client.get<OllamaTagsResponse>(`${this.baseUrl}/api/tags`);
+      const response = await this.client.get<OllamaTagsResponse>(`${this.baseUrl}/api/tags`, this.authHeaders());
 
       return response.data.models.map((model) => ({
         id: model.name,
@@ -126,32 +192,55 @@ export class OllamaModelProxy extends BaseModelProxy {
 
   /**
    * Fetch available models (for setup/discovery)
-   * Returns installed models if available
+   * Returns installed models merged with the ollama.com cloud catalog
+   * (public endpoint); falls back to recommended models otherwise.
+   * An API key is only needed to *run* cloud models directly on
+   * ollama.com, not to list them.
    */
   async fetchModels(config: CodeMieConfigOptions): Promise<ModelInfo[]> {
-    try {
-      // Use baseUrl from config if provided, otherwise use default
-      const baseUrl = config.baseUrl || OllamaTemplate.defaultBaseUrl;
-      const proxy = baseUrl === this.baseUrl ? this : new OllamaModelProxy(baseUrl);
+    const apiKey = hasApiKey(config.apiKey) ? config.apiKey : undefined;
+    const merged = new Map<string, ModelInfo>();
 
-      // Try to fetch installed models from Ollama
+    const toModelInfo = (m: ModelInfo, origin: 'local' | 'cloud'): ModelInfo => {
+      const metadata = getCodingModelMetadata(m.id);
+      return {
+        id: m.id,
+        name: metadata.name || m.name || m.id,
+        description: metadata.description,
+        size: m.size,
+        popular: metadata.popular || false,
+        metadata: { ...m.metadata, origin }
+      };
+    };
+
+    // Local daemon (or a remote Ollama host configured via baseUrl)
+    try {
+      const baseUrl = config.baseUrl || OllamaTemplate.defaultBaseUrl;
+      const proxy = baseUrl === this.baseUrl && apiKey === this.apiKey ? this : new OllamaModelProxy(baseUrl, apiKey);
       const installedModels = await proxy.listModels();
 
-      // Return all installed models
-      if (installedModels.length > 0) {
-        return installedModels.map(m => {
-          const metadata = getCodingModelMetadata(m.id);
-          return {
-            id: m.id,
-            name: metadata.name || m.name || m.id,
-            description: metadata.description,
-            size: m.size,
-            popular: metadata.popular || false
-          };
-        });
+      for (const model of installedModels) {
+        merged.set(model.id, toModelInfo(model, 'local'));
       }
     } catch (error) {
       logger.debug('Failed to fetch installed Ollama models:', error);
+    }
+
+    // Ollama cloud catalog (ollama.com) - public endpoint, no key required
+    try {
+      const cloudModels = await listOllamaCloudModels();
+
+      for (const model of cloudModels) {
+        if (!merged.has(model.id)) {
+          merged.set(model.id, toModelInfo(model, 'cloud'));
+        }
+      }
+    } catch (error) {
+      logger.debug('Failed to fetch Ollama cloud models:', error);
+    }
+
+    if (merged.size > 0) {
+      return [...merged.values()];
     }
 
     // Fall back to template's recommended models with metadata from template
@@ -176,6 +265,7 @@ export class OllamaModelProxy extends BaseModelProxy {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...this.authHeaders(),
         },
         body: JSON.stringify({ name: modelName, stream: true }),
       });
@@ -245,7 +335,7 @@ export class OllamaModelProxy extends BaseModelProxy {
    */
   async removeModel(modelName: string): Promise<void> {
     try {
-      await this.client.post(`${this.baseUrl}/api/delete`, { name: modelName });
+      await this.client.post(`${this.baseUrl}/api/delete`, { name: modelName }, this.authHeaders());
     } catch (error) {
       throw new Error(`Failed to remove model ${modelName}: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -266,7 +356,7 @@ export class OllamaModelProxy extends BaseModelProxy {
 
       // Get detailed info from template if available
       const baseName = modelName.split(':')[0];
-      const templateMetadata = OllamaTemplate.modelMetadata?.[baseName];
+      const templateMetadata = OllamaTemplate.modelMetadata?.[modelName] ?? OllamaTemplate.modelMetadata?.[baseName];
 
       if (templateMetadata) {
         return {

--- a/src/providers/plugins/ollama/ollama.setup-steps.ts
+++ b/src/providers/plugins/ollama/ollama.setup-steps.ts
@@ -14,6 +14,7 @@ import type {
 import type { CodeMieConfigOptions } from '../../../env/types.js';
 import { ProviderRegistry } from '../../core/registry.js';
 import { OllamaTemplate } from './ollama.template.js';
+import { toCloudOffloadTag } from './ollama.models.js';
 
 /**
  * Ollama setup steps implementation
@@ -25,7 +26,8 @@ export const OllamaSetupSteps: ProviderSetupSteps = {
 
   /**
    * Get credentials for Ollama
-   * Ollama runs locally so no API key needed, just verify it's running
+   * The local daemon needs no API key; an optional ollama.com API key
+   * additionally enables listing models available on Ollama cloud.
    */
   async getCredentials(): Promise<ProviderCredentials> {
     const inquirer = (await import('inquirer')).default;
@@ -86,30 +88,98 @@ export const OllamaSetupSteps: ProviderSetupSteps = {
       throw error;
     }
 
+    // Detect system capabilities (with GPU probe) so model selection can
+    // recommend only the local models that actually fit this machine
+    const { detectSystemCapabilities } = await import('../../../utils/hardware.js');
+    const capabilities = await detectSystemCapabilities();
+    console.log(chalk.dim(
+      `  System: ~${Math.round(capabilities.totalMemoryGb)}GB RAM` +
+      (capabilities.gpuMemoryGb ? `, ~${Math.round(capabilities.gpuMemoryGb)}GB GPU VRAM` : '') +
+      ` (~${Math.round(capabilities.usableMemoryGb)}GB usable for local models)\n`
+    ));
+
+    // Optional ollama.com API key - lets agents run cloud models directly
+    // on ollama.com (no local daemon) and unlocks Ollama's web search/fetch
+    // API (https://ollama.com/settings/keys). Not needed for local usage.
+    const { apiKey: cloudApiKey } = await inquirer.prompt([
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'Ollama cloud API key (optional, for ollama.com direct access):',
+        mask: '*'
+      }
+    ]);
+
+    let apiKey = (cloudApiKey || '').trim();
+
+    // Validate the key against ollama.com before saving it
+    if (apiKey) {
+      const keySpinner = ora('Validating Ollama cloud API key...').start();
+      const { validateOllamaCloudApiKey } = await import('./ollama.models.js');
+
+      if (await validateOllamaCloudApiKey(apiKey)) {
+        keySpinner.succeed(chalk.green('Ollama cloud API key is valid'));
+      } else {
+        keySpinner.fail(chalk.red('Ollama cloud API key validation failed'));
+        console.log(chalk.yellow('  Check your key at https://ollama.com/settings/keys\n'));
+
+        const { keepKey } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'keepKey',
+            message: 'Save this key anyway?',
+            default: false
+          }
+        ]);
+
+        if (!keepKey) {
+          apiKey = '';
+        }
+      }
+    }
+
     return {
       baseUrl,
-      apiKey: '' // Ollama doesn't use API keys
+      apiKey
     };
   },
 
   /**
    * Fetch available models from Ollama
+   *
+   * Offers installed local models, the template's curated recommendations,
+   * and the ollama.com cloud catalog (capability filtering happens in the
+   * selection UI via modelMetadata).
+   *
+   * For local setups (daemon at localhost) cloud catalog entries are mapped
+   * to their local cloud-offload tag (`gpt-oss:120b` -> `gpt-oss:120b-cloud`,
+   * `kimi-k2.6` -> `kimi-k2.6:cloud`) so selecting one pulls an instant
+   * manifest and runs it on Ollama cloud through the signed-in daemon.
+   * When the base URL points at ollama.com directly, raw catalog ids are
+   * used as-is.
    */
   async fetchModels(credentials: ProviderCredentials): Promise<string[]> {
     const { OllamaModelProxy } = await import('./ollama.models.js');
 
-    const modelProxy = new OllamaModelProxy(credentials.baseUrl);
+    const modelProxy = new OllamaModelProxy(credentials.baseUrl, credentials.apiKey);
 
     try {
       const models = await modelProxy.fetchModels({
         provider: 'ollama',
         baseUrl: credentials.baseUrl,
-        apiKey: '',
+        apiKey: credentials.apiKey || '',
         model: 'temp',
         timeout: 300
       });
 
-      return models.map(m => m.id);
+      const isCloudHost = (credentials.baseUrl || '').includes('ollama.com');
+      const ids = models.map(m =>
+        !isCloudHost && m.metadata?.origin === 'cloud'
+          ? toCloudOffloadTag(m.id)
+          : m.id
+      );
+
+      return [...new Set([...ids, ...OllamaTemplate.recommendedModels])];
     } catch {
       // If fetch fails, return empty so setup prompts the user to enter a
       // model manually instead of showing a static, possibly stale list.
@@ -125,7 +195,7 @@ export const OllamaSetupSteps: ProviderSetupSteps = {
     const chalk = (await import('chalk')).default;
     const { OllamaModelProxy } = await import('./ollama.models.js');
 
-    const modelProxy = new OllamaModelProxy(credentials.baseUrl);
+    const modelProxy = new OllamaModelProxy(credentials.baseUrl, credentials.apiKey);
 
     // Check if model is actually installed by querying Ollama directly
     let isInstalled = false;
@@ -162,7 +232,11 @@ export const OllamaSetupSteps: ProviderSetupSteps = {
       console.log(chalk.green(`✓ Model "${selectedModel}" is ready to use\n`));
     } catch (error) {
       installSpinner.fail(chalk.red('Model installation failed'));
-      throw new Error(`Failed to install model: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      const isCloudModel = selectedModel.endsWith('-cloud') || selectedModel.endsWith(':cloud');
+      const hint = isCloudModel
+        ? ' (cloud models require `ollama signin` or a configured Ollama cloud API key)'
+        : '';
+      throw new Error(`Failed to install model: ${error instanceof Error ? error.message : 'Unknown error'}${hint}`);
     }
   },
 
@@ -180,7 +254,7 @@ export const OllamaSetupSteps: ProviderSetupSteps = {
     return {
       provider: 'ollama',
       baseUrl,
-      apiKey: '', // Ollama doesn't use API keys
+      apiKey: credentials.apiKey || '', // Optional ollama.com cloud API key
       model,
       timeout: 300,
       debug: false

--- a/src/providers/plugins/ollama/ollama.template.ts
+++ b/src/providers/plugins/ollama/ollama.template.ts
@@ -20,16 +20,70 @@ export const OllamaTemplate = registerProvider<ProviderTemplate>({
   authType: 'none',
   recommendedModels: [
     'qwen2.5-coder',
-    'qwen3-vl:235b-cloud',
-    'deepseek-coder-v2',
-    'deepseek-v3.1:671b-cloud'
+    'gpt-oss:120b-cloud',
+    'deepseek-coder-v2'
   ],
+  modelMetadata: {
+    'qwen2.5-coder': {
+      name: 'Qwen 2.5 Coder',
+      description: 'Excellent coding model with tool support (7B, ~5GB download)',
+      popular: true,
+      minMemoryGb: 8
+    },
+    'gpt-oss:120b-cloud': {
+      name: 'GPT-OSS 120B (cloud)',
+      description: 'OpenAI open-weight model on Ollama cloud - no local memory required',
+      popular: true
+      // No minMemoryGb: runs on ollama.com, not on the local machine
+    },
+    'deepseek-coder-v2': {
+      name: 'DeepSeek Coder V2',
+      description: 'Advanced coding model with tool support (16B, ~9GB download)',
+      popular: true,
+      minMemoryGb: 12
+    }
+  },
   capabilities: ['streaming', 'tools', 'embeddings', 'model-management'],
   supportsModelInstallation: true,
   healthCheckEndpoint: '/api/version',
 
   // Agent lifecycle hooks
-  agentHooks: {},
+  agentHooks: {
+    // Wildcard hook: adjust env for ALL agents when running against Ollama.
+    // Chained before each agent's own default hooks (see resolveHook).
+    '*': {
+      beforeRun: async (env, config) => {
+        // Claude Code speaks the Anthropic Messages API, which Ollama serves
+        // at the host root (https://docs.ollama.com/api/anthropic-compatibility),
+        // while the profile baseUrl carries the OpenAI-compatible /v1 suffix.
+        if (env.ANTHROPIC_BASE_URL) {
+          env.ANTHROPIC_BASE_URL = env.ANTHROPIC_BASE_URL.replace(/\/v1\/?$/, '');
+
+          // Ollama ignores the token but Claude Code requires it to be set.
+          // A real ollama.com API key is used when configured (cloud access).
+          env.ANTHROPIC_AUTH_TOKEN =
+            config.apiKey && config.apiKey !== 'not-required' ? config.apiKey : 'ollama';
+
+          // Model tiers: ollama model names never match the haiku/sonnet/opus
+          // auto-selection, so route every tier to the selected model instead
+          // of letting Claude Code fall back to its built-in claude-* defaults.
+          if (env.CODEMIE_MODEL) {
+            if (!env.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
+              env.ANTHROPIC_DEFAULT_HAIKU_MODEL = env.CODEMIE_MODEL;
+            }
+            if (!env.ANTHROPIC_DEFAULT_SONNET_MODEL) {
+              env.ANTHROPIC_DEFAULT_SONNET_MODEL = env.CODEMIE_MODEL;
+            }
+            if (!env.ANTHROPIC_DEFAULT_OPUS_MODEL) {
+              env.ANTHROPIC_DEFAULT_OPUS_MODEL = env.CODEMIE_MODEL;
+            }
+          }
+        }
+
+        return env;
+      }
+    }
+  },
 
   setupInstructions: `
 # Ollama Setup Instructions
@@ -52,11 +106,20 @@ Download from: https://ollama.com/download
 **Important**: Some agents require models with function calling/tool support.
 
 - **qwen2.5-coder**: Excellent for coding tasks with tool support (7B, ~5GB)
-- **qwen3-vl:235b-cloud**: Latest Qwen with vision and tool support (235B)
+- **gpt-oss:120b-cloud**: OpenAI's open-weight model via Ollama cloud (120B, no download)
 - **deepseek-coder-v2**: Advanced coding model with tool support (16B, ~9GB)
-- **deepseek-v3.1:671b-cloud**: Latest DeepSeek with advanced reasoning (671B)
 
 **Note**: Models without tool support (like codellama) will fail with agents that require function calling.
+
+## Ollama Cloud (ollama.com)
+
+Signed in locally via \`ollama signin\`? The local daemon authenticates cloud
+models automatically - no extra configuration needed to *run* \`-cloud\` models.
+The cloud model catalog is listed automatically during setup (public endpoint).
+
+An optional API key from https://ollama.com/settings/keys additionally enables:
+- Running cloud models directly on ollama.com (no local daemon required)
+- Ollama's web search / web fetch API
 
 ## Documentation
 

--- a/src/utils/hardware.ts
+++ b/src/utils/hardware.ts
@@ -1,0 +1,113 @@
+/**
+ * System Hardware Detection
+ *
+ * Detects memory capabilities of the current machine so that provider
+ * setup can recommend only the local LLM models that actually fit.
+ *
+ * Heuristics (rule of thumb: model weights + context/runtime overhead
+ * must fit into memory usable by the inference engine):
+ * - macOS (Apple Silicon): unified memory - GPU may wire up to ~75% of RAM
+ * - Linux/Windows with NVIDIA GPU: dedicated VRAM is the binding constraint
+ * - CPU-only fallback: conservative 50% of RAM (CPU inference is slow anyway)
+ */
+
+import os from 'os';
+import { exec } from './exec.js';
+import { logger } from './logger.js';
+
+export interface SystemCapabilities {
+  totalMemoryGb: number;      // Total physical RAM
+  usableMemoryGb: number;     // Memory usable for model weights + runtime
+  gpuMemoryGb?: number;       // Dedicated GPU VRAM, when detected (NVIDIA)
+  platform: NodeJS.Platform;
+}
+
+// macOS unified memory: GPU can wire up to ~75% of RAM
+const MACOS_MEMORY_FRACTION = 0.75;
+// CPU-only / unknown GPU: conservative share of RAM for local inference
+const FALLBACK_MEMORY_FRACTION = 0.5;
+
+let cachedCapabilities: SystemCapabilities | undefined;
+
+/**
+ * Probe NVIDIA GPUs for dedicated VRAM via nvidia-smi.
+ * Returns the largest single-GPU memory in GB, or undefined when no
+ * NVIDIA GPU / driver is present.
+ */
+async function detectGpuMemoryGb(): Promise<number | undefined> {
+  try {
+    const result = await exec(
+      'nvidia-smi',
+      ['--query-gpu=memory.total', '--format=csv,noheader,nounits'],
+      { timeout: 3000 }
+    );
+
+    if (result.code !== 0) {
+      return undefined;
+    }
+
+    const valuesGb = result.stdout
+      .trim()
+      .split('\n')
+      .map(line => parseFloat(line.trim()) / 1024) // MiB -> GiB
+      .filter(value => !Number.isNaN(value));
+
+    return valuesGb.length > 0 ? Math.max(...valuesGb) : undefined;
+  } catch (error) {
+    logger.debug('GPU detection skipped (nvidia-smi unavailable):', error);
+    return undefined;
+  }
+}
+
+/**
+ * Detect system capabilities, including an async GPU probe.
+ * Result is cached for the process lifetime; call this early in async
+ * setup flows so later sync consumers (choice rendering) can use
+ * getSystemCapabilities().
+ */
+export async function detectSystemCapabilities(): Promise<SystemCapabilities> {
+  const totalMemoryGb = os.totalmem() / (1024 ** 3);
+  const platform = os.platform();
+
+  // macOS uses unified memory; probing for a discrete NVIDIA GPU is pointless
+  const gpuMemoryGb = platform === 'darwin' ? undefined : await detectGpuMemoryGb();
+
+  const usableMemoryGb = platform === 'darwin'
+    ? totalMemoryGb * MACOS_MEMORY_FRACTION
+    : (gpuMemoryGb ?? totalMemoryGb * FALLBACK_MEMORY_FRACTION);
+
+  cachedCapabilities = { totalMemoryGb, usableMemoryGb, gpuMemoryGb, platform };
+  return cachedCapabilities;
+}
+
+/**
+ * Get system capabilities synchronously.
+ * Returns the cached result of detectSystemCapabilities() when available,
+ * otherwise computes RAM-only heuristics without GPU probing.
+ */
+export function getSystemCapabilities(): SystemCapabilities {
+  if (!cachedCapabilities) {
+    const totalMemoryGb = os.totalmem() / (1024 ** 3);
+    const platform = os.platform();
+
+    cachedCapabilities = {
+      totalMemoryGb,
+      usableMemoryGb: platform === 'darwin'
+        ? totalMemoryGb * MACOS_MEMORY_FRACTION
+        : totalMemoryGb * FALLBACK_MEMORY_FRACTION,
+      platform
+    };
+  }
+
+  return cachedCapabilities;
+}
+
+/**
+ * Check whether a model with the given memory requirement fits the system
+ */
+export function modelFitsSystem(
+  minMemoryGb: number,
+  capabilities: SystemCapabilities = getSystemCapabilities()
+): boolean {
+  return minMemoryGb <= capabilities.usableMemoryGb;
+}


### PR DESCRIPTION
## Summary

Adds first-class Ollama cloud (ollama.com) support to the ollama provider: merged local + cloud model listing, an optional validated API key, capability-aware model recommendations in setup, and ollama profile support for the claude, codex, and pi agents (previously allowlist-rejected).

## Changes

- **providers/ollama**: merged local + cloud catalog listing with origin tags; optional ollama.com API key prompt in setup (validated via the auth-enforced `web_search` endpoint); Bearer auth on tags/pull/delete; full cloud catalog offered in setup via local `-cloud` offload tags; retired recommended models replaced (`gpt-oss:120b-cloud`); `modelMetadata` for recommended models; wildcard agentHook adapting agent env (Anthropic-compatible base URL, placeholder token, model tiers)
- **utils**: system hardware capability detection (macOS unified memory, NVIDIA VRAM via nvidia-smi, conservative CPU fallback)
- **providers/setup**: `ModelMetadata.minMemoryGb`; setup choices that exceed usable system memory are disabled with an explanation
- **cli**: `codemie models list` shows an ORIGIN column when models carry origin tags
- **agents**: ollama in `supportedProviders` for claude/codex/pi; codex emits its custom `model_providers` block for ollama (Responses API) and skips the CodeMie catalog lookup; pi writes an `ollama` provider into pi's models.json

## Testing

- [ ] Tests added/updated
- [x] Manual testing done

Manual e2e against a live ollama profile: `codemie-claude`, `codemie-codex`, and `codemie-pi` all completed tasks via `gpt-oss:120b-cloud` through a local signed-in daemon; `codemie models list` shows 3 local + 18 cloud models with origin tags; setup wizard disables local recommendations that exceed system memory.

## Checklist

- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`

Note: per repo testing policy, no new unit tests were added (tests only on explicit request).