### PR TITLE
feat(cli): add docs & knowledge tools and openwiki agent

### DIFF
--- a/.openwikiignore
+++ b/.openwikiignore
@@ -1,0 +1,15 @@
+# OpenWiki read boundary — keep generated docs away from build output,
+# dependencies, and AI-agent working artifacts.
+node_modules/
+dist/
+coverage/
+.hypothesis/
+.pytest_cache/
+.scannerwork/
+.sonarlint/
+*.log
+
+# Agent working artifacts (plans, runs, cached guides) — not codebase docs.
+.ai-run/
+.codegraph/
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ Why this is mandatory:
 - Guides contain curated patterns, conventions, and architectural decisions.
 - Guide-first work reduces duplicated investigation and avoids anti-patterns.
 
+Knowledge sources and precedence:
+
+- `.ai-run/guides/` owns workflow and policy: git workflow, quality gates, testing rules, security policies, coding standards.
+- `openwiki/` (generated, see the OpenWiki section below) owns codebase facts: architecture, CLI surface, plugins, configuration behavior.
+- On disagreement: guides win for process; source code wins for facts. Report stale guides instead of working around them.
+
 ### 2. Tests Only On Explicit Request
 
 Only write or run tests when the user explicitly asks for it.
@@ -215,6 +221,7 @@ See `package.json` for exact dependency versions and `.ai-run/guides/architectur
 | `opencode` | `opencode/` | `opencode-ai` | Session metrics via `codemie opencode-metrics` |
 | `pi` | `pi/` | `@earendil-works/pi-coding-agent` | Redirects `PI_CODING_AGENT_DIR` to `<cwd>/.pi/codemie/agent`; metrics via injected extension + run ledger |
 | `kimi` / `kimi-acp` | `kimi/` | `@moonshot-ai/kimi-code` | ACP variant prepends `acp` to argv |
+| `openwiki` | `openwiki/` | `openwiki` | Docs/wiki tool, not a chat agent; declarative-only adapter — `envMapping` feeds the profile's base URL/key/model to `OPENAI_COMPATIBLE_*`/`OPENWIKI_MODEL_ID`, SSO/JWT goes through the local proxy |
 | `copilot-cli` | `copilot-cli/` | none | Analytics ingestion only — never installed or launched by CodeMie |
 
 Not agent adapters, but injected runtime plugins under the same tree: `codemie-code-hooks/` (injected into `codemie-code` and `opencode`) and `reasoning-sanitizer/` (injected into `codemie-code`).
@@ -224,6 +231,10 @@ Not agent adapters, but injected runtime plugins under the same tree: `codemie-c
 `sso` (CodeMie SSO — default, owns the local proxy), `jwt` (Bearer Authorization), `litellm`, `bedrock`, `ollama`, `anthropic-subscription`, `moonshot-subscription`.
 
 Proxy plugins live under `src/providers/plugins/sso/proxy/plugins/` — see `.ai-run/guides/` and `docs/ARCHITECTURE-PROXY.md`.
+
+### Documentation & Knowledge Tools (`src/frameworks/plugins/`, `group: 'documentation'`)
+
+Deterministic docs/knowledge tooling (not agent harnesses): `codebase-memory` (MCP + graph UI), `codegraph` (local code intelligence graph + MCP), `graphify` (knowledge-graph skill for Claude Code). Managed via `codemie docs list|install|init <name>`; also visible in the grouped `codemie install` listing. OpenWiki is the exception — it is model-backed, so it stays an agent plugin (`codemie install openwiki`, `codemie-openwiki`) and is listed by `codemie docs` as a pointer.
 
 > Neither `.ai-run/guides/integration/external-integrations.md` nor `docs/AGENTS.md` covers Pi yet. For Pi work, read `src/agents/plugins/pi/` directly plus the design docs under `docs/superpowers/specs/`.
 
@@ -269,3 +280,16 @@ Run `codemie doctor` and `codemie-code health`. If the correct pattern is unclea
 - Keep confidence and policy gates explicit.
 - Follow the project architecture rather than inventing local shortcuts.
 - Deliver complete, secure, production-ready changes without placeholders.
+
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+This repository has a generated `openwiki/` evidence index. It is optional just-in-time context, not required startup reading.
+
+- Treat source code and tests as authoritative. A brief's unknowns and review items are verification gaps, not automatic requirements.
+- Prefer the narrowest quiet validation that proves the changed behavior. Preserve complete failure output.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,11 @@ Claude Code entrypoint for this repository.
 `AGENTS.md` is the canonical source of truth for repo-wide instructions, workflow, policies, and quick references. Keep this file minimal and edit `AGENTS.md` instead.
 
 @AGENTS.md
+
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+See [AGENTS.md](AGENTS.md) for OpenWiki agent instructions.
+
+<!-- OPENWIKI:END -->

--- a/README.md
+++ b/README.md
@@ -213,9 +213,32 @@ CodeMie installs external agents, routes them through the CodeMie proxy, and tra
 | Pi | `codemie install pi` | `codemie-pi` | `@earendil-works/pi-coding-agent` |
 | Kimi Code | `codemie install kimi` | `codemie-kimi` | `@moonshot-ai/kimi-code` |
 | Kimi Code ACP | `codemie install kimi-acp` | `codemie-kimi-acp` | `@moonshot-ai/kimi-code` (`acp` mode) |
+| OpenWiki | `codemie install openwiki` | `codemie-openwiki` | `openwiki` |
 | GitHub Copilot CLI | `codemie install copilot` | `codemie-copilot` | `@github/copilot` |
 
 ACP agents are launched by your IDE, not directly — see [ACP Agent usage](#acp-agent-usage-in-ides-and-editors) below.
+
+### Documentation & Knowledge Tools
+
+CodeMie also manages documentation tooling for your agents — install globally and initialize per project with `codemie docs`. These fall into two capability groups:
+
+- **Authored documentation** — prose a human or agent reads. *OpenWiki* generates a linked Markdown wiki (`openwiki/`) with validated Mermaid diagrams and grounded, source-cited claims; it maintains the wiki on every change (`--update`), can refresh it from a scheduled GitHub Action, and points your coding agents at it via a managed block in `AGENTS.md`/`CLAUDE.md`. It runs on your CodeMie profile (SSO/LiteLLM/Ollama), so no separate API keys.
+- **Queryable knowledge graphs** — indexes an agent queries at runtime instead of re-reading files. *Codebase Memory MCP* (persistent code intelligence graph, auto-indexing, 3D graph UI via `codemie codebase ui`), *CodeGraph* (local-first symbol index: `query`, `callers`/`callees`, `impact`, MCP server for Claude/Codex/OpenCode via `codegraph install`), and *Graphify* (multimodal knowledge graph over code + docs + PDFs + images, with an interactive `graph.html`, agent-crawlable wiki output, and a `/graphify` skill for Claude Code).
+
+| Tool | Install | Init in project | What it does |
+|---|---|---|---|
+| Codebase Memory MCP | `codemie docs install codebase-memory` | `codemie docs init codebase-memory` | Persistent code intelligence graph + 3D UI |
+| CodeGraph | `codemie docs install codegraph` | `codemie docs init codegraph` | Local-first code intelligence graph + MCP server |
+| Graphify | `codemie docs install graphify` | `codemie docs init graphify` | Queryable knowledge graph (Claude Code skill) |
+| OpenWiki | `codemie install openwiki` | `codemie-openwiki --init` | Agent-written, self-updating repo wiki (uses your CodeMie profile) |
+
+```bash
+codemie docs list                            # status of all docs tools
+codemie docs install codegraph               # install a tool globally
+codemie docs init codegraph                  # initialize it in the current project
+```
+
+The tools complement each other: OpenWiki keeps human/agent-readable docs current, while the graph tools give agents fast structural lookups at runtime. See [docs/COMMANDS.md](docs/COMMANDS.md#documentation--knowledge-tools) for the full command reference.
 
 ```bash
 codemie install claude --supported             # install

--- a/bin/codemie-openwiki.js
+++ b/bin/codemie-openwiki.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * OpenWiki Agent Entry Point
+ * Direct entry point for codemie-openwiki command
+ */
+
+import { AgentCLI } from '../dist/agents/core/AgentCLI.js';
+import { AgentRegistry } from '../dist/agents/registry.js';
+
+const agent = AgentRegistry.getAgent('openwiki');
+if (!agent) {
+  console.error('✗ OpenWiki agent not found in registry');
+  process.exit(1);
+}
+
+const cli = new AgentCLI(agent);
+await cli.run(process.argv);

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -273,3 +273,39 @@ codemie setup
 # View metrics
 codemie analytics --agent opencode
 ```
+
+## OpenWiki
+
+OpenWiki (https://github.com/langchain-ai/openwiki) — an agent that writes and maintains a linked Markdown wiki for the current repository, kept current as the code changes. CodeMie runs it through the active profile, so it works without separate API keys.
+
+**Installation:** `codemie install openwiki`
+
+**Requirements:**
+- Node.js 22.0.0 or higher (OpenWiki upstream requirement)
+- An authenticated CodeMie profile (`codemie setup`)
+- Supported providers: **AI/Run SSO**, **Bearer Auth (JWT)**, **LiteLLM**, **Ollama**, **Moonshot subscription**
+
+**How CodeMie runs it:**
+OpenWiki reads its model access from `OPENWIKI_PROVIDER=openai-compatible` plus `OPENAI_COMPATIBLE_BASE_URL`/`OPENAI_COMPATIBLE_API_KEY`/`OPENWIKI_MODEL_ID`. The CodeMie adapter maps the active profile onto those variables: SSO/JWT profiles go through the local CodeMie proxy (authentication and `X-CodeMie-*` attribution headers are injected there), other providers forward their configured base URL and key. The profile model becomes `OPENWIKI_MODEL_ID`.
+
+**Features:**
+- Generates a repo wiki under `openwiki/` (architecture, concepts, integrations, operations) with validated Mermaid diagrams
+- Grounded Claims: factual pages carry versioned source evidence; `--update` re-verifies them against code changes
+- Updates `AGENTS.md`/`CLAUDE.md` with a managed `OPENWIKI:START/END` block pointing agents at the wiki
+- Respects `openwiki/INSTRUCTIONS.md` (user-authored brief, preserved across runs) and `.openwikiignore` (read boundary)
+- Interactive graph visualizer (`visualize`), including static export for GitHub Pages/MkDocs
+- Self-updating via scheduled CI (GitHub Actions, GitLab CI, Bitbucket)
+
+**Usage:**
+```bash
+codemie-openwiki --init                 # Generate the repo wiki (first run)
+codemie-openwiki --update               # Refresh the wiki for changes since the last run
+codemie-openwiki visualize              # Explore the wiki as an interactive graph
+codemie-openwiki --task "Summarize the plugin system"   # One-shot question via the profile model
+codemie-openwiki --profile work --update                # Profile override
+```
+
+**Notes:**
+- `--task` maps to OpenWiki's one-shot print mode (`-p`).
+- OpenWiki prints a heuristic warning when the profile model ID (e.g. `claude-sonnet-5`) is not one of its known OpenAI-compatible presets; the request still works through the CodeMie gateway.
+- For scheduled refresh, see the `openwiki-update.yml` workflow template in the upstream repo (`examples/`).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -23,6 +23,7 @@ codemie doctor [options]         # Health check and diagnostics
 codemie plugin <command>         # Manage native plugins
 codemie mcp-proxy <url>          # Stdio-to-HTTP MCP proxy with OAuth support
 codemie codebase <command>       # Manage Codebase Memory graph UI
+codemie docs <command>           # Manage documentation & knowledge tools
 codemie version                  # Show version information
 ```
 
@@ -40,6 +41,25 @@ codemie codebase open                    # Open the graph UI URL only
 ```
 
 `codemie-<agent> init codebase-memory` runs the upstream MCP installer configuration, enables automatic indexing, and indexes the current repository. The graph UI defaults to `http://localhost:9749`.
+
+## Documentation & Knowledge Tools
+
+```bash
+codemie docs                             # List documentation tools and their status
+codemie docs list                        # Same as above
+codemie docs install <name>              # Install a tool globally (codebase-memory, codegraph, graphify)
+codemie docs uninstall <name>            # Uninstall a tool
+codemie docs init <name>                 # Initialize a tool in the current project
+codemie docs init <name> --cwd <path>    # Initialize in a specific directory
+```
+
+Available tools:
+
+- **codebase-memory** — persistent code intelligence graph with MCP tools and a 3D graph UI (`codemie codebase ui`). `init` runs the upstream MCP installer, enables auto-indexing, and indexes the repo.
+- **codegraph** — local-first code intelligence: builds `.codegraph/` (symbol index with `query`/`callers`/`callees`/`impact`). `init` builds the initial index; afterwards run `codegraph install` to wire its MCP server into Claude Code/Codex/OpenCode and `codegraph sync` to refresh.
+- **graphify** — multimodal knowledge graph (code, docs, PDFs, images) as a Claude Code skill. `install` uses pipx/pip (Python 3.10+ required); `init` registers the `/graphify` skill, then run `/graphify .` inside Claude Code to build the graph.
+
+OpenWiki is model-backed and managed as an agent instead of a docs tool: `codemie install openwiki`, then `codemie-openwiki --init` to generate the repo wiki and `codemie-openwiki --update` to refresh it. It uses the active CodeMie profile (SSO proxy, LiteLLM, or Ollama) — no separate API keys.
 
 ## Framework Init Commands
 

--- a/openwiki/.claims/architecture/cli-surface.json
+++ b/openwiki/.claims/architecture/cli-surface.json
@@ -1,0 +1,300 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:40005670bf388a429975ecd875b53c455c4c47f768e8cb85d1c63dff47dc1334",
+  "claims": [
+    {
+      "id": "claim_39239fb527c645b79146ea00d4e21376",
+      "statement": "The ESM Node 20+ package publishes its CLI surfaces through the package `bin` map and includes `bin` in the packaged files, while its programmatic entry is `dist/index.js` with declarations at `dist/index.d.ts`.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L188-L190",
+          "version": "repo-lines-v1:sha256:61e2536f49f4f187a161e8ed7c7a55149cb5ae98d7efe9ecf0dbcf04a363c72e:eyJzZWxlY3RlZExpbmVDb3VudCI6MywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNWY2MDE1NTQxMjJlZmU4NTVkNTZlMTBjYzliYWYyMDMxY2EzZjRhYjExY2RiYTIyZjFlYmM1ZDM5YTc1NTgyNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNjI5ZTQ1ZjQ4MzYwMWY0MGM0Nzc0ZGY5ZDUyNjhiNTA2ZjAxMTg3Y2NkOTBmMGY3MDAwYWM0YTE4NjU2NjkyNCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjEsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDEyY2EzNDVjY2Y3NWJmOWMwODA2YmNlNjk1YmU4ZGU4MDhiNzk5ODQyNTFhN2E1NGQyMDJjZjYxMDFkZDQ1MSJ9"
+        },
+        {
+          "resource": "repo://package.json#L2-L30",
+          "version": "repo-lines-v1:sha256:9a8de53e0815abfdb863c84cd73cb76431c68f5abac3f7a4826b17ee7a0a47e1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ2OGQ0YTYzZmY3MjkyYmZmNmZiYTg1MjBlOWFlY2JhZTZmYzZjNjkzNjk1N2RjMTdjOGNkOTY2MGQ3ZDBkZTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk2NGQ4YzA3MzQyOTg5MzEwMTU3NmQ4OGQ5OTEyN2U4OWQ2ODkxZDNiMTdlODlkZjAyZWM5YWU3MDcwNWQ4YmUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoxLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2ZmIwOGZkYTFhY2I5NTdiNjExNmJkMzc4MTFhMWZlNDFhMDE2MTFjMDYzMWVkYmY3ODZkNjg4OWEyN2E1NWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkxNGYwYmY1N2UxMDU2NWY0ZjYyZjIwMTQ0MDVkNzRlYTY1MGE4MmM2ODRjMjNiNDJmYWQ1MTM4YjA5Y2RmYzcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_5e05943728834906b0e0ae0703e1b37e",
+      "statement": "The package publishes `codemie` for management, direct wrappers for the built-in and supported agent integrations, `codemie-mcp-proxy` for the MCP bridge, and `proxy-daemon` for the local daemon.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L8-L21",
+          "version": "repo-lines-v1:sha256:5b410cb48060e62393262fd2ba588db58d71ba5500b5dc0fff73dfacdfe4c31d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2YzE0NzU3YjhlMWU5ZDZhN2RlZTk5MDJlOTA0MDdhZDhjZjY3M2IzZThkNzYzZTI3OTUwZDE5ZDA2NzhkNjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIwMDA2MjQ0MWQ4MTU0OTI5NmYzMzE4YmExYWZlMjkzOTBhMWQxMDQxYzBhYzkzZTc4OTFlNmFlODc0YzQ4NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc0ZjUyM2MyZGM1MzgxYjQ4ZjYxMDE0ODQwYWJhYWQ1Mzc3MzRkYzRjNDhkMjBmNzgzNjAzMjBmZWEyYWU5MzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVmMWI3NTgxNmNlMTMwNTVkYzg4YjY2Y2YwZmYxZjE3OTNiNDc4OWJhMGZjMDliYzQ4YTg1YmFhMDc0NDI2YTYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f599cfd7183c4eba8382b3a87c692cbb",
+      "statement": "Direct agent launchers resolve a named adapter from AgentRegistry, exit with status 1 when it is absent, and delegate the original argv to AgentCLI; separate agent entry files also avoid Windows npm wrapper detection issues.",
+      "evidence": [
+        {
+          "resource": "repo://bin/agent-executor.js#L3-L24",
+          "version": "repo-lines-v1:sha256:d49551a1793148d1b3893a8c3d1bf4fd4574220e0f3ba6c3ed544177661395bc:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-claude.js#L3-L18",
+          "version": "repo-lines-v1:sha256:813d61b4155106eb5cc4c95dc16fa7527d35ed340432cb4a3bbcf58d98eeb68f:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_912a1f6657604a478eb0699bd3e37698",
+      "statement": "AgentRegistry lazily registers built-in agent plugins on first access, and separates manageable agents from analytics-only adapters so management surfaces do not advertise or modify unmanaged third-party installations.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/registry.ts#L17-L74",
+          "version": "repo-lines-v1:sha256:b1887c08a65f139fa26df9dd7cb899dd935548daaf70b776c445bcc9b4c30943:eyJzZWxlY3RlZExpbmVDb3VudCI6NTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFmNTYyODM2YWIxZTgyYWQ1MmFiNzZiNGUwNTIyNTIyZWJlZGU3OTUyYmEyMDE2ZDhkNDkzZWU2OGQ4MzdiZjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkwNGNjY2NhYjEzMTI4NGEyZWRkNmFhZTA0NjAxYzEzMWRiZmJjZGM3ZWE1MTFmZWU1MmY2MDEzMDNiMjE3YWYifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L76-L129",
+          "version": "repo-lines-v1:sha256:12d9b58f332cd297ec4f53d337bb51c0013eced77d9d1047cb96102d5321d725:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxN2UyNDQxNWY5MjZlMTAwOWY0MTA2YzdkMzFkYzdkMTE4ZjA3ODBmMTQ2NDRlZjkyNjJhZDdlZWMyZjRiNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI2MzE0ODFhZTIwMDUxNDgwMzk2NjgxZGE3ZWM4ZmRjYTRmOWU1YTBkNjI5YzdlYTVjYjljM2MwNGU1MWZkNTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmNzM5YTA2YzFjYmIxMjQ0ZTMzNjNkMzhiY2Y5ZmE1MGNlODRmZWQzOTljMjE5M2EzYzdmMDhkNTk5MThiMmEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f0860282a9004bd399de0e96e874c0cb",
+      "statement": "The `codemie` root Commander program registers provider and framework plugins, derives its version with a fallback, and composes independent command factories for setup, profiles, agent management, diagnostics, workflows, telemetry, MCP, proxy, and codebase operations.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/index.ts#L1-L60",
+          "version": "repo-lines-v1:sha256:c81c6bd5405d726b685738e9b61914fe88105b9adff0a84ca6df4034e94a9920:eyJzZWxlY3RlZExpbmVDb3VudCI6NjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE1OWM0Nzg3MmI3MWYxMjU4OTk0Mjg5MjQ2NGU3NjRjMGRiMzUwYzIwYjcyMjI4NjQ1NjE1Y2MzNmUwYTA3MjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE0MjA0YjZmOTFlMmQ3N2I2ZjA2MzQ5MmQ2ZjRkN2I5NjI3YzNiNTA2YzY4ZjQ0Y2YyMzM2OGExNjE4ZDJmYmQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjBiNDUwNDdkNTc0Y2Q2NDVlMjRlZGQ0NzhiNGVmODVmMzRhNzQ5NjAwMjI4OTkwNWFkMzQ4ZDI0NmY2M2FmMTkifQ"
+        },
+        {
+          "resource": "repo://src/cli/index.ts#L78-L104",
+          "version": "repo-lines-v1:sha256:e35ee471d630218c27486cc013a799475df5471924f93dd6e630bd03a159f2e9:eyJzZWxlY3RlZExpbmVDb3VudCI6MjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImViMDM0MDM2Nzk4MzljNmRiYjdmN2EyNDhmZDU5YTQyNDA1Y2RlNjEyMjcyZmZjYzhiZDcyZGFiMmZlMDI2N2MiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE5NDIxMzBjMDk1ZDk2ZDZkZjI5N2E4YmUyYjlkZDE5NGIzMTQyNGFlZGExNzYwNzMwZTZjYTk5YTM5ZjczZWEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjEyNDI5NjBlMWZmMWQ2YjU2NTIyOTQ3NWFlMTA1NGI4NDU2ZTg5OWEwMDAwNzQ4MjY4YjdmODRlODRiNjRmMTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM1MTgzYTQ0YzEwZDVmZWFhMWFjZjU2Mjk0NWVmOTU1ODVkYWM0MmFmZDU1NTg4ODBlNTEyMGRjMDkwYjZmYmIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d268e0931f8c456fa7be69a4431417f0",
+      "statement": "At the root, `codemie --task <task>` resolves the built-in agent and delegates argv to AgentCLI, while bare `codemie` presents first-run or returning-user guidance and other invocations use normal Commander parsing.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/index.ts#L106-L145",
+          "version": "repo-lines-v1:sha256:9e7497b7c863b107c1e9235c10bdaf57fbc242888c6c20d2c4dbeb8fee9f68d9:eyJzZWxlY3RlZExpbmVDb3VudCI6NDAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ0MDNlOWIyZWI5MGMyZGM5NjZjMWEwNjA0MGNkYWM4MjkxMzAxMzMwZmQ2YTcwMmVlNTQ0ZWQ4ZTVkNGQzYTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMxNjUxZDEwNTg5ZjA5MGE3YWU3ODU0YzExNTY3NmQ2MjQ4MWZhOTcwZDFlYzkyNmYxNmNkMWE2M2FmOGQ3ZjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI0YTY2MDkxYWQwZDRiNDYyOTYxOGE3NGUwNmU0N2UyOTFlYWIzYWE5MWU4M2U2MDk2OTYxMDhlMmNlNzQyZmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_635408f0011c4eb58f23f40ea373c3d3",
+      "statement": "The `codemie` launcher runs pending migrations and a nonfatal update check before dynamically loading the compiled root CLI, but skips update checks in test environments; migration failures warn without blocking startup whereas compiled-root import failure is fatal.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie.js#L8-L39",
+          "version": "repo-lines-v1:sha256:ac50537cb1c125c1c161b6d9921d80a4421b377ebdc39eea9390390a8a0cb783:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQzMTVjZWU0ZDczZGJmNjA2ODhhNDNhNzdhZmQ1NGIxMTczYzdmYTc5Njg2ZDZhNzZkYmY3ZDk4ZmYzZDJjYmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3Yzc1OTk5NjkwZWIzODAzNGFkNmE3YzIwZTY3M2ZiYzczM2YwOWZjYWZmOWI3NzZjZGQ5MzM1MTU2YWZlMTQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b32837fd6e1147228e02059307a3fd60",
+      "statement": "AgentCLI provides a shared Commander contract for direct agent wrappers, including common configuration and session options, unknown-option/positional pass-through, health, selective setup commands, and a non-shadowing init command.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L63-L140",
+          "version": "repo-lines-v1:sha256:f2eb1777c400d86b563fdb9e6dcd0f962e2a88fd8345e97660afea28534df6c4:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdmNDg5ODE1M2I5ZWVhOTQyYjhjMTA2MjE0OTQwODFjMWRkNTg1MjI0NGY5MmU2YTVhMjMxYjIwMzI5MDM4MTciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY0MDEzOGFkYzNkNjJiMzdlMTcxNDVkZThiNzA3Y2QxMzdhYjgxOWFhOWYxZDVkZDk0YzVkYjk5MmE4OWZmODEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L638-L640",
+          "version": "repo-lines-v1:sha256:90b970b751788e5daeff9dd7c20c089d9de94cfc7afbc660303c8c6da0b1ee1e:eyJzZWxlY3RlZExpbmVDb3VudCI6MywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiOThmOTJjZjZlOThlZjc3M2YwNjViY2Y3NTllNjg0MGRlMDI3ZTc1Y2FiMzY3ZGE4MjhhOWNhMGIxZDJkZDRkMSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiMzViMWJjM2YyOGNmN2U5Y2Y2YmRiMDUxNGI2MzNmNTExMWU0NDZkZDUwMjAxYjQ2MGNlY2ZiNDRjOGNkNWMxNiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMGJiMWY1NGRhN2U2YWY4MWNlYTk4NTlhNWVmNzg3ZTc4ZGRkYzE4MGEwMTNlYjk2MmMwMTYzZGZkNjZiNTYzZSJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_784d53e0d33e4003a4d7073f370fc69d",
+      "statement": "Before adapter execution, AgentCLI validates installation, configuration, authentication, provider/model compatibility, and reasoning effort; it gives `--jwt-token` precedence, exports the resolved profile as environment, strips configuration-only options from pass-through arguments, and exits nonzero after user-facing error reporting on failure.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L158-L280",
+          "version": "repo-lines-v1:sha256:a992487a5a065ba445b278162728e4e48f78c1e124fc7cbd8a6718ad29bf90d9:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjMDViYzhlYzAyNDkwNGY4ZTk1MTJlMDA1MGM3YzcxODk3OGEyY2QyNzhkMWVjYWJjMzIyMWM0NjM0OGYwNjFmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyNWRkMjM5MGE2NmM0ZmY3YWYwZWU2MWVlMGVkNzRlYmRiMTU1MTU3MWZkOWRhNjg2ZmYxMjgwOTZjODNlNjE0IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyOTZjNmFiNzAxNzUxYTlmNDcxOGMyYmZlYzU5ZjE4MjE1YWQzNTUzZjBjYjEyYzk1MDBmNTFhOTFiNzM3MDJiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwMDMyOWE2NjMxMzUwMjE0ZDBjMWI4ZTEzZDI1ZmNhNjJiNmQ1Y2U3MmE4NGI4MzQ1ZDM0OWZmZDZlZjVkZDQwIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L342-L374",
+          "version": "repo-lines-v1:sha256:35cf08eaaca9d0b0adf6a9a6e5ac4e92ec040d70bdeb1ce0dd32845004464173:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJlMjM3NzQ1MGNmZmZmNDhhYTI2N2Q1MDg5YTYxMTZkMDk1OGMwNWM2ZjE1OTk4NzA0M2I1MDVlNjlmYWQyYTYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjkwZDJjZGM3ODU5YzE5ODZhNGMwZjcyMGQ5NzdhZGQwZmFmYTJlNWUwMmY5YzI3YTYyN2M5ZjcyMDQ0NGQxNWMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjAxMzQxZDBjNTg4MmU5MWE2NmM2MGNiODYwMjBiMjQ3ZjBhZmMzMzZjZGY3NmMwYWUxOGJjZDIwYWM4ZmUxZDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEwZWFhODM5MzNkYWQyOWY0NGVjM2U3NzUwMWU0ZjI1M2VhZmEzMDkxN2Q1NTZjODI0Mjk2YmUyNDBmNDIxZTIifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L453-L471",
+          "version": "repo-lines-v1:sha256:990d00b589bd3e28278adf7dce5b877604908d2b679ad3eebaba3d2bc21d52e0:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBkNDBhZDM2NzQ1YTdjZDViNjIzMzg5NTZlNGU4MjY1MWFhM2EzZTg5N2NlNzMwZDk1ZTAyY2I2ZTU3NzVmNWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ5MGZlZTEzMDhlM2FjMDE5Zjk4ZGM2YWNmMWQ5MmFhNjFiZTFmMjc4M2E2N2MxY2FjNDE1M2VkZjI5YjkwYjEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L591-L617",
+          "version": "repo-lines-v1:sha256:60369ab955ad83c1fb62a9544dab1f147b24dc992fc5e2934d5e94862d0bd28a:eyJzZWxlY3RlZExpbmVDb3VudCI6MjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUxNjkzN2Q5ZDYzZGJhYjA0ZTQwN2JkMDc0NTRkNTg5YmZlMzlhNjk1Y2I4ZjU0MjIzYWQ5YWQxNTRkMzRlZjAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJhN2M2NzRmMjI4MmFhYjRjYjlkMjRhMjIzYTY5MjQwMjM0ZjZjZmNlODdhZDk0ZTRlZmZmNjYyMzg1ODUyODUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjcwZmUwYTc5OGIxN2ZlZmFhM2ExMjIyOTc2NTlkNzY3MTExMzgwZGVhOWIzY2ZkMGM1YjBiNjkxZjUyZTI0YzcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f9ada82f9c3144299a98bff56761dac6",
+      "statement": "AgentCLI uses adapter resume-ownership resolution to block external-session resumes in noninteractive contexts; interactive confirmation records audit events and injects `CODEMIE_SESSION_ORIGIN=external-resume` into the child environment so the session is not ingested as CodeMie-owned.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L376-L448",
+          "version": "repo-lines-v1:sha256:900d6b85ea8ec66f5b4491255e337e888edc59a812bc253633b58ccd759be927:eyJzZWxlY3RlZExpbmVDb3VudCI6NzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBhNWU4MjgwMmFlZjRlZTMzNjQwNzc4M2QyYjA0MzA4MzhiZDlmMTNiYjkyNTU4NjAxODMyOGI1YzIxMjc5NWUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNjJmNjBkODU5MGE1NzljZjQ2ZjhkNjczNzhjNGM1NzJiOTYyY2VjY2RiOTBjN2E1ZjdiNDJiOTYwNzgyYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjczMGY5ZTUyNDAzNTUwZDlmMzEyOTBjMjgyY2Y0ZmYyOTRkNWI1YTljNmYwNzU1NmM1N2UwYTIyMTg1Y2Q0NmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ2OWRjNTNiNDJjZGFlZDE5OTI3Y2FlZWJjM2FmNzY1ZjY3NDVmMjY5ZDM5MjZmNDNjY2UxZDQ3NGIwYjA2OWIifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L697-L755",
+          "version": "repo-lines-v1:sha256:1b2ff928005e038ca3642e56a0b40dafac794bc8a634716b76b7ed73d24e4dc5:eyJzZWxlY3RlZExpbmVDb3VudCI6NTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhmODVlMjA3NzM2YjNlZDE4MjgxNDIzZmViYjg4MjQ2ODJmN2I4ZmE0MzMxYzY4NjdlNzFjMDBkYjRmNTMwNzIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjYwNjYwNTg5Y2Y1NGJiZTYxNWY3MDliNjllMjk5MzFkNDFjZmJiN2Q4ODM5MGE3ZjdmODQ3OTQ3ZGIwOTMwMDIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/__tests__/AgentCLI-resume.test.ts#L59-L139",
+          "version": "repo-lines-v1:sha256:b5072ff46fa880881d4aaaa4105f62de5c188b3954a5b7ea07bf5f1f09be73a4:eyJzZWxlY3RlZExpbmVDb3VudCI6ODEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQzYzA4MDJjNmQ2MTM5ZWQxYjVjNmQxMDM2ZDA3N2JlODgwZmRkODY3NDUzNGNlNGRmODUxZGU1MDQ2ZDM1MDAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjEyMzIxMGZjNmY2ZTBiMzNhOWQyOTk5NWUwZGEzODZkMjY4NWMzNTU5NzQxM2M3MjlmZWNhYzRmMmY2MzdkZGEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjUzZjczYjA5Mzg5NmU4MmY3ZWM5YmRjNDNhZDNkZTY4OWIxMjBiZmZkM2M3ZjQ3YzNmNWM3ZTA5NDJkY2YxM2QifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_5b91297e42bb4678bd6840e5e08edee9",
+      "statement": "`codemie-copilot` adds wrapper-specific model resolution: it can list models, prompt and persist a selection for a valueless `--model`, and applies a saved model only when CLI and environment do not already override it before handing control to AgentCLI.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie-copilot.js#L18-L30",
+          "version": "repo-lines-v1:sha256:e047a6cae209f80467859afc6a3bb68493507d98321b438942b82bdcb2122b94:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNjMGNmNGI1YWM0YjE0YjMyOThjOTg5NjQ0YjA3N2I5M2ZkMGI5NWY5ODMzYzFlNWI1NjVkNDE2YzQzNGFjZDAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU1ZTI2Y2Q5MjM2NmY2MGQ4ZWQ5MmQwMjM5ZjA3ZmVmNzRjYWMxNGFhNjlhZGRmOWMyY2MwZDExZWIwMGE0NjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIyZTU1NzFiZjRmMTVjMGFjY2QzMzRjYzg2ZDdmNTg1YWM2M2UyZjMzZmRlNzJlYWE2MjUyMWYxMDRkOGFjMTAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMzOTU5ZGFjNTI4ZWRhYjkxN2E1M2RhZDQ2MjZiNzI5MzI5ZmUxNzc4MTUwNzhjOTIyNjlmNGEwM2Q1MjgwMzkifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-copilot.js#L188-L224",
+          "version": "repo-lines-v1:sha256:3afee7d2ad3f9eb88bc23aa6ef6ade2b2fcacdca514a0db45f1a79c0796868bf:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ2ODZmODhlMGFlOTAyZDA2MDE3ZmQ1YzkxNmY3ZGZhNDAwZGY1YWEyMjM2Yzg0M2M0Y2E4YTliNTZjODYxOGYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI1MzUxZWI3NjUzZDU5YjZiYjQzZTA1MGI0ZWNhMzUwMGIyMzE0MzcyODE1ZTk1MWJhYWQ1N2NlOWFmMmM0MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_22ee2611d0b946b4bb94a17a7813f364",
+      "statement": "The root MCP command and the lightweight MCP binary validate an MCP URL, run StdioHttpBridge, gracefully handle termination signals, and fail nonzero on fatal startup; the binary avoids migrations, updates, and plugin loading and logs bootstrap diagnostics to a file to protect stdout JSON-RPC.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L19-L90",
+          "version": "repo-lines-v1:sha256:7871cb0ea225affd4a03e8ccf8e45761ef12f4e06df06f23c09d1fd8b35a40f8:eyJzZWxlY3RlZExpbmVDb3VudCI6NzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI3Y2U1N2Y5ZjU2ZTE3ZGFiOTM4NjA2ZjQ2NmMzYzBjMzYxMTY2YjIwM2JkZTE0ZjU5YzQ0ZDZmZmJkOGZhYjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkxYWM4ZjQ0NzU0NzIwNjMwNDM4Y2JmYzE0NDQyNzU3NzViMzg1YTZkOWFkM2NlMmM5NTZiMTUyYTBkZTU1ZWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L3-L13",
+          "version": "repo-lines-v1:sha256:ef9c88b8436874fc4ac571a8d7b413185a74dd5839dab963681d6e5d10a408b2:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY1Y2Y1OTFjZDM1ODBiNjYzMWY3NWEyYThhNDZiM2I5ODMzMzYwY2NiNmJlNTZkOWYxYmRhMzFhMWZmMTRjOWEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/mcp-proxy.ts#L16-L56",
+          "version": "repo-lines-v1:sha256:57872c82ed06168f608f7b066d4da9ae7a3c7e2c5b8488077bae50b6df2f1dfb:eyJzZWxlY3RlZExpbmVDb3VudCI6NDEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBmYjZlMWVjNjg5MDdkNjRkMDZjY2MwNmI1YzVmZWE0MGZhZGY0ODdiYjdmODZmMTZiZTg4NTk5NTMzMjdkM2QiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxNmNjNzM4YjliMDFkMzM0YzcxNWI1MDZjOTBjYWU3MzI1MzJhNWI1MDIyYTk0OTU4NmRhNzQ1ZDg1YTI1NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjlkODcyYzM0NjE1NWM2M2Y0ODFkY2FhYjQ0OGU1OGEwOThiMjdlYWMwYTNmZmVkZDVmNWNkZmQ1NTIzZDRiMGUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_30de2d68e52a461ba80a6ce57c05d95d",
+      "statement": "StdioHttpBridge starts stdio before lazily connecting HTTP on its first message, queues messages during connection and OAuth, retains cookies per origin, forwards reply traffic back to stdio, and idempotently closes OAuth and both transports during shutdown.",
+      "evidence": [
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L160-L207",
+          "version": "repo-lines-v1:sha256:83475158d509ee0c09a7ca36125e0c09424cf56a1893bcfcb1284eb90e603714:eyJzZWxlY3RlZExpbmVDb3VudCI6NDgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L293-L346",
+          "version": "repo-lines-v1:sha256:355f2633325044fd10398dc91f5e604d20677baca7f2479141c7d1861b0d3098:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVmMmVkZTczZjM0MDNmYjkwNGJmMjhlNjc5OWE2MTBhYTZhMzEyMjE3OTJhMDI1YjRjMTk5MzQ0ZTYwNjM4M2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L87-L158",
+          "version": "repo-lines-v1:sha256:91da580367e526a6bbc56702bda40177a0c54aa5e8a54f9577d8bf7ad4b45d07:eyJzZWxlY3RlZExpbmVDb3VudCI6NzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyYmJjMTg4NmU0ODQyNWJiMTgzZDQ4ZDE5YTlhZGFhYjZkN2ZlODcxNGE4M2YyMDUzZjUyYjQ4M2EzZjIwOWUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMxZWMxZjM2ZmRmYmZjM2Y2NmMxMmIxZDQ1YjMwYzNlN2Y4NjIwZGNkOTk5NWEzOGU5OTQ4YTVkMGE0ZjRjNGMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYyZmQzM2NlYzJkZjczYzg0OWYwYmU5ZjE3NzE3M2FiODdmZDg2NTBjYjE4MTU5YjEzNWUzOWU4OWYzMzQ5NTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_55cb2de5f11f42f2965c4b92ecf7be40",
+      "statement": "The `proxy` command starts a profile-configured daemon idempotently only when its configuration matches, verifies credentials, makes skill synchronization best-effort, and supports stop/status; its nested aliases merge parent and leaf options to prevent Commander from losing connection flags.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/__tests__/connect-wiring.test.ts#L101-L182",
+          "version": "repo-lines-v1:sha256:5576c78913df6ae2657b62080eb60a262d6e866503f365dd8a8034bc25d3bf13:eyJzZWxlY3RlZExpbmVDb3VudCI6ODIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBjZjY3ZDFiZTBmMmVmNTNjZWE1ODQ5ODhiOGI2MDJkZDY2YTFkYThhODdkYzZkNDE0Y2JiZDYzMGY4OGQ5MjkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQwOTQzZWI0ZTQyYmQyNGE4Y2RiNzY4YmQ0NzE0ZTMxYjgzMWIyNjk1YjE0Mzk3NGNhZjhkNWVhNzc5ZGFmZTAifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/index.ts#L108-L189",
+          "version": "repo-lines-v1:sha256:d862d09e54d8db04de547b9e44ef3dd0226f680cc6cf36c874305fac1768c8d3:eyJzZWxlY3RlZExpbmVDb3VudCI6ODIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA3MTgwMGZiNWRkZGU1MjQxODkxMDUyZTFiNmRiMmEwY2RkN2UyM2U1MTk3NDcxYmU2N2EzMzE2YmVlYjhlOTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZhNTNhYTdjYjY0MWE4Y2ZkZWUzNjlmNjVjNzdiZWJkOTc2ZWE0MTBkYjc5ZTUyMGQ2ZDBkZTdkMTg1NDYyNTAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVjNWM3NDkzNGY1ZTRlYWM4MDA4MzNiODg3MDc2ZjFmNmM5ZGJjMDk3ZDA4NDViNWJmOTkzOTM3MGQ5OWUzOTYifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/index.ts#L62-L90",
+          "version": "repo-lines-v1:sha256:f0596ff8b444e7e01c2a9bb733b734278d96edd407024f1c19e38428fdd5732d:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5NGZjMGMxNzNkMWVjM2ZjNTAxZDdkZmE5Mjg1NTAxYzUyN2NmYjQ3MTI1ODNkYTNjYzM2MTgwNTY2YjRiZTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNhMzBmZjg2MGQzMDY3ZmFkMWI2ZDdlNjJlZjFjMjIwYTM2MmNkY2E1MDNjZDYyNGU5MjY2YmE0ODg1YTAxMWEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_287aad8c15b345abb26cfd1648270a3d",
+      "statement": "The daemon manager uses a state file to await detached daemon readiness and remove stale records, stops with SIGTERM then SIGKILL escalation, and the daemon validates startup arguments, binds only to 127.0.0.1, atomically maintains state, and self-heals on a pinned port before recording failure.",
+      "evidence": [
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L160-L203",
+          "version": "repo-lines-v1:sha256:8ded602c61a424c81ee680ad0caef274916cf6a168e1323acfed6610564c3b61:eyJzZWxlY3RlZExpbmVDb3VudCI6NDQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk1MzEyZDU5ZDIwMGY5YTk0MDhlOTVlMzM2ZjA5MWViMGVhMzQ3ZDgzZjhmNzAzZWQyZDM1YmUyOGNmMDk3NmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQ0ZmQwNzVkZDA3ZDljNjgyMzVmODE2ZmI5ZGFhNzA4YTM3NmRjNmU4ZDM0MGU3ZWMyZmY4N2Y4YTAyZGI5ZWEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L30-L90",
+          "version": "repo-lines-v1:sha256:5f7c311e459d13c16a41e32b477f2f658c6d2f5a464b1c732aa1a51e48f8b925:eyJzZWxlY3RlZExpbmVDb3VudCI6NjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZlZTQ0YzhmZWU1ZTcxNDNmMTU4NjI3MGZmMWFmMDc0NzQ0Y2QxOWFiODJlNDQ0MGE5MGE0YzM1OGUzYWRhZWQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFhMWQxYTYzMzkwMjI5Yzc5ODM0N2U4M2EwNDA1NDQxYzk0MDAwMzUyODRhZDE2OGMxYmY2Y2RmMWQ3MGEzNzAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImZhOWE2ZmQ4ODAxOTAxYzRhYWMxOTJkZjI5YjJkNGJjZTA4YmRiYzA4MWZiY2NlNzNlNmZlNGZlZjE1NTg3MmYifQ"
+        },
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L97-L128",
+          "version": "repo-lines-v1:sha256:256c5edb49eb3f261318c4e973a802648be3c2b7f91f600a4a46760a521de7e2:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjlhYTlhMGJjZjcwZmJmNGIxZDA1MGQ1Y2EzOTU4ZTNiYWQwMjk4NTlhZDJhYWEyYjRlYTdlNDk2NWM1ZmE5ZDAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJlYzhiYWRhNjQ0ODA5N2M5ZWVhNmJkMDI3NDNkYmEyNTczMjI5NjJiYjE2MmI4MjNlNGRhYmZhZjM5YjExN2IiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgzNTFlNWRkMjk2MTQ1YTYzNWRmYzE5OWI0N2MzODhiYzViY2VlMjg0YWIxMGM3OGI2ZGU3MDEyMzNjODVhYmQifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L32-L81",
+          "version": "repo-lines-v1:sha256:fec19315bedfa03f6bc7e1a56f7c39ff9ea01470a6a0a16c286a63cac1e2a6aa:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU4YmRiMTNmOTllNjljYTdhMzVhNWEzNTAyNjA2Nzc5MmQxYTk1YzE3NjkyZGRmMjg5N2Y0NWFmMmRlMWZlNzMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ0OTQyOGQ5MGVkYTBhMGVmODA0ZmE5MjFmYjljYmI1MTYzMmJlMTNhOGQ4OGVjYTQ5OGEyYzg4M2YwMTBlODIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJhYWIyMWRjZDhjY2JiOTk1ZmViMzQ2N2U5OTdlOWI5ZjNhODRhOWM1YzAxODNhYTdhMTBmMWVhODJmOWVkNTYifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L96-L187",
+          "version": "repo-lines-v1:sha256:8897128f0709665c98bb18f06bed536ef38c2298dd51edfe1876fbff0e27f9ff:eyJzZWxlY3RlZExpbmVDb3VudCI6OTIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNWQ1YTA4ZTRjOWEyYTEzYmUyNjEwODAzYjIwMDcxNzZkNzM4NWI4YzNiYjBhYWFjYWJhZjRiYzRmMGRlMGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdkMTNjNjVmODNlMzdkMzdiNGM3NDVlYWM2ZWZmMzRjOTdkYzVmYWNkNDg2NmU0OWUyY2VjNDc4ZWU1OWVlM2YiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3MWMzODQzMGMzMDk2NTMxZDlmYTg4ZGVkMTgwMzkzMTMwOTNmOTQ5N2NiM2E5ZDU0ZWEwNzI0OGZhOTk2YWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_e5bff883ffc04737bf71531c397b98fb",
+      "statement": "The release-critical proxy-daemon lifecycle integration test exercises the actual bin-to-dist detached process path and verifies readiness state, local health, SIGTERM shutdown, and state cleanup in a temporary credential-free JWT environment.",
+      "evidence": [
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L139-L187",
+          "version": "repo-lines-v1:sha256:2e645135a9120a5652e525d403791e81ca48ae22501ef936f3c5d0d191555747:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY0NzlmMTA4ZmM4NTcwNzQ5NTQ1YWFhMWNjZjM2ZjAzOTE5NGExYzQ0YWQ0ZmI2Y2E1YzRjOTEyYTAwODU3ZjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZkZjI0ZmM2OTg5NTNlZDgwMGY2NGYxODU3MzBkMGNhNGQ3Zjk4MGRiMTdmMDYyNWM5OWYzZDU1NDZjMjQ5NDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L4-L42",
+          "version": "repo-lines-v1:sha256:63487e3ec607af47d17300a4f28b4bb5ef76d8641dad8714286b35da6d2f2b0f:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZiNmVhYWZkZTE4YjhiNTFjNDk4MzhlNzdjNTUyMDk3YWM0NzA5NjA1OTRlMjBkMGYwYzUyMGNkMDY1MWE4NGIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzYjllZGNkMWM2MzA0OTc4MmVmMWUwNjFmYTBhMmViNGRiNWJmZjM1OGJlMTA0YTUxYzFhMDM2ZDAxMWYzMjUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE0ZTM4NTY4N2IyY2U3Nzk2YzYzNmIxYTM1NTIyMDQzZTM4YjBjNDE1YjVkZTM1ZjMzYTNiYjdkYzIxNmEzZmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjBiZWQxMDA1OTk1NDU0MzljOGFkOWZhNGM0YmQ4OTY4YzRmYjg5YzhhYzU2ZTE3NDJkODI2NDZhZGY2NzQyNWEifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L65-L113",
+          "version": "repo-lines-v1:sha256:b040e9f9b633da9fc992fb6a23b2042e3b84ff39f2ca2704a037e4a66ea2f1f4:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxM2YzYThiODlkMjI0N2RlZTg4M2RmZDFlNTM0M2NiOWNmMWQwYTQ5MGNlNjkxOGMwZGVmODkzNGI1N2U2M2MiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRhMTY1NTgyZTIwMmQxZTYzMmYwZDdlNDNhMWRjNTliMWMyNWZkMGNkNTc5ODNjMGViNGE3MDI1MjdiNjEzNmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyNDkwZDkxMWI1Nzc0ZDEwNGJlODBkZjExNTc2ZGUyMmI1ZDNhZDRjYjY5NmM3YzE2NmQ0ZmE5OGRkMDEwODIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNlZGE0NDkwNGRlOTgxMjcxZTUwOTRkZmEwNWVhNTFjODFmZDUxMmY0MWI3OTQwNzMzYzQzN2IzMjBlY2I1ZDcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f7b8cd7f11494c8cb963c1f16ae4d218",
+      "statement": "The supported programmatic package surface exports agent registry/types, utilities and errors, environment management, SSO and proxy APIs, proxy-plugin registration, hook processing, and configuration loading.",
+      "evidence": [
+        {
+          "resource": "repo://src/index.ts#L1-L28",
+          "version": "repo-lines-v1:sha256:29f352fabb7fd1863329253909290a9260fcaa59a6a59c91ab4c45f17a3d4b73:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIwODhlOGQ1YjY0M2VkMzM5OGMxZDJlYjIyMjg3YjIxMWRhM2U3MmQ5MmQ0MDIwNmNmMjlhNTFmZTE2YzFhNmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMzZWVjNjdmYTlkN2VlMGEwOWEyZGM0OWE0MzkzNjUwMzNlMWZiNjJlYzUwNTgxNDU0MTA2Mzc3ZTNmY2U5YTciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_5f0a998fdec6494ca610cd15a9d1fd5d",
+      "statement": "Repository conventions require ESM-safe `.js` import extensions, forbid `require()` and `__dirname` in favor of `getDirname(import.meta.url)`, and prefer the configured `@/` alias to new deep relative imports.",
+      "evidence": [
+        {
+          "resource": "repo://AGENTS.md#L163-L177",
+          "version": "repo-lines-v1:sha256:75aa8c6d04e49722129f0cf7442a01b496a50c57f6ca11bf46a648c553ab468e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUwZjgxMzc0NWM0MmI2YjNiNzQ2YjhlYmEyZjczYmRhZTk0NDJkZGZiYTliYjI0OTk5MWZkMjAzYjI2ZTYwOGMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg5MWNiNWM4MWZkYWNlNGM4ZWI3NjMzMDYxYjU0YjhlNGFlOTM3Zjg2NTU1NDI0MzFkMjk4YzAzMmNiZTM3NzEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg5NTcwZjNlYzI3NmUwZjg2NTczMWJjYjE3Mzg3ZmQyMWE2ZDNmZGUzZDNkY2Q4MTBlYzQ4ZTAyNTkxM2E0N2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYxZTYwM2MxNDE5ZjE4MzJlMTFlNzI2NjU4Y2FlMzAzZmMyYTBmZWY3MDhkMzQzMTY2YTM2ODdhMDU0MmI4MTYifQ"
+        },
+        {
+          "resource": "repo://package.json#L2-L7",
+          "version": "repo-lines-v1:sha256:c5c18e6f220e5558e99ad939bf17d97189048b5d7da34e02bdabff128944c5a1:eyJzZWxlY3RlZExpbmVDb3VudCI6NiwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZDY4ZDRhNjNmZjcyOTJiZmY2ZmJhODUyMGU5YWVjYmFlNmZjNmM2OTM2OTU3ZGMxN2M4Y2Q5NjYwZDdkMGRlMiIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMmRkZjU0ZTA4NDNhYzgyNmMxYmMwYzc3NGFhYzZhMTcxMmNkMjI2ODIxMDYwN2MzMjNiYTc2ZDQwNWE5YmFjZSIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjEsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYTZmYjA4ZmRhMWFjYjk1N2I2MTE2YmQzNzgxMWExZmU0MWEwMTYxMWMwNjMxZWRiZjc4NmQ2ODg5YTI3YTU1YyIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMjljNTMwZDJiZDVhMGU4YWZmNGM5NDBiNTFmOTUzMmQxYmY3MmU3ZTZjNGExODZjMmU5OGNkYjY1NzkyMzQxYyJ9"
+        },
+        {
+          "resource": "repo://tsconfig.json#L2-L27",
+          "version": "repo-lines-v1:sha256:162eaf04ca52994eba0f8325178d2d4ff9916c85b975fdc7a24f9a3dad6e85f0:eyJzZWxlY3RlZExpbmVDb3VudCI6MjYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliMGNkOTc0ZWU2ZjM2NjYwMjI0MzRhNmRlODBkZDlmMTA3Zjk5MGYwZDk4MzM1ZjRkYWM2OWYwZGEyYWNkOWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoxLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2ZmIwOGZkYTFhY2I5NTdiNjExNmJkMzc4MTFhMWZlNDFhMDE2MTFjMDYzMWVkYmY3ODZkNjg4OWEyN2E1NWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZiNmExZDhkNjFhY2Y3ODFhNWU5N2Y1Mjc0NzE0ODg5MjQ5MDAxYTVjYmIwOWQ4YmY0NTI2ZDc4MzdlYTY2NDcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bfc0cf69b93e4f2db6d03215faf69169",
+      "statement": "Vitest separates Node unit tests, no-network CLI integration tests, and built network-capable agent integration tests, and configures the `@` alias to resolve to `src` for each project.",
+      "evidence": [
+        {
+          "resource": "repo://vitest.config.ts#L14-L97",
+          "version": "repo-lines-v1:sha256:3ff17579455ff03905aa5c3c256128738154c8a3d4dfeb68b8986afbd2e02e24:eyJzZWxlY3RlZExpbmVDb3VudCI6ODQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIyY2VjYjE0NGE0NmY1ZGNmMTJhNjE2OWZjZWVkNzY5NWU4Mjk0YjA5MGRlNzZmMzY2MWNkZDAyNDkzMDAxNDciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU2NzdkMmYwMzFlOThiNWU5MTFjNWFkNGZiOWIyMTg2YTkzMjUyMmU4ZjQ2ZWU0MGJhYmZhZTNkYTAwZmMxMjEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgyYmUzYjczNDc0YmVkMTRmYTc5MmNiNjQ2MDk5MTA0YmYwMzczY2FmN2Y1MTY4YjExNmRlNjUyMDJjZjI0YTAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmZmFhNjQ1NzcwZTJkN2UyODgzOTNhZGQwMjJjMTI1NzJjYjYzZjAwZDI3MTM0YWMwYjZlYzAxYjBmYThmOTUifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/architecture/system-overview.json
+++ b/openwiki/.claims/architecture/system-overview.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:a9950f3da9e22cecc6fddbe0fdb566a281f272d822196a63e059a483c0b314b0",
+  "claims": [
+    {
+      "id": "claim_90652fe11f0b4c598716e23c6ffb26d6",
+      "statement": "The package is an ECMAScript module with `dist/index.js` as its main/types entrypoint and declares the `codemie` executable plus dedicated agent/proxy executable shims.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L188-L190",
+          "version": "repo-lines-v1:sha256:61e2536f49f4f187a161e8ed7c7a55149cb5ae98d7efe9ecf0dbcf04a363c72e:eyJzZWxlY3RlZExpbmVDb3VudCI6MywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNWY2MDE1NTQxMjJlZmU4NTVkNTZlMTBjYzliYWYyMDMxY2EzZjRhYjExY2RiYTIyZjFlYmM1ZDM5YTc1NTgyNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNjI5ZTQ1ZjQ4MzYwMWY0MGM0Nzc0ZGY5ZDUyNjhiNTA2ZjAxMTg3Y2NkOTBmMGY3MDAwYWM0YTE4NjU2NjkyNCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjEsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDEyY2EzNDVjY2Y3NWJmOWMwODA2YmNlNjk1YmU4ZGU4MDhiNzk5ODQyNTFhN2E1NGQyMDJjZjYxMDFkZDQ1MSJ9"
+        },
+        {
+          "resource": "repo://package.json#L2-L22",
+          "version": "repo-lines-v1:sha256:932e30a5c0c7cfe1671350b5458844cfd7e4de4d3e1ed200a144c399b23058f1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ2OGQ0YTYzZmY3MjkyYmZmNmZiYTg1MjBlOWFlY2JhZTZmYzZjNjkzNjk1N2RjMTdjOGNkOTY2MGQ3ZDBkZTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoxLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2ZmIwOGZkYTFhY2I5NTdiNjExNmJkMzc4MTFhMWZlNDFhMDE2MTFjMDYzMWVkYmY3ODZkNjg4OWEyN2E1NWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMzNGNiYzVkZWI4OGY3NjE4NjdiZDJiOTQ2YTdlMTY4OGYwNGI4YjQzZDU0NzJlZjU1ZGVhNzcxOWJiZWE1MmQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8d82f0d837ef422fbb7a5aed4ba62ea8",
+      "statement": "The root package entrypoint is a deliberately selective programmatic API: it exports the agent registry, selected utilities/configuration, SSO/proxy facilities, hook processing, and proxy-plugin registry access rather than re-exporting all implementation modules.",
+      "evidence": [
+        {
+          "resource": "repo://src/index.ts#L1-L28",
+          "version": "repo-lines-v1:sha256:29f352fabb7fd1863329253909290a9260fcaa59a6a59c91ab4c45f17a3d4b73:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIwODhlOGQ1YjY0M2VkMzM5OGMxZDJlYjIyMjg3YjIxMWRhM2U3MmQ5MmQ0MDIwNmNmMjlhNTFmZTE2YzFhNmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMzZWVjNjdmYTlkN2VlMGEwOWEyZGM0OWE0MzkzNjUwMzNlMWZiNjJlYzUwNTgxNDU0MTA2Mzc3ZTNmY2U5YTciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_354c4252ee274e8784f2477d3319eb32",
+      "statement": "`AgentAdapter` is the agent-plugin contract for identity, immutable metadata, install/uninstall/install-state, execution and version lookup, with optional capabilities for resume ownership, extension/session/MCP support and version management.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/types.ts#L729-L847",
+          "version": "repo-lines-v1:sha256:d08e6df2512d9b409a4731a84d1089798ba623eef2d5b294eda16bba26d7d24f:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJjZWY1MDMzMTAxMGNjYjdhMTlhMjFlZWMyNDEyNTI5MmQxZDMxNjk2NDBlNGUyMzZiMWUzMGU3MzhhYzFhNmZlIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxYjc1OGJlN2MxYzlkMTE3NGUzNzkxYzcwMDE5MWI3ODQ2MTkyMzgyOGMwZWM4NDNhZTc4YjBmODQwNjdlN2I4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_48779df987fb40039e2c86e258cda56b",
+      "statement": "Agent metadata is the declarative boundary for agent installation, provider compatibility, environment mappings, CLI behavior, lifecycle defaults, local data paths, analytics, MCP and extension configuration.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/types.ts#L208-L373",
+          "version": "repo-lines-v1:sha256:cb3afc261b38870a8a83efe73d44da62583858990399b5c93e5895aac7bd9073:eyJzZWxlY3RlZExpbmVDb3VudCI6MTY2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJhNzQ3YzY5YTU3OWZhNTkwMWVkYzQ4ODIyZWU1NDRmYzFiNjdkNzlkYTI0NmQ0ZjBiNTBmY2M5MjU2OTE1YjRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0OTAzYmU0NjJiOWQzNGViOGU0MjUxZGNkZTY3MTY2MWZmMGNhMDA4ODc3YjYxYzk4ZDA5ZDlmMzFjNGQ4MDlkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_43d23d26e3d544b4abfd204d9531deea",
+      "statement": "`AgentRegistry` lazily instantiates the built-in agent plugins on first lookup, stores them by name, automatically records a metadata-supplied analytics adapter, and returns `undefined` for an unknown name.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/__tests__/registry.test.ts#L10-L88",
+          "version": "repo-lines-v1:sha256:40ae5d686c24a77ec4a4021ba26a1b6124d62c40ba3abf064a95b218b0144821:eyJzZWxlY3RlZExpbmVDb3VudCI6NzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzZDUzNjMzNjY1ZDJlZmRhMjRmYzhhNWM3ZmYzNWRjOTk3ZmZkZDM5ZWM4OTVmNWNkZmFlMzJkYzYwYjQ4ZTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFmM2ZhNWQ2MzQyZDA3MmFkOTA1NDMxZTgxZDU2NGYyYzdlODljZjQzNWZkN2YxYWE4MmEzY2YwYWQ5ZDk4MjMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJlZGFlY2FhMTVlOTJhNGE2MWExNTI0M2NkNGZhOTc0NTYxMmQ1ZDJhOTdjNjRmYWNmMWUyZWUzOTNhMzVlMGUifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L116-L130",
+          "version": "repo-lines-v1:sha256:b0090a8d624a95de3af1dcc47387f0ac11fcca1de8c665a9183f468a7ddca097:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjMyMGY4ZGJjZmE0MDU3MDA4MWE2MGFlMDJlNTMzYTU4MzVhN2UyYzQ0ZmRjMjgzM2QxZDk0Y2QxZmUyODYyZDMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L21-L74",
+          "version": "repo-lines-v1:sha256:4fecce737df1b6add64f2284e8c5ce2651f6f5ced63a4fcc1b55ee905dedec19:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFhYTRmNTI5YmIxOGE5NDQyODQyMDJiZTc3ODk0YTEyMjI1ZjIyZTQ1YThkNTkyYmQyNDA5ZDVmZGUyODZjYjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3ZDk5NmEwODFhMDhmZDZkM2Q2M2I1YTZkMTA0NzcyYTY0M2M1NDMzZDE1Yzg5NzMyMzQ5NmExNTFlMDhlNmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkwNGNjY2NhYjEzMTI4NGEyZWRkNmFhZTA0NjAxYzEzMWRiZmJjZGM3ZWE1MTFmZWU1MmY2MDEzMDNiMjE3YWYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_346ae8bb08a8420695fe4a86541f335b",
+      "statement": "Agent management and analytics intentionally have different visibility: manageable and installed-agent queries exclude `metadata.analyticsOnly` adapters, while all-agent lookup retains them for analytics resolution.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/registry.ts#L76-L114",
+          "version": "repo-lines-v1:sha256:4a3cfcad600cd9da18ab7cf7019d6f91dac729ffb7b02d627901b7b36abc73ce:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI2MzE0ODFhZTIwMDUxNDgwMzk2NjgxZGE3ZWM4ZmRjYTRmOWU1YTBkNjI5YzdlYTVjYjljM2MwNGU1MWZkNTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgzM2FjNDQ1NDg0NzJhMTJjYTEzZWFmMjBkYmM2ZjY2NzAyOTMxMDNkOWZkZTZlOTJjYTk2OTEyYTA0ZTZkZDUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3275297a1efc408da763c116963f15cc",
+      "statement": "Provider templates declare endpoint/authentication, models, capabilities and optional environment export and agent lifecycle hooks; provider-specific environment transformation is owned by the provider template instead of being hardcoded in configuration loading.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/types.ts#L66-L141",
+          "version": "repo-lines-v1:sha256:8f12fdd695a434d4bbfe02dd6dd5ce23b47ec1736cd56965687f7e12a81a3bc3:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg4MGQ4YjgzNmQ1ZDU1Mjg2NDk3ZjA1MjZkODlmNWY4M2Q5MDcxMTdhMWZjMTAzYmExYzJmOTY3ZjE4YWYwMzQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNhYjFjMzFmNjMyZmJjZjlkMDhjY2M4NzVjODUxNzIyYzQ5OTQwYWIwZTJhNWY0MjJlODlkMjg0NjZkYmI4OTEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImU0OTA2NjMzYjI4NDg5OGMyM2NjNmE0NTUzN2Y5MzQ0YjRiMTZmMTg5YzMzYjY4NDJlYmU2MmRlNzk0ZjY3YzcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_111ece763a594345b21e65b0ad4d773e",
+      "statement": "Provider hooks resolve provider wildcard hooks before agent-specific hooks; where appropriate the resolver chains a wildcard hook with an agent-specific or agent-default hook, otherwise it falls back to the agent lifecycle default.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L46-L126",
+          "version": "repo-lines-v1:sha256:04793370072307f4006c0c1f88d2f62ae02c7679ddecab13dcffe8d28dd733dc:eyJzZWxlY3RlZExpbmVDb3VudCI6ODEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJlYzRlM2U3NTJlNTYwNzAyZmQ2NTA2ZjA1Y2FhMWY4MWRiMjEzN2VkOTllNzdmMTA0M2NhODYxMDg5YzZhODAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQzYmY3ZmM4ODMyNzZhOTQzNmZhMTYwODI0YjllYzY3NGY4YmY0MTVlZDhmYmYwMmExYTNjZjQ3OWQ3YmM4NTIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE0ZjkxNmM4OTczYWUyYzQxYWEzZjllMTNiYmJlZTk3OTAyYjNkODViNzBiNGQ5N2MyMGU2MGM3MjE0NDZlYmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_34e2f31b595a4778a230358e2c4916bf",
+      "statement": "Importing the providers module is a composition side effect: it imports all built-in provider plugin entrypoints, while the registry stores templates, health checks, model fetchers and setup steps separately; capability lookup can return `undefined` when no registered implementation supports the provider.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/registry.ts#L19-L123",
+          "version": "repo-lines-v1:sha256:2f159c8592298817aff69f9f37af32b4a2387e74b8f40e6c9437ca5d63b36dab:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4ZDZkMmYzZGFlZWIwMmVlMmE4MjYxNWRkYWMzZjE4MGQ4Yzk3MzEyOGUyYjc1NThhOTYyZTFjOTZlZmJhNDFlIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2M2JmNjhiMGZiZDQ0MzIzODZlNjlkYTExMWZlOTUxZTQ0MTRlNjliNThhOWIwMjk4MGYzNTI1ZGU0OWZjNjZkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/providers/index.ts#L1-L49",
+          "version": "repo-lines-v1:sha256:f1d31651d1652143dd8e3016ef32f3c612678ccda13b6109f33c7f7350eb855e:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE3MGI4N2JiNjhmZGMzMDAwZGY2YTRmOWRkYWM2MzZkODQwMTNmZmNhNzhkM2VhOTNiM2RlN2I2N2NjZDhjNTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_09f4b6e96ebc481c9d92ae594f133f1a",
+      "statement": "Provider template registration stores by provider name and is last-write-wins when the same name is registered again.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/__tests__/providers-core.test.ts#L269-L291",
+          "version": "repo-lines-v1:sha256:aba9502843dc4d287b1bc932874cfe4353978f63afdb1f0de201b179f192c136:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU3YzdlMTNmMGQxOTkwMzdjMjhiNzFkMWMzNTdmNjkyNWY0OGU2YTM4ZGY2NjQwMzJlMDI3MjQ3MzFlYjVlMTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ1ZWJiMjhjMDg0MzM5MjBjMTQwN2RmNWYxYzI1ZWNkNjhjNjJhMWM3NGU2ZDRkMDFiMzExYmVmNzlhMDhkYTIifQ"
+        },
+        {
+          "resource": "repo://src/providers/core/registry.ts#L25-L31",
+          "version": "repo-lines-v1:sha256:8fb0b5766c86e0bf073a8d313fcadc249d4e21d12f5b24c3c136c55a88170c5d:eyJzZWxlY3RlZExpbmVDb3VudCI6NywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNGYyYTJmOTk2ZjA4ZTY4MGJkMjkyMTM1YTZmYTQ5NzhiZGEyNmU2MDJkODRmMzNjYjFkNTk0Nzc1ZDQzMDRiNSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYTUyYTJlNjZiOGNjNzllZGMzZGY5YzhlYjAwOThhYTMyNTZjYzdhZjYyNTFlMWU4OGQ4ZTVmMGM4NThiZTZlYyIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNTc5MjdkMjk1ZDljODlmMGMwZjZhNjYxZDRkZjEzZTVjNDEzZmNkMGRkNzkzMWMzMTY3MjIzYjkwM2NjNmFiNSJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_306383c12a41495ea2153684f88e0bc8",
+      "statement": "Framework plugins are registered by their plugin index at import time, and the framework registry exposes only available adapters and filters an agent-specific query according to `supportedAgents` (missing or empty means all agents).",
+      "evidence": [
+        {
+          "resource": "repo://src/frameworks/core/registry.ts#L10-L91",
+          "version": "repo-lines-v1:sha256:93881e48af2ce4d8c003373c92fe45f0bdede58393f6cc34cd6275c22dc2716b:eyJzZWxlY3RlZExpbmVDb3VudCI6ODIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNDMwN2I1NGI0MzhlYjA3N2MyZmEzODI2OTFmZmJmMjk0YjQwNDBkZjNjZWY1YzcxYzllMDlmNmE2OTMxM2YiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZjZTU2M2ZkZGFhMzA5N2YwNzNhMGVmMWRhODliODQ1Y2RiYjE0M2Y2M2I0OWRmOGVkMTM5MTA2ZjFkOWIxNTgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/core/types.ts#L8-L101",
+          "version": "repo-lines-v1:sha256:2d9e892b44637d953c733ba8042eb1645e7916b29c7a16f43aaa1a9175a66733:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ4Y2E2ZWY5MGY0YWYwN2JmNTYyNzM4N2U5ODBiNmE1ZDUxZWMxNDllYzFmZTBhMDgyM2YxZGE0MGVjY2I4MGQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImIxNDUzYmZiYzc4YTQzM2QwZjJmYzZhNzc3MzBhODhmNjllZDhjNzdjZmFjNzA2MzVmZDY3ODAzMzA5ZjBmNzcifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/plugins/index.ts#L1-L20",
+          "version": "repo-lines-v1:sha256:d43e9eaa0843016eed7d16b94a2d706830bc3c8b01eaab215cf62e070e4e6da1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEzOGIzNjQ3ZGQzNzgxOGVhYzBlNGYyMTM4YmU4OTIzYzZjMDA4ZjdiODM4N2ZkNTEzZDMxY2VmZjVhNWRjZTciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_15c85bb881834e21882788ff8b5aa835",
+      "statement": "The CLI composition root imports provider and framework plugin entrypoints before configuring Commander commands; its `--task` fast path dynamically resolves the built-in agent through `AgentRegistry`, delegates to `AgentCLI`, and exits nonzero if resolution or execution fails.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/index.ts#L1-L43",
+          "version": "repo-lines-v1:sha256:48c7a4275d29cab8bafb6cc8731128d15b3983855eb33fc32229b1956c13fffb:eyJzZWxlY3RlZExpbmVDb3VudCI6NDMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE1OWM0Nzg3MmI3MWYxMjU4OTk0Mjg5MjQ2NGU3NjRjMGRiMzUwYzIwYjcyMjI4NjQ1NjE1Y2MzNmUwYTA3MjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNDJmODBjNzEzY2QwYmMzODNmNDNlZTc2NmJmYWJlMmY5NTUxMGFiOTc3YWZkNDNjOTlhZmU0ZDEwM2Q5NGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc0MTc0MzIzMzNjN2IyZWU0MjUyYjIxZGQxOTI0NzcxZjU1ZTMyYjgxN2NkMmIyMGM5YWYyYjllMWIwYmY3OTQifQ"
+        },
+        {
+          "resource": "repo://src/cli/index.ts#L78-L146",
+          "version": "repo-lines-v1:sha256:3a540b8e62b1271f1633755c49d2fd37512a4aff96887878472363df67c496d8:eyJzZWxlY3RlZExpbmVDb3VudCI6NjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImViMDM0MDM2Nzk4MzljNmRiYjdmN2EyNDhmZDU5YTQyNDA1Y2RlNjEyMjcyZmZjYzhiZDcyZGFiMmZlMDI2N2MiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjEyNDI5NjBlMWZmMWQ2YjU2NTIyOTQ3NWFlMTA1NGI4NDU2ZTg5OWEwMDAwNzQ4MjY4YjdmODRlODRiNjRmMTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_89db5666f3164c338d1c7c7f99299086",
+      "statement": "CLI consumers resolve integration capabilities through registries: for example, `list` obtains manageable/installed agents and dynamically imports the framework entrypoint before reading frameworks, while `models list` obtains the configured provider's model proxy and exits with an unsupported error when it is absent.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/list.ts#L7-L96",
+          "version": "repo-lines-v1:sha256:675130676e1b9745de2c93399919168f9ae9c0a7d1cb0b0bf9db6a4dd050f372:eyJzZWxlY3RlZExpbmVDb3VudCI6OTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU4ZGU3MzhjZmU2MDg2YjBlM2FkZmU1YjU4ZTIwMjIwZjk0ODUwZjA4MWFlMGMwZjM0ZmZjNTdiOTUxOWUzMGQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY5MGRjZDliZWI2NjZiNThhNDIwMThlM2U3ZTcyNTU1MjQ2NDQ3OTBkODVjODRkYzllZmExNDRiMDBmYzBlODYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjYwZDJiNTk4YTQyMzY5NDkxNjJkYTM3YTE0MjA5YTRjNGNkZjU4ZjFjODg1MjI0YjE4ZWU0YWQ0NmFlZDI0NGMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEwZTVlYWFiNmE3YWUyOWQ5ZjE3ODA5MWM2MjIzNzZmY2M5OWE1MGFiYTg0Y2U3NDllNjI5Zjk0YWEyNDFkN2QifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/models.ts#L39-L88",
+          "version": "repo-lines-v1:sha256:521bba1bd86c6299d0ee6beca4cffd22b8e8c49d2768b02571b66fa52e582b4a:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxNjVhMjIxNWM2ODQ5YjE5NTE4YTBlYWY4MWYyNTJkYWRmZWY1ZWZkYmVkYTgwZDJiYTRjYWZkN2YwMzEzNTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxNmNjNzM4YjliMDFkMzM0YzcxNWI1MDZjOTBjYWU3MzI1MzJhNWI1MDIyYTk0OTU4NmRhNzQ1ZDg1YTI1NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyZjE1ZDViODNkZGEwNjE3MmRhNzk4MmEyMDVjNGE4MTFlMzc0M2UxODI3NjY5ZTViMjk3MDNjM2M5ZThlOWYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8db305f6904141d6b7db0cf9321bd98c",
+      "statement": "During agent execution, local proxy routing is disabled for providers whose template has `authType: 'none'`; otherwise it requires SSO or JWT authentication and an agent metadata proxy opt-in.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L938-L960",
+          "version": "repo-lines-v1:sha256:c1354589b2d1f49e41fa8c02d184f64d20d406256bdfcbb1c2e676c332936eda:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImJhMGQxODhjOTdkYTY4NzYwMjM5MWZiNmExZTk3Mzk4MzliMmMxMjllYjQ3Mjg3YmZkZDUyOTA0YTNlMGFlZGEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_e1b10dd9979b476ab61619032f2a1e69",
+      "statement": "The project uses NodeNext TypeScript module settings and an `@/*` alias rooted at `src`; production modules conventionally use ESM `.js` specifiers and `import.meta.url` with `getDirname` for module-relative paths, although a legacy production `require()` remains in the Claude conversations processor.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/plugins/claude/session/processors/claude.conversations-processor.ts#L15-L37",
+          "version": "repo-lines-v1:sha256:603a2404bb1122d6c3d41b53a51d79b23dc4cfe3d465c5f92bde724e24fab229:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmYTUyMWUyZjIyZDEyMjcwNjY5NTRlZWMwYTZkMWI5ZGQ5MDc5Y2ZiYjFkOGFkMzM3MzQ3OGIxNDUzYWRiZjYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNjNmQ4YzI0ODU4ODc5NTJhZDEyZmUxMjdmYTNiNjUwMzljZTljNjkwZjI1NjdjM2MyNWQ4OGIzMTk5ZTY2MTAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgyNjIzOGI0YTEzZjM3MWQ3OTgzNDMzMTY0ZDAzZDZmZGFmZTMyMDQ0Zjk5NzY5MWIyMmQ2NjkxZjc5NGE2MmUifQ"
+        },
+        {
+          "resource": "repo://src/cli/index.ts#L3-L12",
+          "version": "repo-lines-v1:sha256:77f11f59ab731c4e1e3055d35b635b9b83a6020ccefd4c016bec8b306f80e2c7:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZmMTA2NjIxZmJjNmNlYzNmNmQwZmEzNDAxN2Q5ZmJjNTcyODlmNDI3YmNlNWYxMzEwODFiNjczYzdmM2Y4MzQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE2ZGNhYzNkNjliYzE0M2EzNTg3YzRhOGQ4NDI2N2U5NmVlZmU3YzVhZTZlYzE5YjFlZWM3NzY0YzFlYmU3NDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3YjcxMDQxN2M0ZTJmZTcyYjBiM2ViZDI4YTgzMzVhMjJjYmNkZmE4ODZiNmRkY2UzODI3ZDRkZDgxZmI5YzkifQ"
+        },
+        {
+          "resource": "repo://src/cli/index.ts#L41-L54",
+          "version": "repo-lines-v1:sha256:5bb04b2915cca3e0c7591fda9594ed18a957ca006b324f0cd51b63ff23be9762:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhMGE5OTZlMjFjZTI2NzY5MmVjMDIwMzdkOTEwNGFlMDQ0YzJkNTEwZWU1NTY2OTJiOTQyNDI1MjhiMWJiNjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc2YzM4MjViYmQ3NDZiYjZhNzdiN2I0MWQ5MjZmZDY2MDYxOGQ0NDk3ZmQ4N2ZkY2IwNWE1N2E2NzY1NjhiNDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjY1ZTFmMDU4MGUyY2FkMGNiMDNiOGRiYjI3NTIwM2Y3MjFlYTZhNjQ4OGNkM2JmN2E2ZDVkNzQ4MTljODhiMzgifQ"
+        },
+        {
+          "resource": "repo://tsconfig.json#L2-L30",
+          "version": "repo-lines-v1:sha256:c758c513ae1a697c2a4f211a0ece7c219d418c91787909bce33467a185b9587a:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliMGNkOTc0ZWU2ZjM2NjYwMjI0MzRhNmRlODBkZDlmMTA3Zjk5MGYwZDk4MzM1ZjRkYWM2OWYwZGEyYWNkOWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg0Yjg5NmM1ZDdkZTViNzI5MjQ3NzY2NDEwOWEwYzQ3YjRlNzdiMjQyMzVhZGM2NTliZDA2YTIzNTYyODJkNzYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoxLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2ZmIwOGZkYTFhY2I5NTdiNjExNmJkMzc4MTFhMWZlNDFhMDE2MTFjMDYzMWVkYmY3ODZkNjg4OWEyN2E1NWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_ca292f4c29cc4a90b6bd416bedd40396",
+      "statement": "Focused tests assert the complete default agent registry membership, unknown-agent behavior, adapter operation surface and installed-agent filtering; provider-core tests verify registration identity and duplicate override behavior.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L31-L61",
+          "version": "repo-lines-v1:sha256:b83146f3662339b238c51ba70a157aab9c28790ec4772732af3b6a1e92ba86f1:eyJzZWxlY3RlZExpbmVDb3VudCI6MzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM0ODMzZDU5NDljMDNhNDBjYTk1MjQ5MTYxMGE2NjU5NjQ0YjNhYTQ2NjM2MmY3OTkwMjBkYmYxOTgxNTQ3ZGIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZmYzc5YzAwN2QxMjA3NWI0ZmQ3MGIzNDg2M2U2MDkyN2U0YzBlOWIwMjRkNjQ4ZmRlOTI0ZDY5YjQ5ZjhkYTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjNjMTg5NDZlOTUwNzAzNjY5Yzg3ZWQ3OTRmNjcxMzI1MDc5ZGI3ODk5MDg3NGU0ZGI1ZTAzY2M4ZmM1OWI4YTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAwNDFlN2YwOWZiNGJmNmVlYTJiY2ExODZhMDU4MjY1MTQwYzMyODBjNzZjOWE3NDU5ZTUzZTNmZWUyYTcxMWYifQ"
+        },
+        {
+          "resource": "repo://src/agents/__tests__/registry.test.ts#L10-L177",
+          "version": "repo-lines-v1:sha256:da4aaa848d40d8af6748110d10b51affd39bc1b200a798ca1965b436736a9930:eyJzZWxlY3RlZExpbmVDb3VudCI6MTY4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjM2Q1MzYzMzY2NWQyZWZkYTI0ZmM4YTVjN2ZmMzVkYzk5N2ZmZGQzOWVjODk1ZjVjZGZhZTMyZGM2MGI0OGU0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxZjNmYTVkNjM0MmQwNzJhZDkwNTQzMWU4MWQ1NjRmMmM3ZTg5Y2Y0MzVmZDdmMWFhODJhM2NmMGFkOWQ5ODIzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MiwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkODE3ZmJiNzNjOTJiMzZkNWU0ODk2ZmY1MWMxYjU4ZWVjMzMwYmJlOTYxYmEwNWZjNjIwNWY4NjdlYTFiY2Y2In0"
+        },
+        {
+          "resource": "repo://src/providers/core/__tests__/providers-core.test.ts#L269-L291",
+          "version": "repo-lines-v1:sha256:aba9502843dc4d287b1bc932874cfe4353978f63afdb1f0de201b179f192c136:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU3YzdlMTNmMGQxOTkwMzdjMjhiNzFkMWMzNTdmNjkyNWY0OGU2YTM4ZGY2NjQwMzJlMDI3MjQ3MzFlYjVlMTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ1ZWJiMjhjMDg0MzM5MjBjMTQwN2RmNWYxYzI1ZWNkNjhjNjJhMWM3NGU2ZDRkMDFiMzExYmVmNzlhMDhkYTIifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/concepts/configuration-and-local-state.json
+++ b/openwiki/.claims/concepts/configuration-and-local-state.json
@@ -1,0 +1,224 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:0ff65ff28e5a1ec2cfb0ac7b8ba6d6a5091516554985877a9c521e61e5e19bcd",
+  "claims": [
+    {
+      "id": "claim_7b724290174f4cca8f2e88dbf3372f3b",
+      "statement": "ConfigLoader resolves effective runtime configuration in the order CLI overrides, environment values, project configuration, global configuration, then built-in defaults, and loads a project `.env` before reading environment overrides.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L29-L36",
+          "version": "repo-lines-v1:sha256:a85687d7202edd96582067b6cb4dff3dfc2dd9219e4a103c14a8ac3bff036159:eyJzZWxlY3RlZExpbmVDb3VudCI6OCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiOTcyYTQyOTM4MmIyZTE0NzE4ZTBlMzdiMDU3MGE4YTE3MDI5OTFmY2Q4NDk4Y2Q4NDA2MGE4YmY0ZjA1MDE3YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjA0NGQ3MjViOTRhMmE1ZDIyZjY2YTU4ZTg0Mjk0MDQwZDZlZTE0ZmMyZGY4M2YxZjZhZWE1YzdjYTUwZTJkYSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDk2NmI4YmI0MmI3MjZkOWRiMzJmMTNjNGQzYmQ5ZTU0MDUxMjVlOTdmNGM4NjkxOWEyMDQ0YWU0YjlhYzAyNCJ9"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L410-L451",
+          "version": "repo-lines-v1:sha256:bc57ef6ee8681c03fff65263c2ce972b96b277e7952831d291199dbba7290c9b:eyJzZWxlY3RlZExpbmVDb3VudCI6NDIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMyYjhhNGEwNTEyNDM2MTczNjg4YmY2MjIzZmY4NjY3MmZjOWY4MTZiOGIzNTFjNDQyODE3YmIwZGM5NzE1YjIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVkZjk1MjFkZTYxMmUyOWJkZWU3YWJkNTZjNmE1N2IzZjBhNTNmMTVlMTBlYThlZTZhM2NlNTc5MzlkOGVjY2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L87-L200",
+          "version": "repo-lines-v1:sha256:6d1807a1f94ff4b374dc88c17d12b647ec3aa82ef4097d67b8d69ed1d4817618:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2ZDlhZjUzNDQwMmY3NDllY2Y3NDFjZjYxMmU4MWU3ZWZmZDY4YmIzNWEzODYzZjE3ZTM1NThjMjk5YjdhMDdiIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5N2Q4NjMyZTU0ZTkyOThhYmI5NTg3MjdlMmQ1MTQwOGFiYWYxMzY2MDM1Mzc5MTAxNDBhYmY2NWIzMGFiNjEzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_03d1c447c35c42169e065a2b01afbb62",
+      "statement": "Global configuration is resolved through getCodemiePath('codemie-cli.config.json'), while project configuration is `.codemie/codemie-cli.config.json` under the working directory; CODEMIE_HOME overrides the default CodeMie home directory.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L48-L62",
+          "version": "repo-lines-v1:sha256:b3236b0bc4aae3dc9450f3ad0cbf31d2877640d5c9cbf7bfed08ee6b58e9a803:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRjYWQxOGU0MGFlMjEwOGJkOGJiOWY3ZTljMTcxNTM0YjA5YWE0MjA5MGM3ZTk1MzJlODliZmU3ZjA0MzkxOTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVkMWZmNmViMTM4NmY1OGI4MTJmY2ZmZTRlNjlhY2I3OGU4NWI4NDNlMDEzMTI0MWQwOTc1NmZjZDNjOTBmZmQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQyN2IwZDY1ODk0ZGI5MGQ3OTBmZTYzMWExYzc1NzM3YjFlNjRkYTQwN2FjYmE1MTMyYmJlZDQ2ZTEyYzBmYWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjYyNGU0NWRmYTIwNjIwNjhjMzVjZmZiYWJhZGI4MjkwZTg0MmVmOGNiOGY2ODI0ZGFmYmUxMmM3OTk3ZmQ0MmYifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L514-L542",
+          "version": "repo-lines-v1:sha256:701d0c9ebe7e708d0fa41754ab0ece9506d3066fc9f3c54a76e199d8c278c978:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ0MTAzZWZlOTNjZjlmZGIzNzI2NzQyMjRlNmFjNWZhYzA2MzQzZjc1ZWY3MDNmOGFiOWY3MWEzODIwNGU0ODQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJlZWVmZGQ1MTEzZDk5MDU2ZjFlMTlkZTFiN2Q1YmVkZTZlMGEzMDFmOWU4ZjdiZTRlYWQzZjhmOGRhODY2YzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUwZjE0MDI4NGY1YTdjY2Y3YmFhYjRkNmNhMDJmZjhjOTIzYjM5NTNhYjk0NzRhZTAwMzgzOWI2YzcwYmU4MjMifQ"
+        },
+        {
+          "resource": "repo://src/utils/paths.ts#L327-L375",
+          "version": "repo-lines-v1:sha256:23745b0e5974ef7eff9854f5c0ab9cbc20ae27a5f074e796f70ba112e37077d3:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNmN2NkYTAwYTUxMDE3YzRjODVmYTIyOTU5NzUyYmY0Yzk3YzE3ZDdhZmQ4NGQ1YzFkOWJkYzg3MWJhZDkwNmUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3NTk2ZjVlMWUyMGIwZDFmNzgyZWQxMDY3ZjcxMTJmOGNlYjg4Y2UwOWEwMWIyMTlmNTkwZjRmYmZkZWYyYzQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ0ZDM3Y2I2NTgxNGM1N2E3Yzg2YTVkYTMxMWJmZTU2MTY5NjYyYTdiYzRmMWZhYmZjN2EwYTM3OTllYjU4NDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bf31686cbeab4dc7a56685cd10b4bdbf",
+      "statement": "Version-2 configuration separates a profiles map and activeProfile from scope-level workspace state, and saveProfile/initProjectConfig split workspace fields out of persisted profiles.",
+      "evidence": [
+        {
+          "resource": "repo://src/env/types.ts#L48-L206",
+          "version": "repo-lines-v1:sha256:d8c2750800ba50f586f83eed82ffb35c7ced76793e3c3519b98901a5a8b71b9d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTU5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyYjk4MThjNDk1NGM5NjA3OWU2NDZkYThiNGFjY2Y2OGJmNTcyY2FlNmM3MGQ1OWJhY2JhNmI4MmY4MzZiYjA3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0ODdkYjUwM2U2MmVhYjNkOTc5N2YzNWM2OTUyNGJjNTZjMDliNjI1ODFjODkwN2RiZGI0MWNkZGNkMTM2NDRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI2YTVjMWUxM2JkYWMzOTkyZDA0YWM5NGNhZTgwYWM5NDhjZmUzNTAyN2Q1YjA0OTA5OTg3NGU5NjJhNDdjZDY0In0"
+        },
+        {
+          "resource": "repo://src/utils/__tests__/config-project-override.test.ts#L394-L424",
+          "version": "repo-lines-v1:sha256:01f83079df09e0a67ae979caa1a89511ee7f2a6328f5c2071bd910232f4e290c:eyJzZWxlY3RlZExpbmVDb3VudCI6MzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU2YWNhMGVlY2I2MTg0ZWZjNWU5Nzg1MTYxNTA0YmYwOGJhY2IyM2ZkNmM2MjgzN2YxNTc3MjI5NzY5OTlkMzIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIxNjQ4YmMyYWEyODlkNmM2YzcwZmQ2ZjIxMmY1OGQwMDU5YmYzMjUzMWU0YTQ1M2RlNzc2NjMyOTZmZDE1MzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI3NzlkMTE4ZDZlM2NiZjQ1MDUzOTc0OGRlZTdhNDMwN2FjYmU2NDQ2Y2JhMjk3ZjI3NjBmYTVkMGJiYTFiYzIifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L557-L618",
+          "version": "repo-lines-v1:sha256:932f8f4713b08e4f196cb5ae7123418db03c1fc435e1e4275294c4c9f436fb6d:eyJzZWxlY3RlZExpbmVDb3VudCI6NjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyZWQyMmYzMDkyMGM1Y2RjMGMyN2NiNDRhZmI1M2MxM2U1MTMyNWEwZjE2MDgwY2ZjOWM5YzZkYmY4ZDczYTgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgxMDUyMDFkNmJlODQ4OTJlYWM5M2VlZmQ2MjExY2MxYjg2NjE4MzY1YzUwOTk1ODg2NDhhMWYxNjE1ZjMyMGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L873-L917",
+          "version": "repo-lines-v1:sha256:76ef92cc59747d742b5316bef19ea47a76527c76c75861f6c75895eabd96361d:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFkYjNlN2NkMGMzYTYyMzA0NzY2ODE2MWQxMDRlOTlkODYyMDljYTNlNzc1NGEyNWIxMTlhNDkwNzg3ODA0MjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjA2ZTk5Mzk4MGU2MGRlMzYwMDZhODJmYjM3NDg1MzdmZDcxNGUxY2YwMTIxNDBmYmQxNWQ5N2FmZDQ0NTdlMDQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8a95e0b8370a41b28edeb0b263b76750",
+      "statement": "The effective workspace is selected as a whole object: non-null local workspace wins, otherwise global workspace is used, so fields are not mixed across scopes and a null local workspace falls back safely.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/__tests__/config-project-override.test.ts#L557-L650",
+          "version": "repo-lines-v1:sha256:2248121a5478ce9e3061b6f885d1f09b5a155bc8aa02be700ac6f1a25574f587:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVmMzdmOGUxMzc5NDg2MTYzYzMxMjUxMGI4ZDY4NGJkMzcwYzg0OGE1NmFjYzBjZGQ2YzU5NDI0YTA1YWMyMDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxN2FmMTEwMWM5N2I3YzJmNTI1NDA3ODJlNjM0Y2M0NDQwZjBlOTcwMzQxZTUyZjk3NTIzMTFkNzhiN2Q3ZDAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA2YzA3MGMwN2UxMDBlMmE5OWE0YTVlY2U4ZTA2Y2M0NGJjMTYzNDM4YTJmZTFiOGU4MmE4OTUxMTdhNTc3MTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjExYTIwOGIwMWM3NzhhZjg4YzYyZTI2ZjI5ZjczMmEwOWJiYWIzYWQyYzgxZmVjY2MwYmZjMDY3ZTlkNjQxMzkifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L203-L221",
+          "version": "repo-lines-v1:sha256:50ea1a4df09fbe4a757c4e56f9bae67768a018c8db80c2cd996c45454732011d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIxYzQ5OTU4YzMzOTY4ZTllYmZmNzlhOWM4MGZjNTc1YjU1NTVkNTRkMzc5ZDAwOGE0MGNhZWFmMGU1YmUyOGYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYTRkMzNiMTdjZTFhNmIyNWE0NWM0MjdjZTFhYmJjMTQ5YjU0NDY0MGFmOTI4ZjJjZmExZWNmMTBjNzk0YWIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_27a10b1a8e5b428e912630057d8a0368",
+      "statement": "Profile selection uses an explicit requested name when supplied, otherwise a local activeProfile when available; local overlay selection favors a same-named profile, then local active or sole profile, and avoids applying a different local team profile's provider data to an explicitly selected global profile.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L105-L136",
+          "version": "repo-lines-v1:sha256:fc89d44e8312e22321631c6ca6a4d2c44702297ed4bd00ae61fc082dd94ddda8:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMDNkZDU1ZmZiNzFiYzExZWI0NDY3ZWNhNjcwNThmOTFkMjk3NjNiYjA5OTYxZGIwN2M4NTMxN2RmMGNmYzIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY4YWVlNzgzMDFjNjk0NjFiZDI1MTFhM2ZmZTdkMDk0ZTI1NDc2MGE1OThmNDg5ZjgzMzRhYWRiODEwMDZkMzIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjYzIzNGEzYzJhYzNmMDBiYzRkYWYzOGI5N2ZmZWJiZjcwMzJmZDY0NzFhNjIyODYwODJlYzU3N2FkNzQxOWEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVjMGUxOWY3YzYwOWYwOTA5MTdiMzMzMjEwMGZkYTM5MjQ4NWZhNGZlMmQwMzRmMjRkZDVlOGE0ZGY3ZTVhNWMifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L250-L325",
+          "version": "repo-lines-v1:sha256:e1bee2b1112e3a2aeb1dea56479d5b28a7d9cefe1d93cce215ba85b3a7aff3ce:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBhZjU4YjZmOWZlMDQ1ODM0YWZmMzRiZjYzNmM5NDU0ZDEwMjM1M2M0YTViMjUyYjcwNDBiMzk0ODEwOWQwMzkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU4YzY1Y2NhOTk0MDMwYmEyMTIzZDAzYTA4ZDdhOTcyYjgwZGExNDgzZDA3OTk4NzRlNjY4YzUyMmM0MGRiMjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkMTRmOTg5ZTUxNjdjZDE4OWUyZDhjOTE4NzE1ZTNhMTY2YTcyOTBkYjg4ZDQyOTViN2NiZGVhY2JlZWVmODUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L328-L395",
+          "version": "repo-lines-v1:sha256:be6c384c40a7f504cacd429e9dca78566b7d55cb1726f43cec16dc1bd2a369b4:eyJzZWxlY3RlZExpbmVDb3VudCI6NjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQ1NmNkMjMyN2NhYTg0NjAzYWE3NTQwYjVlNDA4ODUxZTIxODE4NzVhODU2OGU2MDYyZDZmZDc4MTUzNzdjNDYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjRiYzVkNzMzMGMwMTk2Y2U1NTE5NjQ5YWIzMzdjNTNhOGZlMTI5OGE4YmMxODU1NGFiMDY5ZTUzYjcwODVjYzIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_2f094908e7224f1b9eebddbacb65ae7a",
+      "statement": "When a profile name is explicitly passed in CLI overrides, environment values for provider identity and related CodeMie authentication fields are filtered unless the corresponding CLI field is also supplied.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L146-L193",
+          "version": "repo-lines-v1:sha256:e4d1bf2e86964287b212097a8ebbaa37f9fb595827b9da46f1cc960a61f8032a:eyJzZWxlY3RlZExpbmVDb3VudCI6NDgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFmNDkwOTA1NzRhZGE0NWVkYTJiZTcyMzA1MWU2OTJiODdhM2QzY2NiNGZjYWVjZGM2ZDRkMWMwMjkyZDUzNWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVjYjljNDU0ZTBjZjYzNjZkNTg0ODQ3OGIxZjVkOWI1OGRmYzZkOTU0Zjg1YWMzOTAyNTZlZWVmZjcxZDZjMzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjlkMzZlMjIyODFmMjE4NTc1MzY3NGQwZGE5MDNmNWQxOTYzZjI0ZDQwOTVmYzAwZWVlOWE4NjE1ZDVmZjk3NzEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9a9aeb136ea141eeb696f2e6a2d75d8c",
+      "statement": "Profile management combines global and local records with local entries taking precedence, chooses local activeProfile over global, and writes switching/deletion changes to local storage when a project config exists.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/profile/index.ts#L323-L461",
+          "version": "repo-lines-v1:sha256:9232d829620045cc30fef7e126984bc2ff306c9289410420cf8ad82e8570cc88:eyJzZWxlY3RlZExpbmVDb3VudCI6MTM5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjZDRiOGE4YzAzZTcxMDg2ZjVkMTA5YWEwNDA0MmIwOWM3ZGYwYTRjZGI1MThhZmI3M2Q5Mzg2Yzk0YmFkNzQ0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJlMTZjYzczOGI5YjAxZDMzNGM3MTViNTA2YzkwY2FlNzMyNTMyYTViNTAyMmE5NDk1ODZkYTc0NWQ4NWEyNTZjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTRmYzBjMTczZDFlYzNmYzUwMWQ3ZGZhOTI4NTUwMWM1MjdjZmI0NzEyNTgzZGEzY2MzNjE4MDU2NmI0YmUzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L621-L714",
+          "version": "repo-lines-v1:sha256:f94f0a6b6c6edc849dfe5877122122ab9c157eaafea52f476de5e872044201d8:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgxMDUyMDFkNmJlODQ4OTJlYWM5M2VlZmQ2MjExY2MxYjg2NjE4MzY1YzUwOTk1ODg2NDhhMWYxNjE1ZjMyMGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjIyYzNiZTY5MTU1N2I0MzMxY2U3Yjk5NTNlYzFkZDM2ODk5ZjM5ZTU4MDVjNTllZmQwOGUyNmE4OGZhNDMwZWEifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L716-L855",
+          "version": "repo-lines-v1:sha256:f9554516522b4cdf3f031d0c66ddafa55c9c2ccc803f888165534534fff1328c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5N2Q4NjMyZTU0ZTkyOThhYmI5NTg3MjdlMmQ1MTQwOGFiYWYxMzY2MDM1Mzc5MTAxNDBhYmY2NWIzMGFiNjEzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwNDQ1MzAwOTc0YTA4MGVkNWEyMzk2OGI3ZjdhNDNiNGJlZTg3MzQyYWE0NzEzY2Y4YTQ4ZWNmYjdiMjM0YzUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_fd8f9aadb4ad45b381b10cba46581403",
+      "statement": "Profile status can show per-field source attribution and masks sensitive values; it also delegates supported provider authentication validation/status and reauthentication through provider setup hooks.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/profile/index.ts#L71-L167",
+          "version": "repo-lines-v1:sha256:399c6bd7433c9d4f2304e6e4e2a8c87528577c36564b1d43e76954b614e3f99f:eyJzZWxlY3RlZExpbmVDb3VudCI6OTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg5NDA1NDI1NmZjMzEzMWM5ZDYwNzIxMmI0OGFjNzM1ODZjYmU1YzE0NTAwMGNlYjJkNmQyZjAyYTA3NGI0ZmQifQ"
+        },
+        {
+          "resource": "repo://src/providers/core/types.ts#L311-L415",
+          "version": "repo-lines-v1:sha256:a5f7496801254a6782abfec12c451726ab1ba3ea66885badcd3dc500609dd2c8:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIzNjc5NTMzZGY1MTA1NmNkYWE3YjhkODFmMjQzNjQ5NzNjZGZhMjQ2YzIzNGVlN2I4M2RmZWVlNTViODA4ZDJmIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJiZGE5YWM2NTk3NTEzZjNkZTgwZDgxNzNlMDY1ZTNlMjJkOGM4YTUzMjM4YmRlMTU2ZDcwNzVmZTdlZDUyZjkzIn0"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L1197-L1395",
+          "version": "repo-lines-v1:sha256:06a04e68ed63a00fa149c93297c5815c7aceb4afc8805cca9092183ba69d24ce:eyJzZWxlY3RlZExpbmVDb3VudCI6MTk5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5N2Q4NjMyZTU0ZTkyOThhYmI5NTg3MjdlMmQ1MTQwOGFiYWYxMzY2MDM1Mzc5MTAxNDBhYmY2NWIzMGFiNjEzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIyZjg4OWY4OGU4YmNmNjI5N2MyZGUxYzkxZjgwYTc1NGNjMDFhMjFiY2EwNTg5OTU5NDE0MTM3ZjUzZGMyY2ZiIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_a3ea3ae3ef804f22911c4168a296fcd8",
+      "statement": "A runnable configuration validated by loadAndValidate requires baseUrl, apiKey, and model; provider templates can own provider-specific environment exports, while the generic exporter clears stale auth and model-tier values and supplies a placeholder API key only for providers declaring no authentication requirement.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/types.ts#L65-L140",
+          "version": "repo-lines-v1:sha256:3469fdad5fc631e290d0b26a60918089f09ec41d70e52a716ee789bb964836b3:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyZmU5MTdmMzU1YTRjYTZiY2U5NWYxNmJmNDZmODZiYTcwMDE3MjkyYWU1ODdkMWZlYjEzNDA1MjVhZmQ5NjkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjM2ODczNWI0YWNiNWY5MTljMTA3OGVmMmJjNGZjM2I2Mzc2ZDQ1YTBmOWNlZTg0NDAzNTI4MGQzMzNkYWYyZmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L1067-L1195",
+          "version": "repo-lines-v1:sha256:f12ac1c5df52bc39dbe7bce8acdab619a28cdb23496efc3c1aabb1b44d1ff827:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxZGIzZTdjZDBjM2E2MjMwNDc2NjgxNjFkMTA0ZTk5ZDg2MjA5Y2EzZTc3NTRhMjViMTE5YTQ5MDc4NzgwNDI2IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjMTA2NjJlMDNmZThhYWY2MGI5YjU5OTc2NWM3YmI4N2M2MTY1ODFkZDhmM2U1ZThjZjBmZTMwOGFhMmZkYjlhIn0"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L1404-L1449",
+          "version": "repo-lines-v1:sha256:9d2842015cc1bc885439be76aeb281412ceb8264f60f35054c2d7a2cb0847494:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVkZjk1MjFkZTYxMmUyOWJkZWU3YWJkNTZjNmE1N2IzZjBhNTNmMTVlMTBlYThlZTZhM2NlNTc5MzlkOGVjY2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJmNGFmYmY4NTJkN2IyODgyZGNmMjBmNDQxNmE0OWJmYzk5NDgxZjBhY2JiOTFhMWIzMzA3ODM1NGVhNDYwMWYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_de334f377cb64d0fac7091a5db0e7203",
+      "statement": "Credential-safe diagnostic handling requires sanitizing credential-adjacent log arguments: sanitizeLogArgs redacts sensitive strings and objects, logger sanitizes arguments for file output, and logger.debug forwards supplied arguments to console when debug mode is enabled.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/logger.ts#L161-L216",
+          "version": "repo-lines-v1:sha256:569c716e0d473903591e4283523422ec03d5bf4d1cc08fe152e977b5fde03f62:eyJzZWxlY3RlZExpbmVDb3VudCI6NTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjEyZTZiZjRiMzBhNmVlOTY1YzAxOTZjZTMxNDViODg1ZTFkOWY2ZTQxMzUyYmQxN2FjYTZkNzQ0ZTY0ZDViNjIifQ"
+        },
+        {
+          "resource": "repo://src/utils/logger.ts#L260-L298",
+          "version": "repo-lines-v1:sha256:76a0cf05dabbc14895bbd555d98222984fb64d573434a7b72a282efd74fb8ffb:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMwM2I0Y2QwMWM0OGNmYzFjMTIzYjM3ZDFjNzJmZWM2OGM0MTJhZmIyMDYwMGNmNzcxYjI2NDY2OGE3MmIxZDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4NjgzNmMxOWZiODM0YjAyMTU1NGIxYzdlZjBkMjJiODlkNzZiYTk4NzA5NTVlMGE5ZTM4OTVjNGU3ZTZhMWEifQ"
+        },
+        {
+          "resource": "repo://src/utils/security.ts#L231-L250",
+          "version": "repo-lines-v1:sha256:e7e3f6dcae26acff59960bd34aa36909b48f1b7ee945f1eb8476285ebce0c032:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA0NTNiMmZiMDZmNTQ2ODdiZjAwN2YyODI4MDA5MjljZWRkYjE3NmU4N2FkYzJjNmZkNjdkMWU5NDViNzFjMDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM2M2UyMTk5ZjQxM2UwNmI3YTE3ODg2OTQwN2Y4NTIwNjA5NTg5N2ZmODUyNmJmMGViZDk4OTA5ODE1NWE1M2MifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_dc44ca176bf541ef8049681b463b0839",
+      "statement": "SSO credentials are encrypted, stored in the system keychain when available and in encrypted file storage, with per-base-URL storage names derived from a normalized URL hash.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/security.ts#L256-L335",
+          "version": "repo-lines-v1:sha256:bed3b2f1ea777ac676617da694ddca07ebf502f439fe69a3c9ba2d8cc9599503:eyJzZWxlY3RlZExpbmVDb3VudCI6ODAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhMzI0MmIxZjNlMWY1OGJlNjBhMGViN2ZmMDk1OTc4YmQ5Y2JkYWYzODdkZWFjZTkzNGRiZDA2MmUxZGEzZjMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI1YjExYmZiMGYwYTA4MTU5NTdkMjgzY2U0MGNmNjNlOWVlOGFjYjBmNTE3YmI4ZDg2YjAyNjY5NThjMTUzNTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ2Mjk2YzkyMzM2Nzg3MzkyYTMzZjAzNGEyNGZjOWI0NjgwNTlmMzEwYjRmMzZjMGY3ODZjYTdiMTAyZDA4ZjkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_6134abd2e28c4079aa401cdeb6587697",
+      "statement": "The CodeMie home stores a persistent installation UUID and scoped assistant/skill registrations; loading registrations verifies their corresponding local or home `.claude` artifacts and combined assistant loading gives local records priority by ID.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L1457-L1503",
+          "version": "repo-lines-v1:sha256:5bf6988b50b932eaba23efd3b9bb824d7d8e564e1bcc74b3e32bd0d2da0a2c3c:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJmODdlZGY2ZDkyMzNjODI4YTc5ZGRhZjM5NWY5YWUyMzI3NTIwOWU0YmZkM2M4YWRlZjFkY2UyNGY2NzlkNDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkzNDZhMjQzNThjMjExZDI2ZjBkMzc1OGFhYzk0N2NlYzFhMjlmMGQ5YTdkODFkODM5MjAxNjFhZDJlODIzYjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L919-L992",
+          "version": "repo-lines-v1:sha256:e533a13ae3c4fe57976868a3002935291dc0ea8f5d8f3ef495e39daeed6db43b:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY1YzlkMDU4YWVkYmZiZmM1YzkxMzg0MzgxMzZmZDM5NTAyM2FkM2U1ZDM5ZDE0NzlkNjQ1MWJiMTE4ZmQ5NmUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFkYjNlN2NkMGMzYTYyMzA0NzY2ODE2MWQxMDRlOTlkODYyMDljYTNlNzc1NGEyNWIxMTlhNDkwNzg3ODA0MjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjU4YTQwMmNkNDA3ZWFlMzE1NzgzNGIwZDEzZmY3ZjNhOTY5YTMxMzNmOTcxNDYyNmJiMjZkMWVmYmE5ODQyNzYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3ac0b1b23183412a9ca0e89f7986a8ff",
+      "statement": "Focused tests exercise project initialization, precedence, source attribution, workspace splitting, profile/workspace migration, and nested secret redaction.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/__tests__/config-redaction.test.ts#L4-L81",
+          "version": "repo-lines-v1:sha256:2b215a325c54229dcabe9927c12303da84c0e345e36cf640b402bcd17ed16ab8:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY1NjNiZjI0NTIyMDdiZjk1MjRiNTU0NTQyN2I2ODI3MzdlNjYzY2JkMTU1MTM5MTkwMmIwOWU4ZjZjMjhmNTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJlYmFjNDE3NmMwOGM5YTFiYTM4NTYwNWM4OGY5ZTUxZTUyYjczZjM1NjYxZDA0MzEyODAzM2ZlMzQ1ZTU2N2YiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://src/migrations/__tests__/007-decouple-provider-workspace-config.migration.test.ts#L12-L177",
+          "version": "repo-lines-v1:sha256:fdacea57f03e72053ba92d445636d2ebea5d93e9ffce0b2a2b1e482214165bcd:eyJzZWxlY3RlZExpbmVDb3VudCI6MTY2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIxMzBhMjk2YWI3NDlmMDA4YzI5NGUzYjdlMTQ4ODdkNDI4ZmNmOGFjZDQwNWViMjUwNzBlMjQzNzFhNzZiNTI4IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJhMmI0N2UzN2QwMDBkZTc3NjE4NjQ5ZGUxNzVkMDNhNTJjZTYzYjFhOTM4YmVhZDM2YmFmYmQzZjhmZTlmZWQ2IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiNmE4OTNjZjcxZWFmOTkxOTgzMjQ1MGQ4YWYyN2IwNDhkMzE5NDJiZTY1ZWM1YmM5ZjA0MDJkYTg3YmZhNzVhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI4NTg3MDgyYjIzM2Q4ZmVlOGY3MDk4ZjY1ZjM1YzFlZjMzZjllMmFkYmI3YjFkODg4YTkyMzFkOTBjNmNjNjg1In0"
+        },
+        {
+          "resource": "repo://src/utils/__tests__/config-project-override.test.ts#L53-L285",
+          "version": "repo-lines-v1:sha256:10955e1eb599b2c243cc6528d94d8862c6741343a596306825aecf768a5bd118:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyZWM0NTM1MGNjYjM2NzFlZTA4Mjk4Nzg3OTNiZjhjNTQ3YWZmYTQ2ZTYwNDk1ZTkyZTUxM2Q3YTYyMjcyNTFiIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlZTZiOWMyYzJjZmQwZjlhYzE4NTZlYmEwMGM2NzJhM2JiOWM3MWRlMDIwMTg1ZmQ3YzUxNjJjNjMzOGIxODA4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI3NDA0MDQ2YjQ1ZWIyZWRkNmQzZDE5MzdiN2E0OTM3ZWIxMjViYjNiNTk0NWRkZTc2M2Y2ZDEzMWI5ZDdiMjE4In0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/integrations/agent-plugin-system.json
+++ b/openwiki/.claims/integrations/agent-plugin-system.json
@@ -1,0 +1,274 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:b3c91d597e538b8df08b1d95a65fcfd1a5e1bfb1edcfd4351f078f1d4d96568b",
+  "claims": [
+    {
+      "id": "claim_fa85ad958ca4488cb30f96294b39de5c",
+      "statement": "CodeMie models an agent integration as an AgentAdapter with required management and run operations plus optional capabilities for resume ownership, extension installation, hook transformation, session parsing, configuration summaries, and version management; AgentMetadata declaratively carries installation, compatibility, environment, lifecycle, analytics, and integration configuration.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/types.ts#L208-L373",
+          "version": "repo-lines-v1:sha256:cb3afc261b38870a8a83efe73d44da62583858990399b5c93e5895aac7bd9073:eyJzZWxlY3RlZExpbmVDb3VudCI6MTY2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJhNzQ3YzY5YTU3OWZhNTkwMWVkYzQ4ODIyZWU1NDRmYzFiNjdkNzlkYTI0NmQ0ZjBiNTBmY2M5MjU2OTE1YjRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0OTAzYmU0NjJiOWQzNGViOGU0MjUxZGNkZTY3MTY2MWZmMGNhMDA4ODc3YjYxYzk4ZDA5ZDlmMzFjNGQ4MDlkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4In0"
+        },
+        {
+          "resource": "repo://src/agents/core/types.ts#L729-L847",
+          "version": "repo-lines-v1:sha256:d08e6df2512d9b409a4731a84d1089798ba623eef2d5b294eda16bba26d7d24f:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJjZWY1MDMzMTAxMGNjYjdhMTlhMjFlZWMyNDEyNTI5MmQxZDMxNjk2NDBlNGUyMzZiMWUzMGU3MzhhYzFhNmZlIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxYjc1OGJlN2MxYzlkMTE3NGUzNzkxYzcwMDE5MWI3ODQ2MTkyMzgyOGMwZWM4NDNhZTc4YjBmODQwNjdlN2I4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_7a4394bbfa624c028e4cbca727457b25",
+      "statement": "AgentRegistry lazily registers the built-in agent plugins, keeps adapter and analytics-adapter maps, auto-registers an analytics adapter declared in metadata, and makes all registered agents available for analytics lookup.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/registry.ts#L116-L130",
+          "version": "repo-lines-v1:sha256:b0090a8d624a95de3af1dcc47387f0ac11fcca1de8c665a9183f468a7ddca097:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjMyMGY4ZGJjZmE0MDU3MDA4MWE2MGFlMDJlNTMzYTU4MzVhN2UyYzQ0ZmRjMjgzM2QxZDk0Y2QxZmUyODYyZDMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L17-L74",
+          "version": "repo-lines-v1:sha256:b1887c08a65f139fa26df9dd7cb899dd935548daaf70b776c445bcc9b4c30943:eyJzZWxlY3RlZExpbmVDb3VudCI6NTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFmNTYyODM2YWIxZTgyYWQ1MmFiNzZiNGUwNTIyNTIyZWJlZGU3OTUyYmEyMDE2ZDhkNDkzZWU2OGQ4MzdiZjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkwNGNjY2NhYjEzMTI4NGEyZWRkNmFhZTA0NjAxYzEzMWRiZmJjZGM3ZWE1MTFmZWU1MmY2MDEzMDNiMjE3YWYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b8384dda8dd4494184007f68227db5c4",
+      "statement": "Management surfaces must use AgentRegistry.getManageableAgents(), which filters out analyticsOnly adapters, while analytics can use all adapters; getInstalledAgents() checks only manageable adapters.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/registry.ts#L76-L114",
+          "version": "repo-lines-v1:sha256:4a3cfcad600cd9da18ab7cf7019d6f91dac729ffb7b02d627901b7b36abc73ce:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI2MzE0ODFhZTIwMDUxNDgwMzk2NjgxZGE3ZWM4ZmRjYTRmOWU1YTBkNjI5YzdlYTVjYjljM2MwNGU1MWZkNTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgzM2FjNDQ1NDg0NzJhMTJjYTEzZWFmMjBkYmM2ZjY2NzAyOTMxMDNkOWZkZTZlOTJjYTk2OTEyYTA0ZTZkZDUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_276839e229d64be89f8b1b15dacba70a",
+      "statement": "Copilot CLI is currently a managed adapter rather than an analytics-only adapter, while still exposing a session adapter through the registry for analytics discovery.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts#L12-L29",
+          "version": "repo-lines-v1:sha256:ba51967540aae776737364bda3ec346921f5cfbf7ee35a44acd7946fe8a0187c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhhOTUwMWFhMTI5NzZhYjdmMGJmNWFlZDc0MmIyOTQ3YzBhOWU3MWFkNWQ4MjIxZDI5MjFkODJiMjZiMDRkNjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIzMmZmZDIyNzBhZjQzOTY4ZjI5ZTU3MjFkZjI5MWM5YmUxNjFkMGQ2Nzc4NDY0YWEyOTViMGJjZDQ5NDcwZDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI4MDI5OGFkMDIxODkyZDkwNzE5NTQ4MmMxNGVmMjI0Yzc3ZmIzOWUzMDM1NTc1MjEwMDBiMDQ3YjgxYWU1YWEifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts#L76-L96",
+          "version": "repo-lines-v1:sha256:faf30a94ddc5ba35ca3d05fe18e96129d884de1f0c191bed2d6b6dc125aede43:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI3NzlkMTE4ZDZlM2NiZjQ1MDUzOTc0OGRlZTdhNDMwN2FjYmU2NDQ2Y2JhMjk3ZjI3NjBmYTVkMGJiYTFiYzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/copilot-cli/copilot-cli.plugin.ts#L90-L149",
+          "version": "repo-lines-v1:sha256:aaaf93cf565453ff8281a63eadc5b1bac7ae41cdc5625bd04b1cf947f47f9d52:eyJzZWxlY3RlZExpbmVDb3VudCI6NjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzNTcyNjgwYTY1N2M5YzE1ZGI2YTNmYzcxZDFjZWE0ZDc3Njk3M2M0NGI0ZjdmNmU5ZmY0Y2ZiZDcyYjQ0OWQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjE2OWViODc4NDVmYTZjZTgxZGU5ZTJlMTczYmM0ODUzZTYzZDAxZTI0MTM5YmFiZmE1NTczYTYyNTk2M2FiNGQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9a6a3eff701240e6b8e64552a043492e",
+      "statement": "Per-agent package executables are thin ES-module shortcuts that resolve a canonical adapter from AgentRegistry, fail if it is absent, and run it through AgentCLI; the package publishes shortcuts for the registered launch targets.",
+      "evidence": [
+        {
+          "resource": "repo://bin/agent-executor.js#L11-L24",
+          "version": "repo-lines-v1:sha256:7776d98e2133ee733c12ea0a4eb4dd5dd8ab51b58ccbaf37511299ffebce825e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzMTYzNGJhZWVhODM3ODE1MjMzZmExNzRkMTZlY2MxODk5N2FlNGFmNGYxNmU3N2E5NzcwMjRjNGQxMGFlYzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQwNTdjOWNiYzg2NGJlZjE1MTQ1YzgxNTc4YjdmMGM1ODY1ZTgzYjEzYWMyNGE0YjAzNDQ0MWUwY2FkODllNmMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-codex.js#L8-L18",
+          "version": "repo-lines-v1:sha256:84ca8e281c33d8b9175f6b2e7eedd05980fb80d33e540275035c2e8cf62f2f8a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzMTYzNGJhZWVhODM3ODE1MjMzZmExNzRkMTZlY2MxODk5N2FlNGFmNGYxNmU3N2E5NzcwMjRjNGQxMGFlYzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjZDBhZDZkYmM5Yzk1ZmY2ZmY0NWE2MDQwMTFjOGViZjgzMTY4YzZlZDBkZWNiZTExMDNmNTk2NWZjYzE3NGEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://package.json#L5-L22",
+          "version": "repo-lines-v1:sha256:3c5f384add81688e198c9bdf36ac53eaa531ff9a89d0e17db6e173b30ca2a102:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY1NmQ4MzA5MGM2ZmI5MzQ2M2FkNGYyZjg1ZjhjYTU1NzZmN2U4NWUxMjFkOTU4YTUzNzE4ZTIxZDlmNzZlNmIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIyZjlmMTE4M2M0ZDhmMTM3YTcwMmM2OTU3NjM4Nzg2MzE3YjBjYWEwMzgxMmU4OTNkNjJjNTYzZGI5OTk3MWUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMzNGNiYzVkZWI4OGY3NjE4NjdiZDJiOTQ2YTdlMTY4OGYwNGI4YjQzZDU0NzJlZjU1ZGVhNzcxOWJiZWE1MmQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_671a501ff7914728acf015fc7a56d9df",
+      "statement": "Agent aliases preserve canonical registry identities while offering ergonomic management and launcher names: copilot resolves to copilot-cli and launches as codemie-copilot; the normal launcher convention is codemie-<agent>, except names already beginning with codemie-.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/agent-aliases.ts#L1-L46",
+          "version": "repo-lines-v1:sha256:f03f20c54130c196612f7805d1d82c68485b8f04aee6d08e020f582a6d0f6dfb:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ0MjZmNzMxNWUxOTQzZmJjNzdjYjkwNGI4ZGQzYzA1YWZmOTZiNjVlYzg1NDFkNjllNDBmOTY0NmZlYTVkZjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_6a0b623d040c472394549ab1d28accc8",
+      "statement": "The install command lists manageable agents, resolves aliases through the registry, selects supported or requested versions, runs additional installation even when an existing matching install is retained, restores the CodeMie bin link after installation, and emits plugin-provided or default next-step hints.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/install.ts#L36-L54",
+          "version": "repo-lines-v1:sha256:f1f799beac43833e405201de0b995ee8e0fceb0646ff303788219c0dacaa9daa:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE5NjQyYzc2NDYwM2UyMmNkYzQyZGNmZTIzMjllZDRjNjQxNzZhYWY2YjhkM2Y1NDJhNDYxNTkwYWU4N2RhMWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg4MDA1ZDU3MTA2YTM2MmViMDAwZGFmM2RhNDY3NGM4MmI1MThmZjVhMmUyZjY3ZWU4ZTc1N2EzMzNjMmFmNjYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI3NWM5MjVlNjYyNGQ0ZGRhNDliMjQ1NmJlZDYyNzAyOTNkNzdlNWQzZmFjZWM0YzdhNDgyYTc4MGU1MzMyN2YiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjI4NjVkODAwNTg3ZDA4OWZjNzNkZjljZmFkYzE3ZjM4NWE4MWI2ZGVjOTdiOTc1NGU1N2E4ZGM3OGU4NmE3OGYifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/install.ts#L93-L248",
+          "version": "repo-lines-v1:sha256:4565bbfb6ebb9f3a54101be5e5f205f6bddbad12f57416bccd9d2b614efb9f6c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTU2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyYjc2ZjA0MmNiNWVmYWQ4NzQ2ODMxOGI2M2JkOTM0NTQ1NWM1ZGE4YWI4ZjEwYWY5ZmVhNDA4NWFhNjk0NTcxIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI1NTIyYzQyY2QxOWM2ZDAzZDgwOGM0NTI3MjA1NTI4MjViN2VhMWM1YjQ5MWIyMTg1MTFjYWM3NDE1Y2Y5ZDliIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxODk3ZWJlMWZkMGI2N2I3YmUxZmE5MWJhZDk0OGZiNmE2ZGY2ZWZmZGJhYjMzYTU0MjU0MmIyNzY3ZDhiY2FjIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJiOWMxZTc0OWVjYTc2MzRkZTJjMWM1NmVjNDc5Nzg5NjFmODZmZWQxZjBjN2RmMWI4Yzc5MjhhZDQ0ODc0NTExIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_30f973901f994407a71d182259de0201",
+      "statement": "The update command operates over manageable agents; it updates Claude through its supported-version installer, updates the built-in agent by updating the CodeMie CLI package, and force-installs ordinary agent npm packages.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/update.ts#L207-L234",
+          "version": "repo-lines-v1:sha256:c090c3b9f126f354a5c9f7f7a88f9d1b7f8a1e2c0023e80ea378580f421e79c2:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY1OWIyNjI5Mzg3NzVlYjY0ODY0ZDdlZWVjNzIxMDkyODljMzVmYWY2MDUyNTFkYWMzMWQwNzcwMjRjOWFlYTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjA1YWM5ZjllMWRiMTMwMDZiZTI2NTA4Y2U2MjJlNWVlZjkwODhkYTcyNDRjM2QyMzlkY2MwYTdkMWNlYjdhMDAifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/update.ts#L255-L318",
+          "version": "repo-lines-v1:sha256:e618200c195e4e4912a8df21135389ec2eae2d7c6280a812ce953cccddad5527:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMwN2ZmZjU4YmNlYmMzNmRmNzVjZTA1MDY2YWMxMmI3N2FlZmFmMTU1ZGNjNTA1NWJkYzczZTI2ZGQ5MTU3MTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNiN2QwMGNkODQ2ZGIyMWY2MmE0ZGU2OTlkNjBjZDliN2M3OWI4MTg0MTIwMTE0OTU2YTdlOTE2NmVjZTAxMjIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU2YWJiODdhYTM1ZmFiMjQ5NDQ4NDhmMTc0MGQ3ZWQ1OThiYTdiNWUxY2U3NjdiMjA4OGU5ZmIwYTFhNGM0NTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRlY2RkMDM3OWFkYTU1M2I2ZjI2YWEwNzA3MGZhMGM0NzY4NmQzOTJlMWQ3ZDNiYjc5ZTIyYjBjYjAxYmYwNGIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/update.ts#L43-L140",
+          "version": "repo-lines-v1:sha256:d4f37dff3825b42fc5c6d41e80e7faf5765e909ad2578d3405f31fd90abb8558:eyJzZWxlY3RlZExpbmVDb3VudCI6OTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU2MmMzYjYyYzRiYzc5ZDk1YTEzZTM1NWQwMDZkYzRiNmYxZmEwN2VjMWQ1NDA2NjIyMjA0MzZmMDA5MTQ0YmIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyYTJjYjI1YTEyMmI0NDIyMWE2MjM0ZWM2NjBhN2I1ZmI3ZjliZGU3YjNiOWUyYjNjNTU5YTBkOTZmYWM3MzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b2fe2fdfded64f70bcb9365dd37c09c4",
+      "statement": "BaseAgentAdapter implements normal npm installation/uninstallation, command-based installation and version detection, and shared compatibility evaluation; a below-minimum version blocks launch, whereas newer or older supported-compatible versions prompt interactive choices outside silent mode.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L151-L270",
+          "version": "repo-lines-v1:sha256:d772402ba8db4e10ac1383763d7cb8f9e1b9bf77820aa8233362d1fc78aa1b79:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0ODkzZjQwZTM3ODFlYjg5NmM4MmQwNDZhMDgwNjdhMTFlMzVjZGYyZjFkZmFmMjZmZWE5MGI4ZGI2Njc2NDEzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyNTliMTQwNzJmMDEzNjQwMDg2MGY0N2RlYzc5MjYzZmJkNGYwMThmOWIwOTQ0NjUzZGI2ZDRiMGY5OWEwMGVhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L273-L382",
+          "version": "repo-lines-v1:sha256:1593857c675e11fc687b037441b79b16e49f4bd6babf19b06297472b7caf1bde:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5N2Q4NjMyZTU0ZTkyOThhYmI5NTg3MjdlMmQ1MTQwOGFiYWYxMzY2MDM1Mzc5MTAxNDBhYmY2NWIzMGFiNjEzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI5YTYwY2NkYzc5Mjk5MjU1NzZkYmJhYmRlNjJhNGNjY2Q0YzY2ZjE3MTRmNTNlYWQwNTUzMjM0ODA0NDk3YjdjIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L387-L516",
+          "version": "repo-lines-v1:sha256:a31f832e85815e2827e0b8719d7926180cc15cddb443c348aa20f6b6aa33eece:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIzNjVmYTliYjMzOTFiMDE4ZTM3MGJlNWI1MzE5MDEwNWUyYmYwZmYwZDhlNTY4YzZlNzg4ZmYyODRkNWJjNTBmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0ODkzZjQwZTM3ODFlYjg5NmM4MmQwNDZhMDgwNjdhMTFlMzVjZGYyZjFkZmFmMjZmZWE5MGI4ZGI2Njc2NDEzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiZjc0ZTM3ZWMzNDgxMTdiN2Y1Y2ZjZGRhNDA0ZTEyZjJiNjdiMzMwZjg4ZThmZjhiOGU0YzM0NWExNzk4YWM3IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0OGMzN2JlYjk2ZWY1MTRhNWUxOTU4N2YzZDhiZWNkMjkzZGMzZWUwZDI4YTU1NTJlOWYzYzBjY2IxN2Y5MDA1In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_668bc7b7231a45008c7fab578c8025bd",
+      "statement": "AgentCLI checks installation, loads and validates profile/auth/provider/model configuration, validates reasoning effort, handles native or framework resume ownership before launch, and invokes adapter.run with pass-through arguments and exported provider environment.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L158-L460",
+          "version": "repo-lines-v1:sha256:d720e37dcda2cd1687f3ea2edb35bb9ac0c9cea3be47393a0086d69873b0e90d:eyJzZWxlY3RlZExpbmVDb3VudCI6MzAzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjMDViYzhlYzAyNDkwNGY4ZTk1MTJlMDA1MGM3YzcxODk3OGEyY2QyNzhkMWVjYWJjMzIyMWM0NjM0OGYwNjFmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI3ZTVkNjIyZGNmOWFkZDk5ZGNlYTBjODg3YzRiMzhkYzZjZGQzYzQwMTNiYzg0MGQzOGExZDA0NjZjMGVjNjExIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyOTZjNmFiNzAxNzUxYTlmNDcxOGMyYmZlYzU5ZjE4MjE1YWQzNTUzZjBjYjEyYzk1MDBmNTFhOTFiNzM3MDJiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlYTRiMjZiMGNkMjMxYjBmNDYwY2YyMWE1NDYwNDU3OGY0NDM1YjhiZGUzNmZkYTdlMzUwMjllYjgxYmE4ZThkIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L588-L616",
+          "version": "repo-lines-v1:sha256:b5c5504fc9951743690734642cbd0b25c2d5b0edee46474bf0577019f79fa77e:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0MTliNmM1ZGM3N2ZiNjI3MjhiNTFiMDI5ZmY0NmE3NDc0Y2U1ZDZmNTdjNzI2OWY4OTk0Y2EzMzhkYTA5OTIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJhOWI2MzE0ZDYyYWIzOGM2NzZlODVhODU5ZTI4MzQwYzQxZmJjOTQ3NTAwNmFjNThlYWFkMjA1M2VjYmRjODciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L643-L694",
+          "version": "repo-lines-v1:sha256:fac695b34385946ccaad8fa4734f57092e1b42deff77040dea2c06c27c1060ac:eyJzZWxlY3RlZExpbmVDb3VudCI6NTIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUzMGZiM2Y1ODRhZDExOTBlYzQ4NzM1ZjkxNDBlYjk4ZWNlMzE5MDZjOWQ5MDkzYjNkNWJkNjgyZGFkYjkzMWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRmYWM0ZTQzNjMwYWJmNjhjM2E0YTc1NzNmZDRjNDMwMDhiYTc5OGRkNzZjMzc1OWVlZWY1M2U2Y2ZmOGQyZTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM4NDhkNzU3YmY1ZDFiNWYyODdmYTdmZTgwZTIyMzM2NDgzNDFmMGJlZjMwMGNlZTU1YzVkODIwMTYxOGI4YWMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_972d8df7971d479da34f9a79d5927818",
+      "statement": "BaseAgentAdapter creates shared session and repository context, conditionally starts the local proxy only for SSO or JWT with agent proxy support, maps CodeMie environment variables to clean native variables, executes lifecycle hooks around the child process, and ensures session-end cleanup despite hook failures or signals.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L1059-L1175",
+          "version": "repo-lines-v1:sha256:4b8ce52dea64fd4cef40cd210d0b806c40b7d2b865c40d7d4bc587a173eaa14c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiZWVlZmRkNTExM2Q5OTA1NmYxZTE5ZGUxYjdkNWJlZGU2ZTBhMzAxZjllOGY3YmU0ZWFkM2Y4ZjhkYTg2NmM4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmODRhYTA3ZGEyYmMyY2MxYTQ0NDU0YzBkNzIyZTA0MDQ3ZTM1OWMyZDcxMThmOWEzMmQ4ZGYzNWIyNTc2NTkzIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L518-L645",
+          "version": "repo-lines-v1:sha256:76aba7afcb100ebc671d5eb23ae6dd8aca5566ea0c568d957e7fa434780a29fb:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJiNGRjMTQ4MzVlMDM4YjcwNzFlODFhZDhkYzkxMDNhZWY1ZmJmNzU5ZjYzYTZiYWE1MWJhMzQzNjJjZTEwNTE4IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0ODkzZjQwZTM3ODFlYjg5NmM4MmQwNDZhMDgwNjdhMTFlMzVjZGYyZjFkZmFmMjZmZWE5MGI4ZGI2Njc2NDEzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwNGI5YTBiMTZiOTkxMGJhYTVkMGE0ZGNhZmY4YTYwYzQyOTYzM2JmMmFlM2NiYWNjODIwMjkwNzU4MGQxMGNhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNWQ4YmEwMzIzOTViMGVhM2ZhZDdhY2ZiZmZlN2Y2ZGFmYzYxZmM3NzgyOGQ1ZGMyYWJjZGJlNTE0ZDQ3Y2Y3In0"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L699-L935",
+          "version": "repo-lines-v1:sha256:f4b5d5f76ab09e7d556745187f86f54fea60a452ae91fed326c505141f22361b:eyJzZWxlY3RlZExpbmVDb3VudCI6MjM3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIwOTk1MWE3ZjBmZTFkNzIyZGQ5ODMxMGIwMGVjZWVmMGE1ZWJjZTlkYjhkNDE1YTYzYzZiMGI5ZTlhNDg4ZDJjIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0ODkzZjQwZTM3ODFlYjg5NmM4MmQwNDZhMDgwNjdhMTFlMzVjZGYyZjFkZmFmMjZmZWE5MGI4ZGI2Njc2NDEzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJjMmVmMGVmMDgwNGY3OTdkZWYwZjUyMzU0MzIzZWNjZmE2OWFiNjcwYjc5NGViMDgzZTE0MzA4NTlmMTU4MWI0IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L939-L1041",
+          "version": "repo-lines-v1:sha256:5d289681ab58e5f06e9f5e9fbacc7d8f4cb184ca37c5be95a732ee187db755be:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIxNWVkOGI1ODAzMjkyNTI0OTBhNTA2MjRlOWMwYTk0ZjhlMzZiZjFhMjRiYmMyNDE1NjY5ZTMwZGIwYTBlMTYwIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1MDkyNDJjN2ZmZjkzMGY4Y2MwNTdkZjA2YmZiYWU1MjUzZDUxMjVlYmQzNTIwNjU3ODhjZTU0MDQ5MjA1MmZmIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_cbd5048ad4344ab4937ab3f0267fd7d9",
+      "statement": "Provider lifecycle dispatch keeps agents provider-agnostic: a provider wildcard hook runs before its agent-specific hook, a wildcard can chain into an agent default, and absent provider hooks fall back to the agent lifecycle hook.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L141-L279",
+          "version": "repo-lines-v1:sha256:a4ec4fe611e0551b8b26225491878f28c93da3c330b91805909a92c9602a2773:eyJzZWxlY3RlZExpbmVDb3VudCI6MTM5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIzN2Y1MGYxNzE3ODU4YWRmNmNiMDE1MjZkZTFmNDM4M2IxZTZlZTE5YmFiNWRmNjNmZWZmYzgwYzZlZjQ0YzhlIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwZWY3NGY0YjE2MjJiMzI3OTMyMmM3NDk2NDZmODc5YTNjMzMxZTkxZDFkYzQ2ZWY5MDdjMTgzYTM2NDliNzc3IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L45-L127",
+          "version": "repo-lines-v1:sha256:adefa9eedc17bc8fd7ce5783e7a10df2059b597b2fd717b848b6f726169e6339:eyJzZWxlY3RlZExpbmVDb3VudCI6ODMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFlYzdlMDlmNzdjY2FjYjZiYzEyNGU3NDhkMTE2MmJmMGM5YjA2ZWU3YmFiMGEwYjY5M2M2YmM3NGFjNDQ3ZWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjNThhMWNjNWEyZThlMDliYzAwODZmNWNhY2Y0YzM1ODQ5YjgyNmVjZDM2NjhkMTQ5MmI0ZjRlZWVmZGYzMWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjljNjNjNzUxNjYxZTczZTNlZmU1ZTUyYjc3YjIwMTBlYmY5MTBhMGU3MDVlOWU2YmQxYzdkYTU1ZmJjZDA4ZjkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_2314f83f82b347d485d270fb001d5bb5",
+      "statement": "CodeMie Code is a built-in adapter around the whitelabel OpenCode binary: its beforeRun lifecycle builds and transports runtime configuration, redirects storage, merges default/profile/CodeMie-plugin hooks, translates task arguments, and injects shell-hooks and reasoning-sanitizer runtime plugins; session end routes processing then cleans up those injected plugins.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/plugins/codemie-code.plugin.ts#L167-L224",
+          "version": "repo-lines-v1:sha256:3b8f2819e81dbffddad0c6589ab486ff38025e1b8ddb4d6fe8f37538ec705251:eyJzZWxlY3RlZExpbmVDb3VudCI6NTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQzZTRlOGY5MzYyODI5MmJmYzljMGYyNjRkYTA2YTA2MWUyMTg1NzgwM2ZkYzQ0YjgwMjFjZmMyMzg0Y2IzZjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUyNmRlMGFlMjFlNzFlYmFkZDczZmJlZDk2ZThmYWNlNjEyNDE1M2ExYmQ0ODFkMjU3MmU3ZTg0ZmJiZjhjMTIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFhYWI1OTlmMDZiN2RhN2JiODBkNzY0ZWViODU4ZmFmYWU3ZDU3NWQ5ZjgxYzgwNzJmM2I5N2NlOTgzYjcyMWMifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/codemie-code.plugin.ts#L246-L384",
+          "version": "repo-lines-v1:sha256:3c6305495a00513611a9f172b354758fcb7d0919c915792e22270fe7616def87:eyJzZWxlY3RlZExpbmVDb3VudCI6MTM5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJmOGEwMDVlMGIwZmFhNmEwM2MyMGU1YzhmYTMwM2VkMGE1YWUyMjVlMTE1ZGVkMzUyNzY2ZTk2NGYyNTFjMDJjIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJhZDAwZGYxMWM3MzEzZmMwZTE4NWJhN2YxNDcwZjQ5ZjIzOTNmM2JhNDg4ZTQ3NmE1OGFiM2M2YTI0MTk1MjJhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5NzFmYTkyYzUyZmMwOGNlMGQzMjNlYTZiODg5OGM3MjFiYTc4ODg0OWViYmM4NjI5Y2ExNzNlYmJlNDE2YjczIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0NjkzODY3MGUyNTRhMzhiNjhiMDI0NzcxYWFjOGIxM2NiMmFmYmVjNjA5ZGNjNTg1OGMxNzcwOGI1MDZlMGQzIn0"
+        },
+        {
+          "resource": "repo://src/agents/plugins/codemie-code.plugin.ts#L387-L465",
+          "version": "repo-lines-v1:sha256:dbc080073838e6b31eb2af4b2e73a792cf002afc81ef4df44878bb30995b309f:eyJzZWxlY3RlZExpbmVDb3VudCI6NzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVhZDVmZjUzMzM3MWNmNDEyZGU0YTc5ZjFjNzFlNmNhZmNkODk2Yzk5NGZkYzZmZjc5MGNhOTIwYTY1MTU1OGQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjdkZGNiYTRlNjkwZmQwYTMzNjk2ZjliNGEyNjY1OWY3MTA5ZjUzOGQ0OTE2ZmQyNmRmYWM2YTUzN2Q2ZGUyNWYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjcyMTI5YzI3MzUyYjQ5NTU0OGIwNzFhZTM0YWI5MDgxMTcyODczNDI4ZjZmODdmNTRiNTgwZTUxNTNjOWFhMDIifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/codemie-code.plugin.ts#L469-L539",
+          "version": "repo-lines-v1:sha256:b49479d00df738bc3b73e558fb3f29c3164a2f3551f595590e638c5c6751bbeb:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjcyMTI5YzI3MzUyYjQ5NTU0OGIwNzFhZTM0YWI5MDgxMTcyODczNDI4ZjZmODdmNTRiNTgwZTUxNTNjOWFhMDIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_a3196fe772e741048ac7da904fc532b9",
+      "statement": "The runtime plugin injector writes embedded plugin source to a temporary codemie-hooks file on first use, returns a file URL, registers best-effort exit cleanup, and makes repeated URL retrieval and cleanup safe.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/plugin-injector.ts#L1-L63",
+          "version": "repo-lines-v1:sha256:4f000c1caddc8330637da204e88cf05ac7afc2f9a0af3c4758d0370b5245a22d:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM5MWFjOTkzNzE5OGQwZDc5OTkyZjJhM2QzYTg3MTUxYzhhMDk4MDEzOTFkMmRkNDk4YWNkYzA1OTFjZmU1YzEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/reasoning-sanitizer/__tests__/inject-sanitizer.test.ts#L61-L131",
+          "version": "repo-lines-v1:sha256:375907f036f43ae674b00faf7117e69f1ad5ad7e6cd2d79b312a82a4fd3abe52:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRiOGFhNDEyOTAxZjYwNDQyZGJiNTExZmU2ZTAwMzVmODQ4YjczNzJiNTk5NjcyNTcwZGQyMzIyMDg5NDE4OTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM1MzZlZGFhYjUwMzgxNTAwZWM4ZTA1M2M5NWZhNmIyZGU4OWJiNThjYjY0N2IzOWNhMmZhNDlhOTgxYWYwNDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ4MTdmYmI3M2M5MmIzNmQ1ZTQ4OTZmZjUxYzFiNThlZWMzMzBiYmU5NjFiYTA1ZmM2MjA1Zjg2N2VhMWJjZjYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_fe17c91faf514e7b8c4973ac52c2c08e",
+      "statement": "Focused tests cover built-in adapter installation behavior, runtime-plugin injection cleanup, Codex session lifecycle ordering, registry session-adapter wiring, shortcut behavior, and SSO-gated real-agent smoke paths for Codex and OpenCode.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/plugins/__tests__/codemie-code-plugin.test.ts#L134-L260",
+          "version": "repo-lines-v1:sha256:f79867459598557775cde7a13a831c5f32305875ea82e307f21392aaab3dad03:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIwODI0ZmQ2MjU0ODI1YTBkMDMyZWM1YjQyMDM1Y2U3MDFiYjM5MTU5YjRhZjdkYjU1ZTVlZmVjODNmNGExZGEzIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI3ZTUyZjlmMjE1NDIwZmZhOWUzMTdkZDY5M2EyMWEzNGU2M2VkY2NlMWE4YjgxNDgxODI3YzM3YjMzNGYyNzk1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmMzkyYmRiYWYyMmRhOTA2ZTI0Nzk2MzVhZTI5Y2ZiZWZiODhiNTk1ZTBiYzk3OTM1NTIyZTIxYjFiODM2NWQ3In0"
+        },
+        {
+          "resource": "repo://src/agents/plugins/codex/__tests__/codex.plugin.lifecycle.test.ts#L14-L94",
+          "version": "repo-lines-v1:sha256:0a9093b472af8beb15ffae3c081d12f325021c613db4d5a3306a39f283e7e68a:eyJzZWxlY3RlZExpbmVDb3VudCI6ODEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk2MDhjOWUyZmI0Zjk5NTk4N2EwZmM1OGMxNDM4OWEzZTFiYWIxNTkxMTY5MDU3YThmNWM5YzRjYWM5NTFiZDQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQwMTNlMGQxNDM0MGRhYjNiN2I3YWI2MjVhNmVjMmQ1NTJhNzI1MzBhODE3MDI3MDMzNWIxODIyNjk5MGYwN2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://src/agents/plugins/reasoning-sanitizer/__tests__/inject-sanitizer.test.ts#L61-L131",
+          "version": "repo-lines-v1:sha256:375907f036f43ae674b00faf7117e69f1ad5ad7e6cd2d79b312a82a4fd3abe52:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRiOGFhNDEyOTAxZjYwNDQyZGJiNTExZmU2ZTAwMzVmODQ4YjczNzJiNTk5NjcyNTcwZGQyMzIyMDg5NDE4OTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM1MzZlZGFhYjUwMzgxNTAwZWM4ZTA1M2M5NWZhNmIyZGU4OWJiNThjYjY0N2IzOWNhMmZhNDlhOTgxYWYwNDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ4MTdmYmI3M2M5MmIzNmQ1ZTQ4OTZmZjUxYzFiNThlZWMzMzBiYmU5NjFiYTA1ZmM2MjA1Zjg2N2VhMWJjZjYifQ"
+        },
+        {
+          "resource": "repo://tests/integration/agent-codex.test.ts#L1-L36",
+          "version": "repo-lines-v1:sha256:80b8f1f7329fb95c437ff7d35ada27d0acbaef9b1aed56be06e5bf6cd8a979a7:eyJzZWxlY3RlZExpbmVDb3VudCI6MzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJiYzQxYWVhNmUyY2ZkYzMzODZlZThjM2Y3YjBhNWM2NzRhNjQzOGY4M2MyZWZlNDRjYTZlMWU2NTJkNTFlNzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjYyYTA2ZTZiN2U0NTZmYzMzNDM1ZjhkYTQyNzhiYTVlZmEwM2E2ZTY5ZjQyOWJiMjBkMThmMmY4NmE0M2NmODYifQ"
+        },
+        {
+          "resource": "repo://tests/integration/agent-opencode.test.ts#L1-L51",
+          "version": "repo-lines-v1:sha256:8f7bd0964a69e2bf2e5f54138af22818fcb4193d3cb04d9d3b7a64bb881c0eb2:eyJzZWxlY3RlZExpbmVDb3VudCI6NTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://tests/integration/agent-shortcuts.test.ts#L36-L113",
+          "version": "repo-lines-v1:sha256:f6904e4a35d8d116b0429c4837e018bc750e28db999a7a5a71435b77464304f8:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcyYThjNjBkNzYzMTlmNWMyZDM1NWQwYzIyNWIwZmQ4MzA3ZjdiYzhmMjQ5M2M1ZTBlN2JmNzBiY2ViYTRmMmQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjUxZTM3MjVkYTAwMmI0NmVkOGI0ZGU4ODAwM2FkOTcxMGRjYWYxOGQ1N2M0NzAxZGMzYmVmZjBiMmM1Y2IxM2YiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7bf73240a7554c08997297a13b1d8298",
+      "statement": "Repository integration code follows ES-module conventions of .js import extensions and no require() or __dirname, favors @ aliases over deep relative imports, uses the CLI-to-registry-to-plugin boundary, uses logger.debug for diagnostics, sanitizes sensitive log arguments with sanitizeLogArgs(), and favors project error classes.",
+      "evidence": [
+        {
+          "resource": "repo://AGENTS.md#L163-L177",
+          "version": "repo-lines-v1:sha256:75aa8c6d04e49722129f0cf7442a01b496a50c57f6ca11bf46a648c553ab468e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUwZjgxMzc0NWM0MmI2YjNiNzQ2YjhlYmEyZjczYmRhZTk0NDJkZGZiYTliYjI0OTk5MWZkMjAzYjI2ZTYwOGMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg5MWNiNWM4MWZkYWNlNGM4ZWI3NjMzMDYxYjU0YjhlNGFlOTM3Zjg2NTU1NDI0MzFkMjk4YzAzMmNiZTM3NzEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg5NTcwZjNlYzI3NmUwZjg2NTczMWJjYjE3Mzg3ZmQyMWE2ZDNmZGUzZDNkY2Q4MTBlYzQ4ZTAyNTkxM2E0N2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYxZTYwM2MxNDE5ZjE4MzJlMTFlNzI2NjU4Y2FlMzAzZmMyYTBmZWY3MDhkMzQzMTY2YTM2ODdhMDU0MmI4MTYifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/integrations/mcp-and-desktop-clients.json
+++ b/openwiki/.claims/integrations/mcp-and-desktop-clients.json
@@ -1,0 +1,294 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:69690d6f5837b33fbaf2998251c409804ec91fb055c840adbf0904e8ef1c9cb8",
+  "claims": [
+    {
+      "id": "claim_4a7a81e38e7d458a8aecdb86e9043ea1",
+      "statement": "The package exposes `codemie-mcp-proxy`; its lightweight launcher validates a required URL, imports the compiled bridge, handles termination signals, and avoids normal CLI initialization so stdout remains safe for the JSON-RPC stdio channel.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L3-L13",
+          "version": "repo-lines-v1:sha256:ef9c88b8436874fc4ac571a8d7b413185a74dd5839dab963681d6e5d10a408b2:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY1Y2Y1OTFjZDM1ODBiNjYzMWY3NWEyYThhNDZiM2I5ODMzMzYwY2NiNmJlNTZkOWYxYmRhMzFhMWZmMTRjOWEifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L32-L90",
+          "version": "repo-lines-v1:sha256:0f6faac5071a2abf9e2b21afee6acab7698fbde42e9c2558f1b18331a4bf1410:eyJzZWxlY3RlZExpbmVDb3VudCI6NTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdlMDdjZmJkOThmZDgwNWI1OTIyYjkxNTEwMGIwNjU2MjI2M2RkNjhjZjMyMjdjYzA2YjBiNjFhMjI5MzU4OTAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU4ZmJhZTE3ZWJlNzVmMmEzZDY3YWUyN2UwMTc4NTEwOWQ0YzJkYjVhODExZjQyMTUzNmZiM2QxOTQyODZhODEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://package.json#L8-L21",
+          "version": "repo-lines-v1:sha256:5b410cb48060e62393262fd2ba588db58d71ba5500b5dc0fff73dfacdfe4c31d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2YzE0NzU3YjhlMWU5ZDZhN2RlZTk5MDJlOTA0MDdhZDhjZjY3M2IzZThkNzYzZTI3OTUwZDE5ZDA2NzhkNjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIwMDA2MjQ0MWQ4MTU0OTI5NmYzMzE4YmExYWZlMjkzOTBhMWQxMDQxYzBhYzkzZTc4OTFlNmFlODc0YzQ4NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc0ZjUyM2MyZGM1MzgxYjQ4ZjYxMDE0ODQwYWJhYWQ1Mzc3MzRkYzRjNDhkMjBmNzgzNjAzMjBmZWEyYWU5MzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVmMWI3NTgxNmNlMTMwNTVkYzg4YjY2Y2YwZmYxZjE3OTNiNDc4OWJhMGZjMDliYzQ4YTg1YmFhMDc0NDI2YTYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_ffd9ac91d1964d4b964b915defce0235",
+      "statement": "`codemie mcp add` validates the server URL and name, verifies the proxy and Claude CLI are installed, then invokes `claude mcp add` with `codemie-mcp-proxy` as the stdio command and forwards an optional scope.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/mcp/index.ts#L7-L105",
+          "version": "repo-lines-v1:sha256:eff728ebafcd7cb621219ae1d5e622d205602f67b9ddbb45b8720cde300adad6:eyJzZWxlY3RlZExpbmVDb3VudCI6OTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3MWM5NThmNjZmMjA2MDJkMWY2OTJmMWM3NDJiYTAyMDMyNTA1YjQ3MThmOTUzMDY3MDNiMjg1YjkwY2NiNTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNjJmNjBkODU5MGE1NzljZjQ2ZjhkNjczNzhjNGM1NzJiOTYyY2VjY2RiOTBjN2E1ZjdiNDJiOTYwNzgyYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBkZTE5ZjA1MTE3NGUzY2NjYWRiYWI5ZjhhMDc1NTBlZjk2Y2UyNTBhZDU4OTBiMDk4ZDdmYjc5ZTYyMzljMjkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg3ZTUyOGU3NWQwNDYyOGY0OTY2ZWUxNjYyZWE0MGE1OTZhOWQxYTE2MjRhOTZkMWFkYTNjMGYyZGY4ODM2NTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3b0c34278da246b0a9ed0839baa933d8",
+      "statement": "`StdioHttpBridge` starts listening on stdio immediately but lazily creates one streamable HTTP transport on the first message, queues messages during connection, forwards outgoing and incoming JSON-RPC in opposite directions, and shuts down when either transport closes.",
+      "evidence": [
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L257-L278",
+          "version": "repo-lines-v1:sha256:bd76b37c8710a2c6d0ff410d7072d1120c61bfeb07e0225c1467f9e37d4a1a7e:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEwYWY4YmQ5YjU2OGYxZjkxNzkxNTgzY2EwMGExNDZiOWFmMWU0YmRjOTU1OGFiYzAyOGViYWRhOTYyZWVhYmQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJmOThhODM5NDhlNThjNTVjYjAxM2FmOTczZDI3ZjNkNDM3NmQ4ZjAzNGM4ZDk3MzViNDI0N2IwODBhODJlNmQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY0OTUxN2E3NGQ0MzJhZTUyODQ4MGFmYTdiODYxNTc4MTkyMWY3ZGFlMTEzNzMyOWY3ZWJlZTM1NDE5N2I4MjAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L293-L346",
+          "version": "repo-lines-v1:sha256:355f2633325044fd10398dc91f5e604d20677baca7f2479141c7d1861b0d3098:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVmMmVkZTczZjM0MDNmYjkwNGJmMjhlNjc5OWE2MTBhYTZhMzEyMjE3OTJhMDI1YjRjMTk5MzQ0ZTYwNjM4M2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L87-L207",
+          "version": "repo-lines-v1:sha256:d6687845907e25ecfa94cae3036baeee45cdbc16a10673f69ab0dde0e4140a91:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIxLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIxMmJiYzE4ODZlNDg0MjViYjE4M2Q0OGQxOWE5YWRhYWI2ZDdmZTg3MTRhODNmMjA1M2Y1MmI0ODNhM2YyMDllIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0ODkzZjQwZTM3ODFlYjg5NmM4MmQwNDZhMDgwNjdhMTFlMzVjZGYyZjFkZmFmMjZmZWE5MGI4ZGI2Njc2NDEzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJjMWVjMWYzNmZkZmJmYzNmNjZjMTJiMWQ0NWIzMGMzZTdmODYyMGRjZDk5OTVhMzhlOTk0OGE1ZDBhNGY0YzRjIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_72d39ad6bc55476cbd065d6905681d36",
+      "statement": "The bridge uses an in-memory per-origin cookie jar that captures `Set-Cookie` response values and injects a matching `Cookie` header on later HTTP requests; cookies are not persisted across bridge processes.",
+      "evidence": [
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L211-L260",
+          "version": "repo-lines-v1:sha256:699a3f6eb5027bb9037105b737fcc52d24a3d4a58a9c84ad0c291d293a70a86c:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdhZDFjZDkwMzcyNjkyY2FjNTIxYjQzNzk3MjIxY2NjMDI0OGM4M2NkMzQwYTI5OGM5Mzg5MGQxNzNjNTNhMzEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI1OGYzMmZkZTAyNWUxNjJiOTc2NWI2OWI3ODg2NzU3NWEwODExYmQyYzkwNjc2OGY5MGMyNGVlNGFhMDk5YjYifQ"
+        },
+        {
+          "resource": "repo://src/mcp/stdio-http-bridge.ts#L44-L80",
+          "version": "repo-lines-v1:sha256:1266cf601e4458f479bae24a61fb4ec52f4b9c62e3438c9d1aa997cd8b2f7850:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYwNGQ2NGM5YjUzNjA1ZTAwYmEzYjAxODBjM2MxYzY0OWJmNmY1MDFmMDBkYjg5YThjYzA3ZjVlODViMjQ3ZmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4NzdjYTM5MjlmZjVjMjA5OWE1ODgyMzUzNDdjMDdhNWE3YWRlNzU4NjhmYjEyMThlYTBjNzc1OTU4ZGFiOTgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b9588e799dcd47508b824a44b8da2791",
+      "statement": "The MCP OAuth provider pre-starts an ephemeral localhost callback server before connection so dynamic client metadata has a redirect URI, keeps client information, tokens, and verifier only in memory, and opens authorization in the platform browser.",
+      "evidence": [
+        {
+          "resource": "repo://src/mcp/auth/mcp-oauth-provider.ts#L1-L9",
+          "version": "repo-lines-v1:sha256:dbdbf8c2b3c2b54f20435209c05c2f30df129985c853c43e2b6e29aa495510e2:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiOTcyYTQyOTM4MmIyZTE0NzE4ZTBlMzdiMDU3MGE4YTE3MDI5OTFmY2Q4NDk4Y2Q4NDA2MGE4YmY0ZjA1MDE3YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjAsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNWZiMWIzZTQ4YWNhNzBkNjVkOTJiMTRmMTE5YTJhZGZlZWQ5ZDY0NWM5Y2ZiMWUwOTAyYWZkOTVkM2U3ZmIyNyJ9"
+        },
+        {
+          "resource": "repo://src/mcp/auth/mcp-oauth-provider.ts#L120-L179",
+          "version": "repo-lines-v1:sha256:481fbea9bb7e432cba0c76d992c24744189edbe48bf74995ebce5a76a0f2383f:eyJzZWxlY3RlZExpbmVDb3VudCI6NjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjExYTJkNGM5ZmUwNzE4Yzg1NzQzZjVkNWMyMDNjZDk1ZDhjYTRiYmU0MjNjMWM0NDZiNzllYTNhNjcyY2Y5ZDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/mcp/auth/mcp-oauth-provider.ts#L27-L117",
+          "version": "repo-lines-v1:sha256:11234d381e46603e79adb590a4187645b649a68cd3ad70828bff99a569b90636:eyJzZWxlY3RlZExpbmVDb3VudCI6OTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ0MzhiYWJhNzI0ZDNhNDE2OWQ1MDQyMDBkMTZmMGNlZjMwNGFhYjk0NmM3NDBmYjdmYTNkYTYwOTM4MmE5YmQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFkZGU3MzQ0NWI3NjMzYTRlMjhmZjQ5NWVmMTAzMmE5NTEzMTE3YTFhN2NjNmM0MWQ0N2UyYzY4YjIxYTc2NmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNhOTFkZGZjMzEwNGU5MjAwZGE4MzI2ZDZhZDIwZjAxYmZiOTlkMzBhMDI4YjE4MTlmMzU0M2E4Y2Y0MGRlNDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_2e6569bc26c2470ebd7f83b6584a8711",
+      "statement": "The callback server listens on an OS-assigned localhost port, accepts only one `/callback` authorization result, rejects OAuth errors, missing codes, closure, or timeout, and closes after the wait settles.",
+      "evidence": [
+        {
+          "resource": "repo://src/mcp/__tests__/mcp-auth.test.ts#L44-L121",
+          "version": "repo-lines-v1:sha256:c459257f21f554f9447ab9590ca80d9519b20ad893911920a49715e0d31f4d24:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBjZDk4YWZhOWRjYzE5NGFhMTgzNTI0YjI3M2JlY2RjZDdkZGFhODVjMTVjMzdmYTk4NzI0MTNkZDljMjEyMGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFhMTI3NzlkMWZiZmNjMmMwNGMwMjdkMmZmMDhmZjRmYzI3YTE4ZWY4MzU0NGI5NDFmNGUwODllYTMwZjI4YzQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZkMGIwMzZlYWZiNWZiYjk2MjY4NjdhOWQ3NDY0Zjk2YmM0YWU0ZWJjYzlkNzEwNjc2NGQ0ZWQzYzc1ZjU0OWMifQ"
+        },
+        {
+          "resource": "repo://src/mcp/auth/callback-server.ts#L17-L114",
+          "version": "repo-lines-v1:sha256:d5ef9186ab5aa75b566ccca028028c98ef29d3c22232d36cb3353c5ae12a04a1:eyJzZWxlY3RlZExpbmVDb3VudCI6OTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUwNGE0ODMwMjE1N2MxZDVmNjY0YjJkMjU2NjJjMGI2YmQ3YmQ1Zjg5NGEyOTdjYjU5OTVmZDFhOTZjYjRjY2YiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUwYTJjOWZiZmFmNjk3NGQzZjEwNjFhYjA0ZjdjOTZjNjdjYThhNTE0MDUyYjllMmNlZjU3MzM0MWIzOWIwY2MiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_a3a182c2c9714326876f5ea1b03cc737",
+      "statement": "The unified `codemie proxy connect` command configures selected Claude Desktop, VS Code BYOK, VS Code Claude Code, and Codex Desktop targets; bare invocation is side-effect free, while legacy `desktop` and `vscode` aliases remain as deprecated wrappers.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connect-orchestrator.ts#L251-L281",
+          "version": "repo-lines-v1:sha256:b1a0538651c6c1170f8c79f97aa062635cabf6c9e97e7357dedc94ebd4a38a4f:eyJzZWxlY3RlZExpbmVDb3VudCI6MzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxNDJiMTc2MDAzYzRmMWNkODY1N2NmY2EyYTNlYTk1NTQ5MjI0N2I4ZTIyMmZiZjUzNTkzNmE3Zjc5NmM4MGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY1MzhkMmY1M2MwZjYxMjgyNzBjZWNiMWM1ZjhiYzYxNzEyYTNiZTkwZGUwNTE5OGYyZmM1N2Y4OGFmNTBiNTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkzNmViMjdlYWYxZTdiMzhlMDBlYmM1NzE0YTgyZjk2OWI4MTQ0YmUwZDY2NzEwYmEwYWY3MDgyN2ExMmQxYTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk0ODFlOTQxYTljODk3Y2RkODkxNTdiMzdiZWVmZThlMmZjNmU4NzJmZjdkYmJiYWUwZTEwYTVlZmE0M2YzNDEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connect-orchestrator.ts#L574-L688",
+          "version": "repo-lines-v1:sha256:818d77b42240b5e1e849f190574761338ad604bf9fdfd5b0e4eb50f6af8c39a6:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI1OTA1NDJhM2Y4ZWY0YzUzY2FjN2E5MmY4ODE1OWU5ZjkxYjdkZGU4NDFhNjExYWE3NWQyZGZhOGEzNDAzZjljIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0MThmY2YwNGMyMzE3NmY4NDBiNDMxNGRiZTZiZDU4ZGM5NjNkYTI4ZTAwY2ZiYmEyYjU3ZGMxYzk3YTQzMGI2IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MCwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/index.ts#L281-L361",
+          "version": "repo-lines-v1:sha256:390c7758656a93b2b08af5cdfbc223c8412bb4334a64512fbf785e6606d36726:eyJzZWxlY3RlZExpbmVDb3VudCI6ODEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJmYzdmMTY0N2U3M2M4MDZmNzQyMzc4OTUyNjMyN2RhNjAzZjE5ZTJkM2YyNjlhOWFmYWQzNTkwMzk1NDg0ZTYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhZjAwNzYzYmU5ZmYwN2U3YzFjNTdkYTNmMTg0ZThjZmIzYTNjMjBkY2JhZmM5YTI3Mjc1NWIxZGM2YWU5NTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjU0YTM0YzBiMTYyMGY4ZDc3YTg5YTdhOTRiN2U2ZDE1ODMwYmI5YzYwOTQ0ZDk5NWZiZmVkODNmOTk4NmNlMzEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_a7ceb9788fe0456db31eaa13ea4b594e",
+      "statement": "Before configuring clients, the connect orchestrator requires an SSO-backed profile and stored credentials, best-effort synchronizes skills, and derives a single daemon identity; a daemon is reused only when its profile, port, project, provider/upstream URL, and effective client type match and it passes deep health, otherwise it is restarted.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connect-orchestrator.ts#L119-L246",
+          "version": "repo-lines-v1:sha256:d2dcf3cb206ffe01d0befa4b0d0131b55f61c1517dfa67e31cee08bd72d13881:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlM2MyNDNmZTlhMjk2ZDQ5MWRkZTU2OGRlYmEwOWE0ZTgxMGY2YTZiMzZhYjk4MDQ2ZmY2MjI2NDFiZWZjYWU2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJlNGVhMGY0ZjlhMDQyYWZhNGZmMmI5MjBlM2Q2NzU1ZWUxZmM0ZmIwNDcwMDZmZjQzYjBlNDhiYzEyODBjNzUwIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2ZWY1YzI2MWQzZDdkN2QyNjFmOTdlMGZhYmRkNDhkODM2N2VkZWE2M2VlMDc3MTZkZDJlYjQ1ZDg4YTMwNDhhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI2NTE0ZmQ2NThlYWY0NTgxMzIyYWM4Y2RkYjZkMmVmYzM1ZmZhODI3NzY2MDM1NDU1M2VmMjEyOGM0NDkzZmVhIn0"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connect-orchestrator.ts#L298-L357",
+          "version": "repo-lines-v1:sha256:702b00882b659780e6590b4eddafbf7d3fc230521b4e6f3e682b3d426293efe5:eyJzZWxlY3RlZExpbmVDb3VudCI6NjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUwMzk0Yzk4NjgzZTdhNGVkYzBlMDZjYTAyNGJlOTgzNTA1ZTVmOGY2MTYyNTA2Y2Y0ZmUwOThlMGY2OTk2MDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjI5MzE0ZjA4Y2Q5MzRkZDM4MTUzMThhMDJlOGIzZDk4ZjNhMmZhM2UwMTU0NDljNWQxZTE2M2NkMDNkMDllODEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connect-orchestrator.ts#L605-L688",
+          "version": "repo-lines-v1:sha256:47a7bd8160bfddb253eb3fdb8ffc31f76b3220b890efd2edbd926d9bd3d78876:eyJzZWxlY3RlZExpbmVDb3VudCI6ODQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVjM2JjMjNiM2RlMzM4MWU2YmJlYzc2MzRmZGM1Mzg1Zjg2YmQ4MWRhNDg3MTZjMjAyN2RlNGIwOTU1M2U2MWUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjUyMTcxMTE1NDNmOGE3YjFiOGEyZjVjNmRkOTAyNjMzYzEwZDUzMTI5NzAxM2ZjZWM2MTdlNmY2OTAzODE4M2IiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_c66c3f01b6b74ea98848a3094ba2720f",
+      "statement": "Daemon state is persisted atomically; startup polls for a live state for up to five seconds, and stopping escalates from SIGTERM to SIGKILL before clearing state so a wedged daemon cannot prevent a subsequent connection.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L151-L187",
+          "version": "repo-lines-v1:sha256:fdb0bf659da51126d2d9f0957defc0d71812d05ab9a8b685ff9d13973cae6aed:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYyOGE0OGM0NDY2MDU5YmE5NjQ2ZWMyODJkNjNiMDQ0ZTU5NDNkMjcwY2ExMmM5OGY2YzQyNWY0ODhiYWM2MWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdkMTNjNjVmODNlMzdkMzdiNGM3NDVlYWM2ZWZmMzRjOTdkYzVmYWNkNDg2NmU0OWUyY2VjNDc4ZWU1OWVlM2YiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5NGZjMGMxNzNkMWVjM2ZjNTAxZDdkZmE5Mjg1NTAxYzUyN2NmYjQ3MTI1ODNkYTNjYzM2MTgwNTY2YjRiZTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L32-L80",
+          "version": "repo-lines-v1:sha256:d60cd6edf44464ff8643c1f36e827c12a6583de438b90326c069428856d24e17:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU4YmRiMTNmOTllNjljYTdhMzVhNWEzNTAyNjA2Nzc5MmQxYTk1YzE3NjkyZGRmMjg5N2Y0NWFmMmRlMWZlNzMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImM4YmIwNzQzYzEzNWYwMjgwZDAyZjFiMTNiNDg5MjZjOTdkOGRhZWNhMzI2MGVjMDQzMWNkMzI3NzgzNzI3ZTgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ0OTQyOGQ5MGVkYTBhMGVmODA0ZmE5MjFmYjljYmI1MTYzMmJlMTNhOGQ4OGVjYTQ5OGEyYzg4M2YwMTBlODIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZiNDRlNjQzMWQ2MjkzNGU3MTJlNGI5Y2U0YWU0MDI5ZDY1Nzc4YjI0ZjM1ZTlkNjhiMzQ0MDkxMDEwMmZmZDQifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L96-L148",
+          "version": "repo-lines-v1:sha256:7ed7ff61b6bd0e87cceafc4af7ae22aa443832b24bb8e0f54d05941ee25d5d25:eyJzZWxlY3RlZExpbmVDb3VudCI6NTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNWQ1YTA4ZTRjOWEyYTEzYmUyNjEwODAzYjIwMDcxNzZkNzM4NWI4YzNiYjBhYWFjYWJhZjRiYzRmMGRlMGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk1ZWYwMWJjMDhkYmMzYjYzZTRlNzVlYTNkMjZhNWI5NDE4OTE4NzdlMjdhZDg5MTMyOWM4NDExZDdkOGRjNGQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3MWMzODQzMGMzMDk2NTMxZDlmYTg4ZGVkMTgwMzkzMTMwOTNmOTQ5N2NiM2E5ZDU0ZWEwNzI0OGZhOTk2YWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjExN2Y0NTU4ZTZmM2JmNjBhMzhiZjhkYmI5MjNkM2YzY2I0NTE0MDNmOTczOTEwZmZmNjMzOWRmOWRjN2NmODQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_874cb0666bf045a480a9c4e125d7489f",
+      "statement": "Claude Desktop configuration discovers compatible Claude models through the local gateway, writes CodeMie inference settings and a managed MCP list to the active config-library entry while preserving unrelated keys, and warns when a Linux managed-settings file can override the local configuration.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L710-L755",
+          "version": "repo-lines-v1:sha256:61e6d70c5909561c6fe44d684e3f25aea880db11201df39fcdbba49a934b8e65:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjExNDM2ODY1MWZiZDBmNWQzZjgyZWIyNWNkNjM0YWI5NTk4Y2FiNDg1MGU0NTMwNGViMWUxOTEwZTE1MmUwZDYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L74-L170",
+          "version": "repo-lines-v1:sha256:0dc3a3c88d1d3e6172b8cab2de7c3818c1181f3a394c6b15bb45269520b2f246:eyJzZWxlY3RlZExpbmVDb3VudCI6OTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImExMGVlMzZlYmFhZjY0MDhkYjUyZjEwMWNkYzczZTZmZmRiMmQzOGZkODA4NGNiNDQzNTY2M2Q2NmMwZDBlYjMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L765-L938",
+          "version": "repo-lines-v1:sha256:b503a7d8af81e62ceb17144880a014738e1825bb748c4d552682666f59a6c9be:eyJzZWxlY3RlZExpbmVDb3VudCI6MTc0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI1MjBiZTMwNzI5MjdmYjhhZmNjYTJmMjAzMTA4NzM2MGFkMTU2YjY1OWE3YWU1YzYzM2Y2YTgwM2Y0MjM0ZDkxIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIxM2UwMjAwYTg3ZmQ2MmM5MjhmNjU1YjU4MWNhMDA2MDk2N2ViYTdjYjE2MTk5NDE0NTFkM2Y5MjZhYmE1ODkzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwODRhOTE2YmY1MTQyYzY4ZjIyZWI4MTY2OGE4NDY3ZjIxMzRkZGNjZjQ3ZTU2OTljZDdlOWQwZTYzYzc2MzI3IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_d2a89afe1c6a4031b65918a21aa079f6",
+      "statement": "Managed MCP catalog fetches distinguish an authoritative empty array from failure: missing credentials, non-2xx, malformed/non-array data, and an all-invalid non-empty payload return `null`, protecting existing organization entries from accidental revocation.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/managed-mcp-remote.test.ts#L81-L150",
+          "version": "repo-lines-v1:sha256:2e5194d4ec0965c48c097f19c8e016cb9759f91ac8cc3aae91e7a12a88c09bb0:eyJzZWxlY3RlZExpbmVDb3VudCI6NzAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRlOTEwODZjNWM5ZjZiZWYyOWY1YTA5YjVlODJhZTIxMTM0MzllNDgwNjg3MDk5YTVlZjExMTE4MTc0NWZmZWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU2ZDM5MjQzNjdhMzUxYjU5OGU5NmJiZTZkOGE5NDljYzE2NGZkNmU3NDFiOGI4NDkzZTkzY2EwOWJiZGU5OGEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ4NDUxYjhjODc0MjRmZjA0NDM3MDVjNGMwYzZlMjg5YjE2MjgxYWJkYjc3N2MyZTBiZTE0MTBiMjIzMjE5NDkifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/managed-mcp-remote.ts#L117-L187",
+          "version": "repo-lines-v1:sha256:999ab08b80c2c8dfb8b6888a6fec737465d92a7e3ed6d4c5a410517b44e983d1:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQyNzliNjgwNTIwZWQ1MjZkY2M0YzhhYTM3MzUyNzU5MGUyODE5NWU0MGZiZTYxMDdlMWU1YjQ5NWE0NTc3MzUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7761e9f031f0436ab57d88eb9447b930",
+      "statement": "Claude Desktop maps only valid HTTP or SSE catalog entries, validates structured OAuth essentials while preserving unknown OAuth fields, supplies a default issuer only for a structured configuration without a usable issuer, and reconciles CodeMie-owned entries without deleting unrelated user entries.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L302-L388",
+          "version": "repo-lines-v1:sha256:da096142b8054386e4765dd72452c4ecff76a565e4ed04bf922a17c9c6c58457:eyJzZWxlY3RlZExpbmVDb3VudCI6ODcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijc5ZjQyNmJkMjczMzhlMWQ3NTg5ZDJiNDFlNzg2MmJkN2M0MTg4NDhiMDI5NmE1NzRhYmJmYjk2OGE3NTlhODQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhOGM2MDMzYjk1MmI5MGI0ZmFmMDk3MGQzMDk4MWE4MDk2NmM1NzJlYWZhNGE1NTQyYmNiYjEzMGY0NGNjOTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQ0NmY0NzIxZDdmNGIzMTMzYzM0NGVhZDc5MzNkOGVhMmIwMmEwZmFlMWE4OWJkZjU4YzE2ZWIwNTk5ZTk3ZjciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L591-L681",
+          "version": "repo-lines-v1:sha256:80dd4f2fecff23ec133b3200f9b3a2f164feb7168418ff1e56c47c8c9be779a7:eyJzZWxlY3RlZExpbmVDb3VudCI6OTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQzYTU2MmE2MDI3ZDkyZmUyZjg4YmRlOTU4ZTlkOGU1ZGUyOWY5NjUyNTNjZGIyY2ExYTVhMTQwNWIzMmM0NzUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZjYzk2OTA1ZWE4N2ViMzMxMGZiNzY5OWQ0Y2E0MGUzOWE0NmUyY2JkOThmZDQxN2NkNzYyNjJkM2E2MjJlYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE1NTRjMzU4MTYwYTFlNzY0ZjM3OTkyMzYyYzk3NTcxM2Y2ZmUxNWQ4OTcyNzYxZjBlNDdkYmE2MzYyMjAzMTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjYyMDJlMTE4MWViMjJkZjQyZTNjZjZmNGYzMWFkOTY5ZDMyNWFmZWVlNDQyYWU0MjUyYjlmMTkzYzgyNzg3OTgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/managed-mcp-remote.ts#L11-L18",
+          "version": "repo-lines-v1:sha256:c5b12c302b2cb0c92baf14bfae0f44bf81bd1273a5ce371d401ca8ee1481cada:eyJzZWxlY3RlZExpbmVDb3VudCI6OCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiOTcyYTQyOTM4MmIyZTE0NzE4ZTBlMzdiMDU3MGE4YTE3MDI5OTFmY2Q4NDk4Y2Q4NDA2MGE4YmY0ZjA1MDE3YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYzYzNWFmNjJkNGQxMzM3ZWJiMzIyNDg2ZjVmY2NhNTgwNjlhYmEzZTBmMjQwNmRmODQ5ZDkyNGJiZWZmYmE0ZCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiYzUyZmNjNDYwZDhkYTcxYjUwMzYzYTgxNWU2M2E5OWY4MjQ3YzkwZjg1MGFmNmQ5OWNkYWE3MmZmMzQ5YmYzZCJ9"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/managed-mcp-remote.ts#L55-L114",
+          "version": "repo-lines-v1:sha256:f0d191da4f98af626feaa07a270b7ed1e9419d79fcf7ca0d2a1312d412aa5619:eyJzZWxlY3RlZExpbmVDb3VudCI6NjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYyYzc3ZGRjMzcyNGM2OWFjNTZiNzJkMjQ5NjIxMzc3Y2ExZmIyZWQ1OTgxOWY5OGQxNTcwNmU4ODA5NTkzNWYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBkM2EzMzg4ZDRhNTMyYTQ5M2M1NGY5OGY0MWMwOTJmMjhhZjliMmNmMDFjYjU3YjU4MzIyNjhjMzA2NDZkOTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b2baef8f0dbe4d2985b5e14b009528fa",
+      "statement": "The Claude Desktop managed-MCP marker uses atomic write-ahead ownership state: after a successful catalog fetch it records old-plus-new names before writing config and narrows to the durable set afterward; after a failed fetch it preserves prior organization entries and marker state.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L649-L681",
+          "version": "repo-lines-v1:sha256:678fdd984792d885cacdff7082e73c0e22708fb21b93920f238c4b03ca2b818e:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY2NzFjOGE2YTMzNWRkMTQ3N2NlODlhM2E2ODY2YTI3ZDBjMjFmMzQ3YjkyYzQ1NDM2NTBiZmNjMjc1ODY5MGMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZjYzk2OTA1ZWE4N2ViMzMxMGZiNzY5OWQ0Y2E0MGUzOWE0NmUyY2JkOThmZDQxN2NkNzYyNjJkM2E2MjJlYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjYyMDJlMTE4MWViMjJkZjQyZTNjZjZmNGYzMWFkOTY5ZDMyNWFmZWVlNDQyYWU0MjUyYjlmMTkzYzgyNzg3OTgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L815-L861",
+          "version": "repo-lines-v1:sha256:381245461f4a6f303d48b4babf1ca0381ef7a3cc65d07e47c6a14b9ad8f67146:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ3ZDRhY2JmZTQyOTQ4MzkyZDQyMzNhMGJlYmQyNTBjZmVkODJiMTg2NGUwNGMyYWU1ZGYxMjZlZTMzZjVkZTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjcyYWNlYTYzNmFhNGVkM2I2MDMxZTRjZmM2YTZiNzZkYjkyMTAwODUxNTM2ZGYxZjIxNzZlNmY0MzBjNWJjMDYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmNTQ2NGIxMzRlYTdmMDYzOWM2Y2ZhMjExZGExMTIyZWY1Njk4ZjdlZWYzNmNmYTE1OTQ2YjkyNmRlZGIzZDIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/desktop.ts#L921-L926",
+          "version": "repo-lines-v1:sha256:87893694fa8b5a393119be27a934c3a5a8f32f778badb6e1ccef4f99658e367d:eyJzZWxlY3RlZExpbmVDb3VudCI6NiwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNGJiNTI4ZjAzNzA1OWI1MmI0MzcyNzYyNjViNjhlMjBjMDdiZjk4YzdlOTg1MWI5MDYxZjM3ODc0ZDlmNjNhYyIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNjhiOTQ1NDAxMGIxNjZhM2IyZDBhN2JlZjQ0MzZhYzg5OTIyOWVkYWVlZTBhNzI1ODEwMjMzMzg3MTIzNjk5NiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiYTU3MjdkNWE5OGQ1MzE3YTc0YmQxOWY3YmQyMzQ2MjM4ODQ2OWFiNDliODZlZGFlYzQ1ZGY2NTdiMDljNGFmNiJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_5cbb712e8ee34e6fba2cca20af657325",
+      "statement": "The VS Code BYOK connector reconciles one CodeMie custom-endpoint provider, preserves other providers, settings, and an existing secret reference, uses atomic writes, and fails rather than overwriting invalid JSON; the Claude Code extension connector similarly preserves unrelated settings while upserting its two managed Anthropic environment variables.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/vscode-claude-code.ts#L79-L173",
+          "version": "repo-lines-v1:sha256:2e027e4a9118f776e262be2bff10d4972fb0ac2e86104687866c1a021460eb75:eyJzZWxlY3RlZExpbmVDb3VudCI6OTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA1MzBkMDg0ZDhlNGI2ZDYwY2M2MGVmMTRmMzM2OWZmZDExMjkxMmUxMTk2ZjBlMjAwZDgyYmMwYjZhNWRlNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIxOThjMWY4MjhjZDlkZjg0NDRmZmYwNmM2MGM1MjdiMzU4YjU5ZDk5ZDExNDM2NmI4NGU5NGRhYjJjY2E2NzMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/vscode.ts#L107-L170",
+          "version": "repo-lines-v1:sha256:2a16f2c1d9229ff19457b44608b179619b1b87aa6ec76467a59c47abda1fa9f4:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg3ZWFlZTU5YjdhYzk2MmRhODIwMjdiZGM1NjNjM2YzNzE4MjA2MTdlODVmMGE2NmI4OGY4OWZjYjFkYTgzOWEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyYTJjYjI1YTEyMmI0NDIyMWE2MjM0ZWM2NjBhN2I1ZmI3ZjliZGU3YjNiOWUyYjNjNTU5YTBkOTZmYWM3MzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5MTE2ZmUxNmQzMDk4YjcwNjVkNzAyNWI4Nzk4NDMzNjE5Y2M5ODY5YWQ1ZWZjMGI1Mjk5MTFkYzBlMGNkNWYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM0MDJkNDNlNjU2MTNmOWM0NjgxYzFkYzgyZjAwODk5MGIzNzNiZmMzNThlNjcyYzIzNzJkYjg2NzFlYmVkOWIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/vscode.ts#L173-L267",
+          "version": "repo-lines-v1:sha256:6c5ea0776f63568743160b3df27676ec5500b2f9c7a1b54c90ed1ca83c729192:eyJzZWxlY3RlZExpbmVDb3VudCI6OTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRjMWVjMDNkM2FkYThmNjQ5ZWQ1NDRmZDZiNWQzM2NjNzZkYmY3MWJjMTk0ZmE3OTYwOWE1ODRkOGI1OWMzNDEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIxNzk5YzY1OTg4NDEyZGU3MDYzMWQ5MDg1ZjM2NjA1NzYzNjZiN2QzNzhiOWY2M2QxMDRhNzE3YWEyOTAzYWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkyMDQwZTA5NWE5NGUyYWRhNzRlNDIxZjM3MTg3NTFhOTFhODEwYmZkNjZmNDhmNGU5MzljN2I3NDgwZWI2NzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_edcae8c5987144b79f5f566f77b0f2af",
+      "statement": "The Codex Desktop connector validates and surgically splices sentinel-delimited CodeMie regions into the shared Codex TOML configuration, records ownership before writing, preserves a pre-connect backup, and disconnects by removing only managed regions with backup restoration or an error when safe removal cannot be established.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/codex-config-toml.ts#L1-L13",
+          "version": "repo-lines-v1:sha256:d6e8f23d7905b0f20e94b1cc73c63b2136bd365556d6c64b30b9cacc2694888a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ5OWNlYmIzNDI0MTE0NDFlN2JmNjZiZjIwZDY5NDdjYzIyYmM1NmRmNDQ4YzRlMzRmMTk1MmI4YzRkNGI1MDgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjUzOTM4OThkOTA4OThiNWI2MDc4Nzg2NTZjODcxYjU0M2I5NDVlMWE5ZDY2MmZjZjM5ODQ3ZDFmMDI1NDZkNGUifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/codex-config-toml.ts#L187-L255",
+          "version": "repo-lines-v1:sha256:fe136fc24f9015b4306c245638fdfc6fa419f9060032a0dd70a7ed02c4fed6c0:eyJzZWxlY3RlZExpbmVDb3VudCI6NjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjkxYTQyNTg0ZDI0NjYxODg0NDJmMWQ1NzNhMjA5Njc0YzgxYWY3YzNkY2Y0OWEzNTA2Y2YwYjVjZGQ2MjgxMTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQzYmVkYjUzOWFhMWY2ZmYxYzViODRkZWQ4ODkyMDZlYmMyNDYwN2ZhZDFhYThlOGMzNDVhZmVmOTFjMzI2Y2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/codex-desktop.ts#L1-L8",
+          "version": "repo-lines-v1:sha256:632cbe75f6dcd5a57023f131167492c555b9ee01815d46541c46321b1f488d6b:eyJzZWxlY3RlZExpbmVDb3VudCI6OCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiOTcyYTQyOTM4MmIyZTE0NzE4ZTBlMzdiMDU3MGE4YTE3MDI5OTFmY2Q4NDk4Y2Q4NDA2MGE4YmY0ZjA1MDE3YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjAsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiYmMzNzA5MzdkMjE3ODIzNGExMjgwNTgwZWYwNGIzYTNiNDQ2NWU4MzE1MjY0YTgwOTU0MjA2OWUyOGZhNTg4YyJ9"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/codex-desktop.ts#L231-L301",
+          "version": "repo-lines-v1:sha256:08179dacfb5b852143f6f5e88f2427fbdaf32a7c4e767d112e03c56e5ae74f14:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZhYzEyNzZmMGEwZjE1ZTNkNjY0N2EzNjU4ODhhMWY2Y2EyZmZmNzI5ZWMzNmI3MmViOWM5Njg5ODIyNmI2NGYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/codex-desktop.ts#L328-L396",
+          "version": "repo-lines-v1:sha256:979b6cf766104a6f8959acedbc1335b3a009a168d8eba72304f9aa921ee93d14:eyJzZWxlY3RlZExpbmVDb3VudCI6NjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjlmMjA5NTE5NDA4ZGZjOGMxNDdjYzMzMmVlODYyOWNhMzVmYmIzNGFjNGM2NjdjMzg4ZTk2M2I4NGM2NDJlMzQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImRkZjgzZDc4ODNmZDA1ZDkwNWI0NjA1ZGJjNTlhMDVmOTI2ZDgxOTBmMjJlZDIxMGM0MzVlOGQ2NGNiNWZlMjQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_69f12aea56044c4299d6082f45cda2ac",
+      "statement": "The repository has focused unit coverage for the relay's lazy routing, cookie wrapper, and idempotent shutdown; OAuth callback/provider lifecycle; managed catalog validation; and Codex configuration connect/disconnect round trips.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop-roundtrip.test.ts#L65-L117",
+          "version": "repo-lines-v1:sha256:ac3b1182d64c37555f15d8e00f88abb53b8653e2e757a97e4c2c5316c59915d7:eyJzZWxlY3RlZExpbmVDb3VudCI6NTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEwNTJmZGJkMjQ0NWFjYmIwZjRhY2ZiMjI4MGRlZTI4NzVhNTE0NjExMDZlNDVhOWQ3NmY4ZDc4MmY5NjBjZDIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImRiNWJhNWI4MzUwNjg5NmNlYTY4M2MwODUzZGQ3NzNhNDY5NTRiN2FkMzhlMzQ2MGYwMzEzZTkwZWE1Yjc5ZDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/managed-mcp-remote.test.ts#L17-L240",
+          "version": "repo-lines-v1:sha256:b353fbb4f164c73690098ea675dbd82cd23059169e1ff1de668ea4aa0808b50f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjI0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjZDFlMDk5YTg0MDM4MDU2OGJiMDYyNmJlOTYxYzNjODg1ZjRiOTA0NjZjOGQxNTNiODZhNWUxMTE2OTllMjQ2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzZDBiZjJhYzIxNzQ3MzczNDcxOGQwMjFkNGI0OTRiMWQyODdkYThmNzE0ZTYwZTI0MDU2MTBiNTkxZjY4MGMyIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJjMDhhNDk4NWQ2YmI2ZjBhZGJhZjdiYjkxNDA3NGFkZjk4MGU2N2U0ZTZkYjVjYzRlZmI2ZDFiYjdhMDdjYWUyIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZWUxMDcxYjc2ZGNjZjZkMTMxODY4ODRlNTU4YjUxZjZjMDg5YjBkNjhlMTA2MTM2MDlmMjAyMmMwYzA5MDA3In0"
+        },
+        {
+          "resource": "repo://src/mcp/__tests__/mcp-auth.test.ts#L44-L303",
+          "version": "repo-lines-v1:sha256:5cc1b9b7f237b5dd1999fe551c433b6912ecc6a69c0a4025f95c7f1130597aa7:eyJzZWxlY3RlZExpbmVDb3VudCI6MjYwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIwY2Q5OGFmYTlkY2MxOTRhYTE4MzUyNGIyNzNiZWNkY2Q3ZGRhYTg1YzE1YzM3ZmE5ODcyNDEzZGQ5YzIxMjBhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhYTEyNzc5ZDFmYmZjYzJjMDRjMDI3ZDJmZjA4ZmY0ZmMyN2ExOGVmODM1NDRiOTQxZjRlMDg5ZWEzMGYyOGM0IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        },
+        {
+          "resource": "repo://src/mcp/__tests__/mcp-bridge-logger.test.ts#L230-L458",
+          "version": "repo-lines-v1:sha256:d7561f2eddb67b0e940c2365f18181d1c31962dea869f7fcf92551a6fdf2f198:eyJzZWxlY3RlZExpbmVDb3VudCI6MjI5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJiZTg0ZWM3MWEzNzg2YTk3MjdlZjMyODA1MTEwMmJmNWE3M2I0N2VmZmVlZjNiN2RmMmFkMjM2NmU5ZjUyYzA1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlMWMyMDY1ZjEyOWFiOGE0MDZiMzkyMWUyNDdjYzFkMGU4MjU2OWM3NWJjZDgyNDA5NzUzODAzN2EwMTZkZWIwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/integrations/provider-plugins-and-local-proxy.json
+++ b/openwiki/.claims/integrations/provider-plugins-and-local-proxy.json
@@ -1,0 +1,292 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:e0ac50f22efd158b702bb61d1380a6108a1d219f6a34942cedb607e272426e99",
+  "claims": [
+    {
+      "id": "claim_8ffba014ebe147a58e1d079f309c2e94",
+      "statement": "Provider templates declare identity, connectivity, authentication, model recommendations, capabilities, optional environment export, and agent lifecycle hooks; the capability vocabulary includes streaming, tools, vision, embeddings, model management, function calling, JSON mode, and SSO authentication.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/types.ts#L10-L22",
+          "version": "repo-lines-v1:sha256:e8b847cf8bc5e33bbab32155e6386a12cbb9b36b6f2364f072b31f20963ce97b:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ5ZmNiYTE4MTQxNjQ1M2QzMGM4ZjU3OTE4MjgzNWRlYmJjYzlkMmU1NjgxYWJjMjE0YTc5MzBmYjc3YTNkNTgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNlMzE5OGUyYjZmZWZjZmI0MzYwNGU5ZTI5NDM1OTBkNDRjNjI1MWU4YjQwOTgzOTU3ZTVhNWY5ODM1MjIxY2MiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ2MGE1ZDY1MzMzMjQxYzU3MmE5Yjc0ODU3YzcyNTcwMjgwMTk0ZDNlMTNjODJlOWFkZGY1YWM4MmJmYWRmNjQifQ"
+        },
+        {
+          "resource": "repo://src/providers/core/types.ts#L65-L140",
+          "version": "repo-lines-v1:sha256:3469fdad5fc631e290d0b26a60918089f09ec41d70e52a716ee789bb964836b3:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyZmU5MTdmMzU1YTRjYTZiY2U5NWYxNmJmNDZmODZiYTcwMDE3MjkyYWU1ODdkMWZlYjEzNDA1MjVhZmQ5NjkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjM2ODczNWI0YWNiNWY5MTljMTA3OGVmMmJjNGZjM2I2Mzc2ZDQ1YTBmOWNlZTg0NDAzNTI4MGQzMzNkYWYyZmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_c9c40df9118c40b9a13652e7b9126254",
+      "statement": "Importing the providers module triggers built-in provider auto-registration, while ProviderRegistry separately stores templates, health checks, model fetchers, and setup steps; health checks and model fetchers are selected by their supports predicate and setup steps by provider name.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/core/registry.ts#L19-L123",
+          "version": "repo-lines-v1:sha256:2f159c8592298817aff69f9f37af32b4a2387e74b8f40e6c9437ca5d63b36dab:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4ZDZkMmYzZGFlZWIwMmVlMmE4MjYxNWRkYWMzZjE4MGQ4Yzk3MzEyOGUyYjc1NThhOTYyZTFjOTZlZmJhNDFlIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2M2JmNjhiMGZiZDQ0MzIzODZlNjlkYTExMWZlOTUxZTQ0MTRlNjliNThhOWIwMjk4MGYzNTI1ZGU0OWZjNjZkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/providers/index.ts#L1-L49",
+          "version": "repo-lines-v1:sha256:f1d31651d1652143dd8e3016ef32f3c612678ccda13b6109f33c7f7350eb855e:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE3MGI4N2JiNjhmZGMzMDAwZGY2YTRmOWRkYWM2MzZkODQwMTNmZmNhNzhkM2VhOTNiM2RlN2I2N2NjZDhjNTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d4e3d22fe6464b8cb18e9b100e7a7676",
+      "statement": "Built-in templates cover SSO, JWT bearer authorization, Ollama, LiteLLM, Bedrock, and native Anthropic and Moonshot subscription providers, with declared authentication and capability differences that drive integration behavior.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/anthropic-subscription/anthropic-subscription.template.ts#L15-L32",
+          "version": "repo-lines-v1:sha256:a4fe7edcf194070eb53340ef0b9253bc61b11a035a09c1c1bfa509b6f07c515c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM0ZmI4NWI3MjkyZGU1MjEyZTY3YmJiZTBhMjcxM2M2OTIyMDdlOGNmYzU1OGZmZjQ5NDU3NmMwOWQ0ZGUzNzIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIzZDEzZjE5MmQ1OWE1ZjNjMGUzMWM5NDgzYmI0M2RjYzVhMWVlYTE4NmM3YTcwYTYwNzhmZTE4YTRiZjdiOTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM2NTdmYTFiZjM2ODY3NTYyMzZjZGU5YTVmYmUwMDVlMDBiMzlkM2Y5ZDAzNjk0MDA5MjI2NTM3M2RlYjkwZjIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTc3MThhOThjM2I1NmEzYmMyMTg2ZDVkZTVmYjljYWQ1MGM1MjJjNjYzNDYxM2NiZWI5Njk3NzVjZmI0OTEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/bedrock/bedrock.template.ts#L13-L28",
+          "version": "repo-lines-v1:sha256:f136bf8f26179f35fc79a286877df3dc9fa51af976b31b1f90fd706e6712e483:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY4ODNkZjA5NDcxODYyNWYyNjFmZTc5ODM2N2QxN2NmZTM0NTMxNmJmYTNmNTE2YTdmZDExN2E0NGQwOTFkZmMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIzZDEzZjE5MmQ1OWE1ZjNjMGUzMWM5NDgzYmI0M2RjYzVhMWVlYTE4NmM3YTcwYTYwNzhmZTE4YTRiZjdiOTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3NTJlMTk1Zjk5MTRhMzEwNjQ1OWY2OWI4N2Q1MzFmMmMwOWRmNTA1ZTJiZGExZDFmZGNmZDVkY2YwMWZjM2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjYWI5MTcyZjdhNTBjZWE2YmQwNmE3ZTRjOTNmZTBiZGM0YTI0MDFmOTUzYzU2NWE4ZjlmNWU3MDI5MTMyMzEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/jwt/jwt.template.ts#L17-L40",
+          "version": "repo-lines-v1:sha256:a42d23b29eafcfb702b252d223b5eca2e9c38e149f5b133fc84114680d934b87:eyJzZWxlY3RlZExpbmVDb3VudCI6MjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU3ODQ2YzFlNDIzMzE3Njg4OGM0MjY5ZmI0NzM5MTE0NWI1NGFjYzAxOGI1NjhjM2RiYzFjYTVmZWM3NjEzN2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzZmEyNmQyYWM2OWEyYzFmNmRiNGQ5ZTUyMjcyZDQ4NjMzMTgwMDlhZTY1ZjU0NWYzNjlhYzBhMzY2YjU1NzgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY3ZTRkY2EzZjA2YjU4MzFlMTNiNTE5MjA0NzgwYjYxN2U2NjJiZDM4MGNmMzc1MDIzMTk0N2E1OGVjNTlkNTEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjYWI5MTcyZjdhNTBjZWE2YmQwNmE3ZTRjOTNmZTBiZGM0YTI0MDFmOTUzYzU2NWE4ZjlmNWU3MDI5MTMyMzEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/litellm/litellm.template.ts#L13-L27",
+          "version": "repo-lines-v1:sha256:aa9f7df9a6af4caa420451fa94515b97f6c639d218c6b3a852b8ee663bc73033:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUyMjk0NjQ4Mjc4MmU4MmM0MzUzYjM3ZDY3NjAyYzU2NDk4YWJlOTcwZWRlYmQ0NjU1MTBjMGRkYTFhNWRjZDAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIzZDEzZjE5MmQ1OWE1ZjNjMGUzMWM5NDgzYmI0M2RjYzVhMWVlYTE4NmM3YTcwYTYwNzhmZTE4YTRiZjdiOTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3NTJlMTk1Zjk5MTRhMzEwNjQ1OWY2OWI4N2Q1MzFmMmMwOWRmNTA1ZTJiZGExZDFmZGNmZDVkY2YwMWZjM2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImE4Nzg3NTZiZjljNzA3ZDlkZTEyNjA3NGUyMzIyOTI1ZWJiODA5MGZlNmRhNTcxY2YyNTQwZGYwNDk1NTY3YWEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts#L15-L27",
+          "version": "repo-lines-v1:sha256:edf55b5cc08ed6f92cc1277e8ba6779b023f6db07e4b36bbfb231919df118d41:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJjYTM0N2E0NTYxZmQ0Yzk4MjEwZTcwNmYwZTM2YjExZmNkZDJiNzIyMDQyMWI3NzQzNGYwOTk5OTdiMzdhZWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImIzZDEzZjE5MmQ1OWE1ZjNjMGUzMWM5NDgzYmI0M2RjYzVhMWVlYTE4NmM3YTcwYTYwNzhmZTE4YTRiZjdiOTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM2NTdmYTFiZjM2ODY3NTYyMzZjZGU5YTVmYmUwMDVlMDBiMzlkM2Y5ZDAzNjk0MDA5MjI2NTM3M2RlYjkwZjIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTc3MThhOThjM2I1NmEzYmMyMTg2ZDVkZTVmYjljYWQ1MGM1MjJjNjYzNDYxM2NiZWI5Njk3NzVjZmI0OTEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/ollama/ollama.template.ts#L13-L31",
+          "version": "repo-lines-v1:sha256:d074ffffa630dec5c5928a81224e43096b06730f89d3f847903ca2735ae40440:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImExMWZkMjM2YmIyNjUxZjE0YTA3ODczNWU2YjI5NmFkZWMzMjUyMzdjMDU1NzcyZjNlOTljMTcwNDI2ODg0YzkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJkZDRkMjBhNGEzYmQ5ZDkwMzc0NDEyOWI3NjM4MmNhZWJkZGQ5OGI2ZjY3YTdlMzM0ZjA2MGYwYzc5MDY2YmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3NTJlMTk1Zjk5MTRhMzEwNjQ1OWY2OWI4N2Q1MzFmMmMwOWRmNTA1ZTJiZGExZDFmZGNmZDVkY2YwMWZjM2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQzZTdjMGVjYjM5NzNhN2Y3YWMzOTBiZTY5ZTlkZGEwZDcxOTIzNTA3MjkwZGYzNzEzMDJhODI1MDU5YjNmY2QifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/sso.template.ts#L17-L35",
+          "version": "repo-lines-v1:sha256:4f6d354df773a925fab2087da53805f8fee93a97689df43cf278ea84e9523c0b:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM3ZGZjYzJmZDQzZDk0MDVkZDRjMmQzOWIwYTMwZDhkZjNjM2VkMmMzN2VjZjI3MDU3OTczZmJjNjJmZDMyYjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg4ZWI1YTNjMTBmNjEwMDg0NjU2MGVjZTJlMzU1OWI1MWM3Y2FjYWFlMTMwMzljNDQ2MTg3N2M0MTNjZDNiZWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjYWI5MTcyZjdhNTBjZWE2YmQwNmE3ZTRjOTNmZTBiZGM0YTI0MDFmOTUzYzU2NWE4ZjlmNWU3MDI5MTMyMzEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3e11492368b441a6ae2d541cf2e22a5a",
+      "statement": "Browser SSO opens an ephemeral local callback flow, persists successful cookies and API URL with expiry derived from the access-token JWT exp claim or a 24-hour fallback, and retrieves URL-scoped credentials only when fallback credentials match the requested origin; expired credentials are cleared.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/sso.auth.ts#L174-L205",
+          "version": "repo-lines-v1:sha256:1194655a25d7af90f9b9ce4d4dad89b3f42108cf0920304412ce2980fcddc85a:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRkMzNjODY4YmQ5ZmVmM2YzYzBjZDE3NmRjNWIyYzFjMzgwY2YzMWRiYzUwZjg2NzY5NDNhN2RjNzhlYmIzNGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBmNTFkMDI1MTlmYzU0MzgzZjE4Nzc1MmVkOWFhNDRjNDc0MzA5OGQzMjE2OGVhOWEyNDQ5Y2Y1YTBkODc0NmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImU0Y2Q5ODgzN2YyNzU3ODE1OWEwMGM2NGI0ZTMwNmYwMWZkMDE3NjlkNTFiZGIwZTM1NGE2ZGQ5NTJiMTlmZTIifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/sso.auth.ts#L313-L383",
+          "version": "repo-lines-v1:sha256:155c628714e0aaee7d861491630a0775755a903296f2486e89b1b0221bc18dee:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE2NTg4ZDk2ZWJhYzNjZjY3Yzk1YTk1YTc4ZmI5MGNiNzdlZTU0OWY1ZDgxMjgxYWIzNzJkMWEzNWM0NTNjYTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFlMzU2NzhkZDEzMTRlMTNiMjAwNTZhZjI0OWM2OTc0NDZiNzA5OTMwZjliOTdhOTJjNTlhYjUyYWJlMDFjZDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAwMzlhY2E3YWQ0YjVkODAzOTdhNjFmMTIzYWQzY2U5ZGIzMmY5NjY5NzBkNTQ1NmMxNjZjZjMyNTFhZjI5NGUifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/sso.auth.ts#L40-L62",
+          "version": "repo-lines-v1:sha256:66d209f23f76d18830b35545554a92a0d51a8d3129f007c9f52f8e64e1ce86fc:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJiOWE5MDIyZjIyZmU1ZDhlMzBlMTcxZGFjY2ZiNTc5ZTdhNjgxYTFlNzZiMWNkNWUxYTljNTdhM2UxYTEyZDMifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/sso.auth.ts#L79-L164",
+          "version": "repo-lines-v1:sha256:c683c65131d3ee88446e11857d16868104b6a0a80689cad23d4dc4bd29f51adb:eyJzZWxlY3RlZExpbmVDb3VudCI6ODYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE1NGM2MjViMWRiOTA3MmVjNGRlMjBmZjI5OGM0NjZkY2ZhNTQ4YjRiNjZlOWYyNGZmZDE5YzBlNTkxYTYxOTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQyZDJmMTFmMWZkMTU4MTViMWY0MGVlZjRhM2NjMTY5ZGZjMTgwZmE5NzYxMDJlYTdlN2UzN2QzY2FmNzNjZmMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_79847e94be8a4ea6b5e8240c05a50c28",
+      "statement": "CredentialStore owns secure SSO credential persistence, preferring the system keychain and falling back to machine-specific AES-256-CBC encrypted file storage.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/security.ts#L256-L287",
+          "version": "repo-lines-v1:sha256:0b2e9f4878a125f62bc832c76f6e95813fd7214d19b743ba8d21bcce53ca9647:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhMzI0MmIxZjNlMWY1OGJlNjBhMGViN2ZmMDk1OTc4YmQ5Y2JkYWYzODdkZWFjZTkzNGRiZDA2MmUxZGEzZjMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI1YjExYmZiMGYwYTA4MTU5NTdkMjgzY2U0MGNmNjNlOWVlOGFjYjBmNTE3YmI4ZDg2YjAyNjY5NThjMTUzNTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjlhZjdlNjk5NmRiMDk0OTRmZDg1YjcyMTRmZmM1NDc4NjM1NzIxYjcyMGFhYTk4ZmIwNjYxNzk0NDNiZGViNjYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9e45f5610e1c4241afb8673c1f34b375",
+      "statement": "On startup, CodeMieProxy chooses JWT credentials from explicit configuration, environment, or credential storage and otherwise loads stored SSO credentials only for an SSO provider; it throws AuthenticationError when required credentials are absent and initializes interceptors before binding the local server.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L51-L124",
+          "version": "repo-lines-v1:sha256:0b593fd0c29fcbf2e215b773b5314f8fcdbac81164cb0c35048e20f937d39ca5:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ1NGI1OTI2M2JjMjcyNmEyMTI0MWIxMDRiY2IwMzNiY2QzNjEzMTM2YzdhMTUxZTI5YjAwNTRlMjc4NzBkODgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVlNzM1NGZkNGIzN2Y5YmVkMmZjZTExYmIzOTJiNmE0YmYyYWZkNzRmZDc3MmIzOGE5OTUxZGU1M2MxOWNkNmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk4MzU2Yjk2NmU5NGQzOWRkOTJlNTNkNTBmYTliZjQ0MTY1OTcxNjkxZGVmZjY1NWE1NTAwZmRiNmQ2MGI0ZWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImU4ODQ0M2JmYTM4YmIyNjMyYmU5MjhmNDI1YTNkZTQwNzI1YjRhODM5ODQyN2U3N2ZlODlhNmQyZDhjNGUzNjQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_fc6d9a5aeb204dd48b55568519d215eb",
+      "statement": "BaseAgentAdapter bypasses the local proxy for providers with authType none even when a stale JWT environment value exists; otherwise proxy-capable agents use it for SSO providers or JWT authentication and receive the local URL plus a proxy-handled API-key placeholder.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L1020-L1040",
+          "version": "repo-lines-v1:sha256:e8cbd49cc589643e3f11acfbf2915df360159f98b4d81933eb28daf91b911eb6:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxNDE3ZDQ2ZjlkMTI3NDdmZDBmMjA3NTJjZDdiNDU4NjdkZjZjYzkyZjE3NWVhOTZkNjYyNmM5MDYwYjNkNjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjlkYmZkNWM0NGIxMTI2NGNiZmZhYjgyZmFlNGRlZWNiZjljNzZkMDU1MDNlNDJiYWE1OTMyYzg0NzcxNjAxODgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L941-L960",
+          "version": "repo-lines-v1:sha256:c5969db2929e64f3cc903eb7aeea62d6168ce64dae1a2be1ab75deeb5b204400:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkZDNkNTMxYzQyMDFlNjk3ZmE5ZWQ2MzQ3YzhhZjI2YTNhYmYwNjQzZTJiYjFiOTNlYzNlNTE2ZWZhNTUyNTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJiM2MzYmI2Mzk1ZjQ3NGE4MGFiMjJhNGM1ODFlOGJkZDZjNjQ3YmRlYzEzZGM3OGU5MDBmYWQ3YzY4MmFhY2IiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImJhMGQxODhjOTdkYTY4NzYwMjM5MWZiNmExZTk3Mzk4MzliMmMxMjllYjQ3Mjg3YmZkZDUyOTA0YTNlMGFlZGEifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-routing-guard.test.ts#L1-L15",
+          "version": "repo-lines-v1:sha256:65e9f88627d38e64286aeb1b157be58028e5162a2979a74437c81b400540fd25:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYyM2NiNGMxM2Q2Nzc1OWQ1NGY3NjcxZDQ0MDM0OTcyZDA5MDNhMzlkMDhhZmFlNzNiYjk4MWViOWFiMGRjZjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI2OTdhN2JmM2RhY2E4ZDYwZGZjYThjZjEwYzNhMWM3OTI3NjBjN2U2NDQzNTZiM2RmMjQzNTgwZTkzOTA2NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_dac5d9aed5be4f2eb22bf5f293fa0944",
+      "statement": "The proxy exposes pre-auth /health and /healthz liveness responses, invokes start hooks only after the final port is known, and on stop runs stop hooks, closes persistent connections, closes the server, and destroys HTTP agents.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L172-L223",
+          "version": "repo-lines-v1:sha256:924a187e8f38789639d996deda47bde80248b543bd37e31d6a3559af6a8522c5:eyJzZWxlY3RlZExpbmVDb3VudCI6NTIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJhZmE3OTc3OGFkOTZmMmI4M2QzMDY3YzA1Njc4YmNmYTVhNzJiNWVlOTU5N2E0N2JiMTRlODJlYzFiMTk2OTAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjhmZmMxNWI1Y2ZlM2FmYWVjZDI0MTQ5MWNlNmEzZWJhNGMxOTQzZGM0Yjc4NjJjMDkyZWU0M2VhMTU3NmMxN2YiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZjM2EzYzFiMjRjY2Q5NDVlZWI1NDA3OTM2OGNjNGQ4OWQ4YmE2MTgyZDY0MGExNmZiNmE2NDBlZTNjY2M5OTYifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L238-L256",
+          "version": "repo-lines-v1:sha256:25e95450b1e8bc1581d86d1556f4ef46d7008b2dcd47a4dcda5469d2e846f29c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImM2MTdmZGYwZmY3ODQxM2JjNjQ3NGRjN2I2MGJiZTNlNDI4YmQ1MmJjNmQ0YWQ2NTg1YmY4N2MxNjdlNDJjZWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJlOTZlYWYzNGIzM2EzMzg0NzJmMmQ2NTBlMGY2N2E4Mzk4ODM4ZDU4OTQ4YWViNThhZmI2NzliNGMxY2UzYTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM1MjhjY2FmNWFmYzFmZTZkYzc3NDgzMzg4OTEwMjY0ZTAyZTFmZmYyNGM2OWIyMzZmZjM3NmRmOTcwZjcwNzYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_60bc265bbabb4384acd8f93a3a73ec6b",
+      "statement": "The detached proxy daemon binds 127.0.0.1, persists startup state, and pins a previously bound port on restart; a pinned port retries EADDRINUSE up to five times rather than changing the stable desktop gateway URL.",
+      "evidence": [
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L73-L140",
+          "version": "repo-lines-v1:sha256:801bdf2adc81fa62bcc00e623b48a9aadadf63ae49ef08a6d5d0a265dfde592c:eyJzZWxlY3RlZExpbmVDb3VudCI6NjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZlNWUzMTlmYjE4YTgxNTVmNTUyMzBkYTcyODM1Y2NiM2MxYWE3Yzg5YmIwNjM2YTg2MzAwMmViNGU5ODhiNTciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ3MDQyODFlNTI4OTY2NDg1NDAxMjdjNjZiMjJlODQ2YzNjYzg0YTUxMGNiZGNiYTk5NmNmMDY4MGYyNTEzNTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjZhNWI3MmJjM2Y2MTgyOTc5MzJjNzRjYjVkMWEwMDhhYzZkYWIyZWM0MmNjYTk5OGViZTc3YTRlNjdkYmU4YTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFlMGRiMGIyZTQyYjMzZDAyNzQ5OTQzMmVmN2MzYTI3YzQwZDE5ODljZjI4YjRlZTI1ZjA5ZDdmMTM1NTU4YTQifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L145-L193",
+          "version": "repo-lines-v1:sha256:e4a14f85368f123ad5499b12f6bc4e7ca6900686d364287b70b213abe1d164b8:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBiNWY5NDc3NzFlMjA0ODdjODEwOGZhMDg4YTE3MzU5YjhhMjg3ZGI5NzYyNDU2MGFhMzA3M2FlNTgwOWE2NTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxN2FmMTEwMWM5N2I3YzJmNTI1NDA3ODJlNjM0Y2M0NDQwZjBlOTcwMzQxZTUyZjk3NTIzMTFkNzhiN2Q3ZDAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFlMzU2NzhkZDEzMTRlMTNiMjAwNTZhZjI0OWM2OTc0NDZiNzA5OTMwZjliOTdhOTJjNTlhYjUyYWJlMDFjZDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVlMTJiNjExODk0M2UzMGMwMDY4MzNlNzgxNjMwYTUzYjMyZjQxN2VmNWY5Nzk1YzNmMTJmMzMwODAyNGM1ZDkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_1e2bcdfa7ea74c20b9a0006ce2312ade",
+      "statement": "Proxy plugins are initialized in ascending priority and expose request, custom-handler, upstream-response, headers, chunk, completion, error, and proxy lifecycle hooks; a custom handler that returns true bypasses the entire normal pipeline and owns security for that traffic.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/registry.ts#L35-L81",
+          "version": "repo-lines-v1:sha256:6dff2e6b1ce0a8bbb44409b845a90b09d10292d0e5d11d0491e7ec1d3640af29:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjkyNmVkNzE2YzA3MjZmMmE4MzA0ODc5ODNhY2ZmZDgzNTk5MmQ2MWM5YWZiMmRmNTRjYzg1Y2Q4NDQzNjcxNmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRjZTE3N2E1MjY0NDRkZmEzY2I3MjEwMTM0MWZiMTUzNWI3NjQzZjljMzBiYzU2NDA1YWQyNzI3MDQyMWRiMjciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/types.ts#L66-L131",
+          "version": "repo-lines-v1:sha256:9b8119fff0b06bc069ce03de43876c1db56c975e1c66b0444c8e7e69db6fb8c2:eyJzZWxlY3RlZExpbmVDb3VudCI6NjYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFlYjY2M2Y2YmE0MDAwMGEwNDQ0YTI1Yjk2MmM2NTA2ZWFhNTgwMDEyYzRiMDU3ZjVhYmRjYThjODFhNjQyZjEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM5YjkzMjEwN2RkMzZlMjNjOGJmNjIzMjJiODU5OTJhNzJiZWM5ZDMwYzA5OTE4M2IyN2M2NDgyMjEwODc3NDkifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L258-L360",
+          "version": "repo-lines-v1:sha256:8f31832d9bd1aac0f11c94313862ccd2704dec8975b706f6e19914cda9032db3:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIxMWRmODdhNDczMTZjNzA4YzU1MDIwOThlOWFmNmM0NDUzNGViODBiZWFkY2Y2MDYzMDI4ZWZjYTg1OTM3YWJlIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4MWEyYTdiNTc3ODYxMjc0NzUyZWYyNTA2MWMzNjIxNzJiMjVhYTQxN2M3ODYyZDAwOTY2M2ExODg2OGUzNTVmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2YTQxZDczYzQ1MjJiZWEzOWZmODE1ZTI0YmNmMTMxMTg1MzFkNjcxZWIzY2Y1MzEyMTg4NWUxMWExYzQ3MjRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjNjkwMGQ2MDEzYWFhMmNhM2QxMDZjYTUzZTUyODY2NjhjYmU1ZmZkODg3NTQ5M2FhYjkzMzUxODI4ODYwNjc1In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_4d2ac256f0b04b8ab06f32054aaab422",
+      "statement": "The normal proxy path reads mutable request bodies as Buffers, removes host and connection headers, forwards to an upstream stream, runs response hooks, streams chunks through optional transforms, and runs completion hooks after the downstream stream; response buffering is available only through explicit upstream-response hook tools.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/types.ts#L84-L102",
+          "version": "repo-lines-v1:sha256:e0072cf46d873c48179772a62461be559d8608778fa6ac11c1c9d7ab09dcf989:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI3MGVhYmJiNzQxNDhhNDI2OTRjOTVmYmI5NDNkYzE5YWFkNmFkZmQ1ZGZjYjc2Y2I4OWIwYjU4NTJiOWZmNjkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVjNzY0YzFlNzYzNzk5ZDhkMGRmNzMzOTRjODY0YWRiNTc5Zjk3ZjgyNmQ0YWJlOGVhOWMzODQ0NTc5NWEyMTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjA0OTRkZWFmNzA4YTFlMzQ4ZTU3MjFmN2UzODlmNTM4YzBmMDliMTQ2NjhiYjM3NGJkMWMxMGQ3MzNmNmE2YTcifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/proxy-http-client.ts#L282-L424",
+          "version": "repo-lines-v1:sha256:741d96d81bd5bea52e411a340b269e671bbb63e59b94f20c9b4621753b082906:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyNWNlN2FjYmU1M2E0MWU4MzBlMGVmODgwYWViZDNiZmFmNDYzMjczYzA5MzExYzQwOGJkOWE4YmEwMmZjNGRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L375-L438",
+          "version": "repo-lines-v1:sha256:4117b2b0c695f9e7fee7d429201b8e59df2c154f42d6443862bf8b0bbc4195cc:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImM3YmIwZmZhMjU0ZDk0MWE4MjIzOGIyYTI2Mzg2ZTdiMWIyMjYwMTUyYWUwYWI0NDNhNzM5NWQ0MzQ5YjQ5NGIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZmMDI2ZDQ0MmJhYzdiZmE5MmFkNjE1MTEyZjVmZjEwOTk3MTE0MGFmODBkZWIyNmY1ZTIxZjE0N2VlNTQ3MDUifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L440-L610",
+          "version": "repo-lines-v1:sha256:25e9955e572e0c2bd233c45e83d25e2355a6c82ff38d5674e9bb19b158e7c866:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcxLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1ZTEyYjYxMTg5NDNlMzBjMDA2ODMzZTc4MTYzMGE1M2IzMmY0MTdlZjVmOTc5NWMzZjEyZjMzMDgwMjRjNWQ5IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI5ZWJhMzgyMWQ4N2U3MzJmMzUwMTE0YzRkYzBiYWRhNzExYmU0ZDgwMjdmYWNlNmRhMTRhZjAzMDg0NTdmOGY1In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_01d6b73255e946f289ae6c90161a9a1e",
+      "statement": "Core interceptor ordering places MCP auth routing before endpoint blocking, gateway-key validation, mutually exclusive SSO/JWT injection, client normalizers and sanitizer, header injection, logging, and session sync; gateway-key validation strips the local authorization header before upstream auth is injected.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/gateway-key.plugin.ts#L14-L80",
+          "version": "repo-lines-v1:sha256:1a4572088f2c2b5784cde70f00f9c6b83bddd119e16657d102116e1a06b7c808:eyJzZWxlY3RlZExpbmVDb3VudCI6NjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk5Y2Q0ODdiMjM1YjU1MmZmYjVkNmY3YjUwNTdmM2M4NzcyYWE5ZTlkMzM2MmViMzlhNmU3MjAwNGQ1YzU3OTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI5NzhlMjUwM2I4Y2YzN2EwNmY3ZDZmMGEzYTZiNmZlMzU2OTFmYmNhYjUwYjg3NzVjYWI2ZmFiYzcxYzU5MmIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg0N2JhNmM2MmE1Y2Q4ZWVhNzY3OWVjOWZkNTRlOGIzZTRjZjEwMzUxYWNjYmNlYmVhNzY3NWFiNjFmMDdkY2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjczNWI1NmY2MmI3Njg2YTBkOGZhZjgzNjQyYzY3NTFhNDc2ZmY0YzQ3Y2UxMmQ2MDJhZDg5YjE4ZGVlNGVmNzgifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/index.ts#L29-L51",
+          "version": "repo-lines-v1:sha256:a2b50f1f6cbed44bc3071f349ef44da9c3610a7f479d4e4e68032569c6d6199d:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRjNGI0NDBlNTUyZDgyMWFiYjBhNTEwNDkwZDE3ZmYwZjFiMmNhZjI2OWJhYzdkZWE4Mjk0NGQ1ZTg1M2NlMmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg2YTQ1ZjhkMTk2NjJkNjQ3NTZkYTk5OGZlNmI5NmQ5ODA0MDdkMDg3MGU1NWM4OWUzNTY2YjY2MjMyYTUxOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI0MDMxYTY2YWQxZWFhM2Q3NTUwMmFkZDM4ZGYwMjc2ZjIxMjE4NTMzZjc1MDc5NjI2OWE3NWIzNzQyMmJjNzMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjMTM0MWJjNjE1NDc0OTU5NzhmYTI2ZmUwMDQ4YjM2NzA2NDc4MzViNzRjNzUxYjQ4MzBiZWRhNWExY2M0YjQifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/jwt-auth.plugin.ts#L20-L58",
+          "version": "repo-lines-v1:sha256:312b3549e932312ca9964d1b188b71efc8378b965b9a5b31cd2f65ddc4d45c2e:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVlZjM5ODgyMzk0NGNlZDZjYWRlNjU1MzJmMWYwYWQyNTkzNWRmNGEyNTgzMzkyYjE1MTMxMjBjMmU2YjNjMTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE1YmY1YWZhZTk1OGU1ZjgzMGU1NGNjZTY4MThjODFmMmVhY2U4N2FjYjJlNzRlZDEwN2QzOWQ4OGNmZTFhNjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/sso-auth.plugin.ts#L21-L92",
+          "version": "repo-lines-v1:sha256:ffa04a667eb1c8b08e9a8b60562c511216f2c9ca6a5f23c8900ae3690d28bee5:eyJzZWxlY3RlZExpbmVDb3VudCI6NzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVlZjM5ODgyMzk0NGNlZDZjYWRlNjU1MzJmMWYwYWQyNTkzNWRmNGEyNTgzMzkyYjE1MTMxMjBjMmU2YjNjMTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE1YmY1YWZhZTk1OGU1ZjgzMGU1NGNjZTY4MThjODFmMmVhY2U4N2FjYjJlNzRlZDEwN2QzOWQ4OGNmZTFhNjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7870102889044b9e96d57532abf2fc3b",
+      "statement": "For codemie-code and codemie-opencode, request sanitization removes unsupported reasoning fields from chat-completions requests but preserves reasoning.effort on Responses requests while removing summary variants, reserializing the body and correcting content-length when it changes.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts#L34-L118",
+          "version": "repo-lines-v1:sha256:35b370855ba2604a40f14e7d5e8f4a758723c5e3f544386e676aebbf9d68913b:eyJzZWxlY3RlZExpbmVDb3VudCI6ODUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE2YTA1MmNiNmM2ODY1YTBjMWJhZjQ2NzhmYzRjNzZlMDE1N2QwZWZmN2QwYWQ4OTVjNDVjMmM5ZWE1N2MwNDQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjMyODM1NmY5YzJhZjgzNTQ2MDJiYWJhZmUzYjZjNzVlYzAxZjRkOWQ2MTU2Y2FkNTNmYTMzOWVmZTcxNDBiMWQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-normalizer-body-contract.test.ts#L138-L193",
+          "version": "repo-lines-v1:sha256:3e0f164bd31d2ac39fbb180849886bf88dd0959f803dbde62b81503fddc9a75b:eyJzZWxlY3RlZExpbmVDb3VudCI6NTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNjNDAzODJmMGEwMWVkZTYwYzYxZjllNWVmN2FkYmZkNjI4OTQ1M2QwMTY3MzMzNmZkM2E2MjBmZTMwODllNDgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY1ZjdjNjE4OWRmOGY1NDJmNDg3NGJlMGQzZDRjOWNjZGFjYWMyYjUxODJjM2UwMmFmMWQwMDZhZmFmOWRmNWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMwZmQyNDdkZmQ3NTVkODZkMGFlYzBiMDM1ZjhmYTYzNGY4OGRhM2VlOTM0YTY1NGFkZDNhMDUwNmY2YjJhYTYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_99a190e16aef4506b634de4d68d487ca",
+      "statement": "Session synchronization is an optional SSO-only lifecycle plugin requiring session ID, client type, and SSO credentials; environment configuration overrides profile configuration, sync runs on a guarded periodic timer and final shutdown, and an explicit sync URL takes precedence over the bound local proxy URL.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts#L185-L273",
+          "version": "repo-lines-v1:sha256:dbb8d14ed4b452440f000119691536870d9762233ac4e6288cb929938ac9d2fb:eyJzZWxlY3RlZExpbmVDb3VudCI6ODksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFkYjNlN2NkMGMzYTYyMzA0NzY2ODE2MWQxMDRlOTlkODYyMDljYTNlNzc1NGEyNWIxMTlhNDkwNzg3ODA0MjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts#L37-L123",
+          "version": "repo-lines-v1:sha256:9b7c6f00d476bfaad6ac0900ebcbfc7dd7826a5f9895dc77c1ed9cd675dc3e87:eyJzZWxlY3RlZExpbmVDb3VudCI6ODcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVlZjM5ODgyMzk0NGNlZDZjYWRlNjU1MzJmMWYwYWQyNTkzNWRmNGEyNTgzMzkyYjE1MTMxMjBjMmU2YjNjMTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkNWQyN2IzZGIxZGI2N2JkNWJjYzE3ODczNjYwYzUyNWM4YjRhZDBjNDU4ZjA2ODM2Njk0MDRlMjdlZWIxMTEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ3N2MyODQ3MDljNjQ1ZGY4NzZhZWIyNDVmMjcyODc5YjQzYjUyNTI1MjAwMjRlNGRkNTM1ZDBmMTMyODUzNTgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d5067727f6f94941a212056b105d7545",
+      "statement": "Proxy error handling treats client aborts as normal disconnects, invokes error interceptors for other failures, returns normalized JSON errors before headers are sent or destroys an already-started response, and logs NetworkError and TimeoutError at debug level.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L612-L699",
+          "version": "repo-lines-v1:sha256:c82a1197d80bba383e22d7088f5a0544283512f6c546b8ef245a9ee65c59e872:eyJzZWxlY3RlZExpbmVDb3VudCI6ODgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY1OTgxZjkzYmUwMDBmNWZjZWNkZmZiNzUyMmI1N2YyOTY3MzUzMTVkNWQ1MDBmMDdlYjdjNDBhZWFkZWU3MDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4NTg0ZDFjYzA1MmE0MjQwNDYyZGZmMjExNzlkNjQ1ZjAzYTQxMTE3OWZjZmU5ZTRmNmQzZjVkZGM2ZGUxYzMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7478255094aa411ead8bcbf917961b66",
+      "statement": "sanitizeLogArgs sanitizes sensitive strings and object values before logging, and the gateway-key interceptor uses it for configured keys and incoming authorization values.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/gateway-key.plugin.ts#L14-L77",
+          "version": "repo-lines-v1:sha256:23de228a29ab6c15613b8a9333adc372b5e92526b9f9fdbbd94b5f52bd558f23:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk5Y2Q0ODdiMjM1YjU1MmZmYjVkNmY3YjUwNTdmM2M4NzcyYWE5ZTlkMzM2MmViMzlhNmU3MjAwNGQ1YzU3OTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgxMDU2MDRlN2EyNWUyYWRmZDQ1MTZiY2UyODg1NzFlMTlkNjQzYTMxMTJjYjlkNzI5NGFhNzJkNjk4YjE5NWMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg0N2JhNmM2MmE1Y2Q4ZWVhNzY3OWVjOWZkNTRlOGIzZTRjZjEwMzUxYWNjYmNlYmVhNzY3NWFiNjFmMDdkY2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjY5N2IzYjM3YjliODU1NzllNTc3ZmNlYmViMTg5Nzk2MDgzYzhlMzAwYjQ1YzNkYjMyNmYwMWRkM2VkOTY4OGMifQ"
+        },
+        {
+          "resource": "repo://src/utils/security.ts#L231-L250",
+          "version": "repo-lines-v1:sha256:e7e3f6dcae26acff59960bd34aa36909b48f1b7ee945f1eb8476285ebce0c032:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA0NTNiMmZiMDZmNTQ2ODdiZjAwN2YyODI4MDA5MjljZWRkYjE3NmU4N2FkYzJjNmZkNjdkMWU5NDViNzFjMDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM2M2UyMTk5ZjQxM2UwNmI3YTE3ODg2OTQwN2Y4NTIwNjA5NTg5N2ZmODUyNmJmMGViZDk4OTA5ODE1NWE1M2MifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_e9043c21d5ff488b9872800d2eb30530",
+      "statement": "Integration tests exercise the full forwarded-body normalization contract and real detached daemon lifecycle, including pre-auth health and state cleanup.",
+      "evidence": [
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L1-L43",
+          "version": "repo-lines-v1:sha256:23880afdaa87b5c7634631b96bb2f9ac77e7236b44907784df591eb92d3484a8:eyJzZWxlY3RlZExpbmVDb3VudCI6NDMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjU4ODZmNmU3YTJlNDExZTg1ZjU2ZjQxMzU1NDI5OTA4YTc1MDVkMTQwYTg4MTFiNzJjOWU1YTBjZjIwYjQzYzUifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L139-L187",
+          "version": "repo-lines-v1:sha256:2e645135a9120a5652e525d403791e81ca48ae22501ef936f3c5d0d191555747:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY0NzlmMTA4ZmM4NTcwNzQ5NTQ1YWFhMWNjZjM2ZjAzOTE5NGExYzQ0YWQ0ZmI2Y2E1YzRjOTEyYTAwODU3ZjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZkZjI0ZmM2OTg5NTNlZDgwMGY2NGYxODU3MzBkMGNhNGQ3Zjk4MGRiMTdmMDYyNWM5OWYzZDU1NDZjMjQ5NDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-normalizer-body-contract.test.ts#L1-L28",
+          "version": "repo-lines-v1:sha256:ef48e04495513989c272bd79438b9e4b2559df5bb2fdf1bfc5bf64d1259bb4c7:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgxYTY0NDljY2IyMjYyY2RmZTJiNTM3NmQyZTc3MGU3ZGQ2N2UxOTc1ODQyNWYwN2ViYWFjOWVmYzhiOGJmZGYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg5ZWVjZjhiOGU2ZjZhM2JmZmRjNjU0MGU1YTk0OTg5MDdiZjRmNzQzZWRkMmZjOGRhZDFiZWI4ZTJhZDk5N2YifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/operations/daemon-migrations-and-diagnostics.json
+++ b/openwiki/.claims/operations/daemon-migrations-and-diagnostics.json
@@ -1,0 +1,272 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:2852da00bfbfdfc33575bfb12aa17db6f82e066e98cf5f046970bca7fbd8f2f9",
+  "claims": [
+    {
+      "id": "claim_0612474b3e6742dd968be7e4a43dcd52",
+      "statement": "The `codemie` executable wrapper runs pending migrations before loading the compiled CLI, warns rather than blocking when migration execution throws, skips update checks in test environments, and treats failure to import the actual CLI as fatal.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie.js#L8-L40",
+          "version": "repo-lines-v1:sha256:375c05263af73a07f093330cb0e53d9af124185474a57a841e1a0fd432483170:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQzMTVjZWU0ZDczZGJmNjA2ODhhNDNhNzdhZmQ1NGIxMTczYzdmYTc5Njg2ZDZhNzZkYmY3ZDk4ZmYzZDJjYmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3Yzc1OTk5NjkwZWIzODAzNGFkNmE3YzIwZTY3M2ZiYzczM2YwOWZjYWZmOWI3NzZjZGQ5MzM1MTU2YWZlMTQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bc2022184f394295bc63be300d66d318",
+      "statement": "Migration modules self-register through the public migration index, and the registry returns all registered migrations sorted by ID for predictable execution order.",
+      "evidence": [
+        {
+          "resource": "repo://src/migrations/index.ts#L18-L31",
+          "version": "repo-lines-v1:sha256:097529b63ee1353180ecc6df054aa4978117f827397a3c9cd73e60122ff8c01d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFhZWJhZGZhYjkzMjQzYzIzNjViMzRhNzhiYWQ5MjFjOWRjZDNmZmIwZDU5MmY1OGZkYTZjMzg3ZTFlZjBiY2YiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM1NGUwMGViMWExYmNjM2IzZGQwYWE2N2UyZDBjYTVjMTY1NGIyMWVmZjAwNzk4MTE4OWNiOTNmODIxMWNlZDkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjNThhMWNjNWEyZThlMDliYzAwODZmNWNhY2Y0YzM1ODQ5YjgyNmVjZDM2NjhkMTQ5MmI0ZjRlZWVmZGYzMWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/migrations/registry.ts#L7-L24",
+          "version": "repo-lines-v1:sha256:c4608132e057a2e05ef1cbcc91eda884676a8c35ba61a765178711e260c26d83:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhNmI5YTUzZThmZTUyMGVmZmZmY2NmMGVmODcxYzgwZWFjZTM0ODRhMDcwYWJmMzllNTkwMzk4Zjc0NjQ1NGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJmNzAwNTRlYTQ0ZjczMjQxMzVkMTcyZjY3NDJlZDM0NTFmMGQ4YmQ1YzI4MWExNGNlYTdlZTYwMzVmMmYxMTEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVmY2U1Y2Y2M2NmZDU2OTIyZDE5OGIyNzEwNGJhZTA4NDdmYzg5NWM5OGM4ZjI5MzljNDFkMzNkODFjNDZjM2UifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_aba785c9974b4131a1f82abb70e3028b",
+      "statement": "Migration history is stored at `getCodemiePath('migrations.json')`; absent or invalid history is treated as empty, and pending selection excludes only IDs with a successful history record.",
+      "evidence": [
+        {
+          "resource": "repo://src/migrations/tracker.ts#L12-L32",
+          "version": "repo-lines-v1:sha256:8e4bd58ea1c763b2256a8c7419bed07c83e6296d7b460ae7158b642d8589d0eb:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRjNDhmZGExZTQ1MDhiZDg3ZGNiZmRlMTkxNTI1YTE3NmI0MDUyYzc5ODRhYmNjZjRiNzYyZjM1MWJhZDZiYWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjViMDExZmI2MzY3MjdiYzBlZmY4NDNhZDhkOWFmMTgwZGUwMDEwNjljOTY0ZWYxY2UzY2FhMzYwNjUzMmM3NDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/migrations/tracker.ts#L48-L54",
+          "version": "repo-lines-v1:sha256:d2728112b7b5876387a2ade3ac5959e5bfce07aff1c9213f4e2f35db983307bb:eyJzZWxlY3RlZExpbmVDb3VudCI6NywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNGYyYTJmOTk2ZjA4ZTY4MGJkMjkyMTM1YTZmYTQ5NzhiZGEyNmU2MDJkODRmMzNjYjFkNTk0Nzc1ZDQzMDRiNSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNmU2MGI3NzJlNzM0MjgzOWI3YTIxYWE3M2JlNzViYmJkOTBhMGRiMjQyZTViZDkzMzJkZTFhZGRjOTc0NDI4MSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiYzdhZmY5NjYzMzQzNTQwYjJkNzZhZWNjYWEwODI5ZTdlMWI0MmY0ZTM5OGJkYTRmNjc3MGJhNmVkOGJlNDcwNyJ9"
+        },
+        {
+          "resource": "repo://src/migrations/tracker.ts#L80-L98",
+          "version": "repo-lines-v1:sha256:edca4a9139fdb837f540f4251d280107f1e1f45f28d2d0db184386f1fc3f232c:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkNjJhYThjN2ZjZWYwYmQ2YTVlYTE1MmM5NjY2MDdkODJjZjc4NDRhZDdlMTU3MmYyYzJjMmE1YjU0Y2RlMDIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjhhZjcxZDYxY2JiODhkODdiMDdmNjM3ZDI1NjRiNTc3MGE4MTBlNmZkMWQzZTI4MjM4NWI5YTA2NTNmNmI0MjgifQ"
+        },
+        {
+          "resource": "repo://src/utils/paths.ts#L338-L375",
+          "version": "repo-lines-v1:sha256:395bcae02872c756ae7df3038d9097bf66c0de7f0a7f95a2d259bcf26029044d:eyJzZWxlY3RlZExpbmVDb3VudCI6MzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI5MjQwNWQ4NWY1ODE4MTg2MTgwMWUxNTRmNzYzMjNlNzBlYTllMTlhOGY0NzE5Mjk4MGUyYzlmNjNiNDRlYTAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNmN2NkYTAwYTUxMDE3YzRjODVmYTIyOTU5NzUyYmY0Yzk3YzE3ZDdhZmQ4NGQ1YzFkOWJkYzg3MWJhZDkwNmUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJmNDlkY2M4YzkwMmFmZWJiMjA1NWZhZjIwZTk2MzhmNGI0NjEzN2U3MThjZDllMmJlZGM2YTE0NjZmNmE2NDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ0ZDM3Y2I2NTgxNGM1N2E3Yzg2YTVkYTMxMWJmZTU2MTY5NjYyYTdiYzRmMWZhYmZjN2EwYTM3OTllYjU4NDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bce26ca4c97d4a02bbc95f4bcbf57908",
+      "statement": "The migration runner records both applied and successful no-op migrations, does not record failed or thrown migrations so they remain retryable, and continues processing later pending migrations after an individual failure.",
+      "evidence": [
+        {
+          "resource": "repo://src/migrations/__tests__/migration-runner-ordering.test.ts#L188-L267",
+          "version": "repo-lines-v1:sha256:8bd044a2486ff13f08af0e00be32af1f064200866861ad988b01b86e1942c520:eyJzZWxlY3RlZExpbmVDb3VudCI6ODAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3Y2MxZTViMTZmNTE0MDQ1MjlkMGZlNGU0YmU3NWJjYjkxNmI1ZmQyMGY1OThjYmIyNGNmNTBhYjY3MjM2NTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ4YWJmYTYyM2JkZGFjZGFkZjk2MjllZGQ2YmZhNTA5NGRlNjc0MmZjMGRlMTAxMmU2ZDk0NjY1OWY5NGEwMDQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ5ZTU2N2EzNWUxYTRiZDczZDA2OTMyMjQ2MjI2NjU5ZWVkNjNlNTU2NzBmMDU4OTg1ZTI1Mzc3Njg3OGRhOTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI3NzlkMTE4ZDZlM2NiZjQ1MDUzOTc0OGRlZTdhNDMwN2FjYmU2NDQ2Y2JhMjk3ZjI3NjBmYTVkMGJiYTFiYzIifQ"
+        },
+        {
+          "resource": "repo://src/migrations/runner.ts#L42-L104",
+          "version": "repo-lines-v1:sha256:afbf647db2d15e1bf36772c648f9fa0fa75d79c2f6356da37d1964e6148eb254:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY4MTdhZmNlMTdhMDM1MTlhMTNjYzUyNTMxMmM4OTdkNTlhOTUyNTc2NzY1YTA0OWM4YjNjYTI4MzVlZDhjYTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYxY2ZhZjVkMmFmNTVlZDQ0ODNkYzA5NTNiZjA3Mzc2MzQ3NWQ1MTRmNjE0NDFkMzZjMmI4MWQ5NjQwYjIxZGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg2NmQ3ZWIxNWI3ODExNjcxMjYwZjUyYjhhZGY5MjMxYzUwMjhjMWE4MzIyOTRjOGFlMmYzNmNlOTQxNzBiMDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImExZTA4NWEwZGVlNjVhZTE3YjdjNjVjYjI0ZDdlNzlkZWFjYjc4OTA5MzFhMDUyZjI5ZWQxZGY1MzU4OTJlMmYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d1849db1e7d44302a888671104da8896",
+      "statement": "Migration dry runs execute pending migration logic without recording history, leaving migrations pending for a subsequent real run.",
+      "evidence": [
+        {
+          "resource": "repo://src/migrations/__tests__/migration-runner-ordering.test.ts#L204-L213",
+          "version": "repo-lines-v1:sha256:3f0acf22745ac9a30fca83eb380641371c07f80c9503c7c54b6a3b49f20e839e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg2YzA2YTBjZWEyODA2ZThjNTBiZmEzZmIyNGJkNDJkZmVjOWEzNDE4ZjJmNWE4MDZiOGI4YjJmYzc3OTkwMDUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ5ZTU2N2EzNWUxYTRiZDczZDA2OTMyMjQ2MjI2NjU5ZWVkNjNlNTU2NzBmMDU4OTg1ZTI1Mzc3Njg3OGRhOTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjlmOTZjOTA1NzA2MTBlMGI1ZmFhZGYxYTBlNDRmOWViZWNmMzlkN2M5NWQ5NWNiNTQ2NWI0ZTU0MmQ3ZDIxN2QifQ"
+        },
+        {
+          "resource": "repo://src/migrations/runner.ts#L50-L75",
+          "version": "repo-lines-v1:sha256:ffa2c4095533c636abc004c07fb2e35d8622bfb195888e66b95e992df229f7b5:eyJzZWxlY3RlZExpbmVDb3VudCI6MjYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY5YTdlNjUwNDc0YWVmNGU5Zjg1MDI0MGY5MzgzMzkwNzNiMWRjOTQxNTg2OTI0NmM5YWM5NmQ3ODdkZDY0ZDEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg4MDA1ZDU3MTA2YTM2MmViMDAwZGFmM2RhNDY3NGM4MmI1MThmZjVhMmUyZjY3ZWU4ZTc1N2EzMzNjMmFmNjYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI0NmUzMWY1YzVhODY1OTZmNGE1ZWZkZTg1ZTIyZDU4ZGExYWM5NGI1OWFlNDRhNDgyMmI1OTA1YjU4NDBmYWEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFhYzkxN2RjMTNiMWM2ZjU5Mjk0ZDZkZDg3OTJhMmFiOGU4MWY2MmZmNmY4ZDNhZjIyZjMxMzA4M2ZlNTViNDgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_af1668958e2447a3ab2fe401ce1ebe9a",
+      "statement": "The proxy daemon entrypoint validates required target URL and state-file arguments, binds the local proxy to `127.0.0.1`, persists its state atomically after startup, and removes state while attempting to stop watcher, telemetry, and proxy on SIGTERM or SIGINT.",
+      "evidence": [
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L130-L177",
+          "version": "repo-lines-v1:sha256:5ed6d5c6017b395f07a775c8b5afe528d50c740bbe2059763c526d1b712cfc33:eyJzZWxlY3RlZExpbmVDb3VudCI6NDgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFkMDIzYTI0MGZhMzRkNDk4NGJmOTAxZGMyNGIyZDczMTEyMmQxODIzMzg3YzYzNjRmODkwNGQ4ZDM4MjgyYzgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkMGYyZDNhM2FhZGEyNzU4NjQ1NzhkMGE0MzkxNTYzOGQ1NDNmZWNhMmM5NDg1OGRiOTQxMjExZTg2Y2VmMmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkyNzU0ODU4YmRlMmU0MjA1NmU4ZDY4ZTExM2FmMzEwZDkyZmUwN2RmZDVjZjQwNjgwNGM0ZDRlN2NlMDBlNzgifQ"
+        },
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L30-L90",
+          "version": "repo-lines-v1:sha256:5f7c311e459d13c16a41e32b477f2f658c6d2f5a464b1c732aa1a51e48f8b925:eyJzZWxlY3RlZExpbmVDb3VudCI6NjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZlZTQ0YzhmZWU1ZTcxNDNmMTU4NjI3MGZmMWFmMDc0NzQ0Y2QxOWFiODJlNDQ0MGE5MGE0YzM1OGUzYWRhZWQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFhMWQxYTYzMzkwMjI5Yzc5ODM0N2U4M2EwNDA1NDQxYzk0MDAwMzUyODRhZDE2OGMxYmY2Y2RmMWQ3MGEzNzAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImZhOWE2ZmQ4ODAxOTAxYzRhYWMxOTJkZjI5YjJkNGJjZTA4YmRiYzA4MWZiY2NlNzNlNmZlNGZlZjE1NTg3MmYifQ"
+        },
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L97-L109",
+          "version": "repo-lines-v1:sha256:6a29de0a935bf8102a01539cb39680a77ac000c30a049ffd456926e815c7a816:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjlhYTlhMGJjZjcwZmJmNGIxZDA1MGQ1Y2EzOTU4ZTNiYWQwMjk4NTlhZDJhYWEyYjRlYTdlNDk2NWM1ZmE5ZDAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJlYzhiYWRhNjQ0ODA5N2M5ZWVhNmJkMDI3NDNkYmEyNTczMjI5NjJiYjE2MmI4MjNlNGRhYmZhZjM5YjExN2IiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZkN2QwN2VkNmMxZjAwOTJjNDM0MTY1MWY1NGZlMjc1MmI1MTg2NDE4YmUzNDdjZDE2NTdmMGY3NDFmYzRiODMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_dca6d3ab17eb45988a90079f5f4bd195",
+      "statement": "Daemon-manager state is rooted in CodeMie home, validates liveness by PID rather than state-file presence, removes stale state, starts a detached wrapper and polls up to five seconds for ready state, and throws `ToolExecutionError` if readiness does not arrive.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L32-L81",
+          "version": "repo-lines-v1:sha256:fec19315bedfa03f6bc7e1a56f7c39ff9ea01470a6a0a16c286a63cac1e2a6aa:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU4YmRiMTNmOTllNjljYTdhMzVhNWEzNTAyNjA2Nzc5MmQxYTk1YzE3NjkyZGRmMjg5N2Y0NWFmMmRlMWZlNzMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ0OTQyOGQ5MGVkYTBhMGVmODA0ZmE5MjFmYjljYmI1MTYzMmJlMTNhOGQ4OGVjYTQ5OGEyYzg4M2YwMTBlODIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJhYWIyMWRjZDhjY2JiOTk1ZmViMzQ2N2U5OTdlOWI5ZjNhODRhOWM1YzAxODNhYTdhMTBmMWVhODJmOWVkNTYifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L96-L148",
+          "version": "repo-lines-v1:sha256:7ed7ff61b6bd0e87cceafc4af7ae22aa443832b24bb8e0f54d05941ee25d5d25:eyJzZWxlY3RlZExpbmVDb3VudCI6NTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNWQ1YTA4ZTRjOWEyYTEzYmUyNjEwODAzYjIwMDcxNzZkNzM4NWI4YzNiYjBhYWFjYWJhZjRiYzRmMGRlMGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk1ZWYwMWJjMDhkYmMzYjYzZTRlNzVlYTNkMjZhNWI5NDE4OTE4NzdlMjdhZDg5MTMyOWM4NDExZDdkOGRjNGQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3MWMzODQzMGMzMDk2NTMxZDlmYTg4ZGVkMTgwMzkzMTMwOTNmOTQ5N2NiM2E5ZDU0ZWEwNzI0OGZhOTk2YWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjExN2Y0NTU4ZTZmM2JmNjBhMzhiZjhkYmI5MjNkM2YzY2I0NTE0MDNmOTczOTEwZmZmNjMzOWRmOWRjN2NmODQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_21a143d8cd864bf1a5ee050035dc6661",
+      "statement": "Daemon shutdown first sends SIGTERM and waits up to five seconds, escalates to SIGKILL when necessary, and clears the state file even when forced termination prevents daemon-side cleanup.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/daemon-manager.ts#L151-L188",
+          "version": "repo-lines-v1:sha256:748e783db6ee836a71ce02ba8e1ff9ec9bda4b1d533f6290bd8ac9bd4af4c8b3:eyJzZWxlY3RlZExpbmVDb3VudCI6MzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYyOGE0OGM0NDY2MDU5YmE5NjQ2ZWMyODJkNjNiMDQ0ZTU5NDNkMjcwY2ExMmM5OGY2YzQyNWY0ODhiYWM2MWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5NGZjMGMxNzNkMWVjM2ZjNTAxZDdkZmE5Mjg1NTAxYzUyN2NmYjQ3MTI1ODNkYTNjYzM2MTgwNTY2YjRiZTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b151b0b5395b4b9d900b3bdb54988023",
+      "statement": "Proxy health checks never throw: shallow health probes local `/health` with a 1.5-second deadline, while deep health additionally performs authenticated model discovery with a six-second deadline and classifies failures as dead socket, unauthorized, or upstream error.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/__tests__/health-check.test.ts#L24-L163",
+          "version": "repo-lines-v1:sha256:6f17a9ea49cb7cc01beabd51c5d49f0cc82d6826f959ae1465d87de7abba2ea8:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhNWJhODVjMDgyNTdkOGY3YzZjNTIyYjFkN2E3OGY3YjZkZDQ1ZWVkYTBmMTk2ZmU1NWJhZjIzNGFiZDEyZmYxIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGY1OTRjMDM3NDFhYjEwNzY4MjU0ZWI0NGJmNTUwZWU0MDJjYWEwODBjYmJhNzFmNjYxZTZhNDUyNWQ3OWFhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlZTZiOWMyYzJjZmQwZjlhYzE4NTZlYmEwMGM2NzJhM2JiOWM3MWRlMDIwMTg1ZmQ3YzUxNjJjNjMzOGIxODA4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MiwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkODE3ZmJiNzNjOTJiMzZkNWU0ODk2ZmY1MWMxYjU4ZWVjMzMwYmJlOTYxYmEwNWZjNjIwNWY4NjdlYTFiY2Y2In0"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/health-check.ts#L1-L123",
+          "version": "repo-lines-v1:sha256:86350c4bd5aa31255b793ee247c7e64e8213d209b53675f3c95f194513849698:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MCwicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_147c0466fa12458eb89f3a873cd266e3",
+      "statement": "The in-daemon watcher deep-checks every 30 seconds without keeping the event loop alive, restarts recoverable failures in process on the pinned port with bounded exponential backoff, and persists unhealthy state then stops watching immediately for unauthorized sessions or after three failed recovery attempts.",
+      "evidence": [
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L111-L128",
+          "version": "repo-lines-v1:sha256:59276f0587afd969e01668c3687f1bf1b34103f4a08daca8cdc35bc396825a21:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEyMzRhYjkxYTY3OTU0ZDQ5MTkzYTVlOTFjZWE5MGQ4ZmYwYzVmNzBiZDE2NTkwNzIzOTNlOThjY2JhMGVlYzgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVkNmU3YWE0MWRjYTlmYjBkODI4NmQ3YzkyZDNlZTZlOTM0YTNkMzczNzAwNzFlYTgzMjFiZjZhMTdjMzkzNjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgzNTFlNWRkMjk2MTQ1YTYzNWRmYzE5OWI0N2MzODhiYzViY2VlMjg0YWIxMGM3OGI2ZGU3MDEyMzNjODVhYmQifQ"
+        },
+        {
+          "resource": "repo://src/bin/proxy-daemon.ts#L179-L200",
+          "version": "repo-lines-v1:sha256:c62cef8ed4c29466e2630da17be2b005abbf6a1007b2fd01bee34132424ae8b1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgwNDllZTE2MmFiZjk0OWMyYWFmMWI5MmM2YjUxYWZmY2NhY2JjMTI1YWNkZjVlMDVkYjVmMDA1ZjE3YzkzN2YiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRjZDkwODQ5MzY5OWUyZGQxNjQxY2Y3MjM2ODIzODgzNTljN2UzOTQ3YWQwYzQxNzU1M2Q0NTFlMDZlYzYwNmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjMxZTJiMDdmOTBjYmU0NDViOTY4ZDU5ZmE4NjhjNzI4NjhlNzMyYTViNjJhOTcwNjhlZmY2MjVlZTEyODA4N2UiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgwN2VlMThjYTlmYjRiODYyNjQ1OTJmOTU2MmQ5MGQwMzZkNTRjZWRkMGQ1NTY3ZGI2MDVkYmFlMTlkOWYxMWYifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/__tests__/watcher.test.ts#L49-L134",
+          "version": "repo-lines-v1:sha256:f8866c0841356556add30dc681c302c293a61aa877951511015b290c4561dcd9:eyJzZWxlY3RlZExpbmVDb3VudCI6ODYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMmZhYzg0NzFmYTdjNmM4ZmY2MDhhMWQ0MTBkZTJhMzgyODcxMzY0MWQ3NTc4ZmI5MjFjYTk5MGRlNzk5NzMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMwZTFkY2Q5MGVmNjI5ODhlYjBmOTAyYTlkODNmZDlhZWYxYjMzZTkyYTU0M2RiMzE5MjZmZmE2ODk2NDU0MzQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/watcher.ts#L30-L123",
+          "version": "repo-lines-v1:sha256:98a889760fcd0a44d67d144657a6607e77cedfe4d98cf7b4e70b61aefbb8764f:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQwMmIzNTRiYmY0ODhkZTBkYmMxNjM3YTcxYmQ4MWQ3MDZkNDJkMDJmNTZkZWM4MDE4Y2VkNTVhN2I4YjBlYWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc4ODI3NzI1YTNmMTViNmRkMGExN2YxN2M2OTk5YWZmZThhMmFjMmQ0ZmNhM2EzOGQ3MjhlZTBkYmIwODg4YjciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3b33d06fd9d04e11954c579d2bf0cb31",
+      "statement": "`proxy status` reports process state using shallow health by default or authenticated upstream health with `--deep`, supports JSON output, and can clear a stale watcher issue after a successful deep status check.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/index.ts#L191-L279",
+          "version": "repo-lines-v1:sha256:9c7d54092288f1ec934b2a1f05f628ea4615b9d4dfbcc357eebd0d6dee156590:eyJzZWxlY3RlZExpbmVDb3VudCI6ODksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEwNjE4ZTc3OTI3YzlmYjNjMzQ5NzZjNmQ5NmIwYjZmNWFjNGU5Mjc2ZTIxYzBmODEwODM2MzQ2NjI4YjRjZjIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjNhNGZmYTYyYzgwOWE4MjcwZjQ1Mzc2YTg4ZTZiYTg2MWU4ZjYwMTJkYjlhYTEyMTI3M2ExMWM3NjhlZTk5YTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjliMjA3Njc2MmFkNjE1MzUxMWQ0OTM1NzIwYmRkNGQzZTViZjM1MDc1MDc3NDE5ZjE1ZTZkYTZjNDAyZmQ5ODkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_09edc4453c774a3eb43d352b4ed40336",
+      "statement": "Automatic CLI updating is rate-limited by a home-directory timestamp, uses an exclusive lock to prevent concurrent installs, validates semantic versions, defaults to silent auto-update, and handles errors without blocking CLI startup.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/cli-updater.ts#L153-L193",
+          "version": "repo-lines-v1:sha256:8e12d554bb3ac0d02cf5afd0336c8a24f760f56e5db4d1a9a1edc8904f58b103:eyJzZWxlY3RlZExpbmVDb3VudCI6NDEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU1MWFiNWQyZDM4OWNjNjgzZTNjODM5Y2RiZjk0ZmMzNTQ0NzJjZDM2NWVlNTAxMzMzMmEzYWU0YjkxZDNjMTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjYTc3MDg5NGViMzE5MDVhNGU3MmJkNDdjODE5N2E0MTM3OWYzYTczMjgyZjNhZDdiYmZiOTFjZTRiNWJlNDMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/utils/cli-updater.ts#L23-L32",
+          "version": "repo-lines-v1:sha256:63130a3b83866a69333e5ce1ee54b7d4d9691eb47eab3b4c0e70af1af1d9dd8b:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI4ZGM0ODAzOTZlMjc1ZTYyNDQ3MmI0N2VkN2M2NTM2MjE1MDcxZGE5MTI3OWVlZDA1OWQ4N2QwNjM0NDUyZjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBiYjg5NGViMDQ2Yjk1MWUyNzMwNWRiOTM4NmMyMGM3OGFlZjJlMzdkNjkxMjQ3MmRjMTZhZmM2NzM3ZjA3ODMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjE1MDg4NTZmYTg4YTJkYTc5OThmMzAwYzAzYmQ2ZTZjM2Q4YjRiMWQzOTVkMzhhODdkODQ0YjMwNTBhYjJkMTUifQ"
+        },
+        {
+          "resource": "repo://src/utils/cli-updater.ts#L305-L386",
+          "version": "repo-lines-v1:sha256:fa618297b5ee40df1f8b1d8f1efd49ac280cec371c75f9ab8cb7050b6223839d:eyJzZWxlY3RlZExpbmVDb3VudCI6ODIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE1NDEyODE1NDc2NGRmMDA2MDMzNzY2MTZiMDQ2ZTg5MmQxOGMyMzYyMzlhNzUyMDdjYjExMzg4M2VjYWEwMWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgzMzczZTVlNmVmNTUwZTc3ODQ2OGZmMWNiYTBkZTNmYThhZDRiNDY3N2NkNGE0OGIxYTdiOWFkOWU4Mjk0ZTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/utils/cli-updater.ts#L52-L114",
+          "version": "repo-lines-v1:sha256:9a640162539eea95b2d8e753d024d0336ad07793d64ee17aefc09842b89d71fc:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc3NjI1Mjg4MjQxNGVmYzdmMjgzN2UyYTEzYjQ3YzkxNGIxZDExY2ExMTY3NmY5YmQxMGJiYmNhNzU3YTM2OGUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_a62af90624cb4f1798c22b3b3dbb7ef2",
+      "statement": "`codemie self-update --check` reports availability without installing, whereas the explicit update command reports check or installation failures and exits with status 1.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/self-update.ts#L11-L67",
+          "version": "repo-lines-v1:sha256:ff7ee09f3a921f0d05d12c9296a73686457a3ee9c3dbddccd5db40501e705e0b:eyJzZWxlY3RlZExpbmVDb3VudCI6NTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNmOWNmOTExMjQwZjNkY2M0YWE5NzM1NTg5ZTlmMjFmYmY2ODMzYjI5NjkwZGY4NWQ0NmY0ZWJkMzQyYzdiMWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxNmNjNzM4YjliMDFkMzM0YzcxNWI1MDZjOTBjYWU3MzI1MzJhNWI1MDIyYTk0OTU4NmRhNzQ1ZDg1YTI1NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFjNTEwODE0OTA4ZWIwNzc2NmIxMGU2YTJhMmJlNmJiYmE4ZjljMzc4MjgzZmRkM2ZlOGIxYWMxNTU3Zjk4MWEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_1e951de7bec44d1a9f565d9407fc6dfb",
+      "statement": "`codemie doctor` orchestrates standard environment, configuration, authentication, and integration checks, runs a provider-specific health check after configuration with a 15-second timeout, and `--verbose` enables debug output and shows the debug log location.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/doctor/checks/index.ts#L5-L14",
+          "version": "repo-lines-v1:sha256:d122f130496bae733122ee23c37f7b78f5ddaad8f46ff3a244e778b97b3ce0f9:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFlZTE2ZDY1MTQ1M2M3MzNlYzJlZjg3YTcyMGRjNGE4MDU0YTljZjVjZjE4OGVkOTMzNWQ0ZTY4NjA1NGI4Y2EiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBlMDlmMjk4MDI1OGJkNTQ0NzhiZWJjNzRjNzgwMTRkYjFmZWI2NTBjY2M1Y2ExYzQ1ZjExNTBiNmFlNThmNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkNTIyNTkzZTg3NDBjYTE4NzhhNDNhNjgzYzc2MzFkNDdhZWY2ZDk5MGM2Nzc0ZTFlOGVhNzBiYTZkYzIwY2UiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/doctor/index.ts#L26-L216",
+          "version": "repo-lines-v1:sha256:15357ed677dc7810f67f24ee757e17bacea309b0982405106d74db82c1257be1:eyJzZWxlY3RlZExpbmVDb3VudCI6MTkxLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjMzE0YmQ0ZjJmM2M2NTI2OTljNzQzOWFmMTg2NmEyN2ZkYjFhNTZiMjU2NzYxNjEyNDgwMTQyMWIzOGU2NWI4IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1ZmU2YjM2M2IwNGNhZGFlMGM0MDEwZjkxNDQxODZiNGRiMjJmMzU4YTE0MDI1ODRlMjc0M2ExODJhNTdhNzMzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhNTYxODNmYzhiNTEwMjUwMjY0NTc5Mzk1MzM5MzIyODFlZjkwZWU4NDc4OWMzMmUzNzdiZjkwNWJmODM1OTk2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_71974dc444ee4c8fb83f945caf4b9a2c",
+      "statement": "The logger gates debug console output on `CODEMIE_DEBUG`, writes sanitized file logs under the CodeMie home log directory with date rotation and five-day cleanup, and `sanitizeLogArgs()` redacts recognized sensitive keys and token-like values.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/logger.ts#L161-L216",
+          "version": "repo-lines-v1:sha256:569c716e0d473903591e4283523422ec03d5bf4d1cc08fe152e977b5fde03f62:eyJzZWxlY3RlZExpbmVDb3VudCI6NTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjEyZTZiZjRiMzBhNmVlOTY1YzAxOTZjZTMxNDViODg1ZTFkOWY2ZTQxMzUyYmQxN2FjYTZkNzQ0ZTY0ZDViNjIifQ"
+        },
+        {
+          "resource": "repo://src/utils/logger.ts#L260-L297",
+          "version": "repo-lines-v1:sha256:d3d183d160a117a7def9282d641bb289209595b3b166eafda4953ef90dce8478:eyJzZWxlY3RlZExpbmVDb3VudCI6MzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMwM2I0Y2QwMWM0OGNmYzFjMTIzYjM3ZDFjNzJmZWM2OGM0MTJhZmIyMDYwMGNmNzcxYjI2NDY2OGE3MmIxZDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ4MGQ1YmVhMjhkOGMyMzUyOTg5YjAyNWZhN2YwNTc4ZTVmODc3OTM2NzFmNjdiNTA5ODMzMjI3OGI5Zjg3MDAifQ"
+        },
+        {
+          "resource": "repo://src/utils/logger.ts#L62-L94",
+          "version": "repo-lines-v1:sha256:fa2a5ee01f421fd2ff0e6a6850060ce4c821a2530bb7238eda245ae0d9a8975b:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYzNDYwNTc0MjFmMWE3MDAwM2I4M2Q4YmZmMjdmZWQ4NzcyYzVhODY3MDAyYWI5ZjgyYWQ1NTIxMGMxYjE0YjAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/utils/security.ts#L21-L126",
+          "version": "repo-lines-v1:sha256:f24a739476b5c0e239261f654827614c1d5b5b1ccd49c488cbd87233d154dcb9:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI1ZDEwYTI3NmUyMGRkZjc3ZDc5NDdmYzFmOGU3OThlOWIwZGY4OTlkZWRkZDA0MWE0NzdlNWM0ZDFmNDgwNTY3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI4YmIwZWY5YmMwMWU3ZjE5NzI0ODk2NWZhYWQyYTI2YWNiNGQ1NzFkMTAyODc4MWUwODkwYWQ0NTZmNWE1ZWQ0IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4In0"
+        },
+        {
+          "resource": "repo://src/utils/security.ts#L231-L250",
+          "version": "repo-lines-v1:sha256:e7e3f6dcae26acff59960bd34aa36909b48f1b7ee945f1eb8476285ebce0c032:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA0NTNiMmZiMDZmNTQ2ODdiZjAwN2YyODI4MDA5MjljZWRkYjE3NmU4N2FkYzJjNmZkNjdkMWU5NDViNzFjMDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM2M2UyMTk5ZjQxM2UwNmI3YTE3ODg2OTQwN2Y4NTIwNjA5NTg5N2ZmODUyNmJmMGViZDk4OTA5ODE1NWE1M2MifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_69e58f1f86e54702a1c909683dee0592",
+      "statement": "The project exposes `ConfigurationError` for configuration failures, `ToolExecutionError` for failed tool operations, and `getErrorMessage()` for rendering unknown caught values.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/errors.ts#L1-L40",
+          "version": "repo-lines-v1:sha256:2e3b11ec06288f9f7a0d4593f257ae7f7178f82ceb69550ec5e7e851495ee374:eyJzZWxlY3RlZExpbmVDb3VudCI6NDAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQxZDhjMzdlYTcwN2E0OTc1OWExZGNjNzc2NDFlYmE4MjJiZWY5M2M5MDNjZmYzNzVmYzliYWRlMWQzZmM5ODIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ0ODIyZDMwMzg5NGJlOGE4NDA3NmI5MjcxZjNlNzdhODVhOTUwZWVmYmUzMmU2ZDQxMTk1NzM4OGM3MjQxZDcifQ"
+        },
+        {
+          "resource": "repo://src/utils/errors.ts#L128-L138",
+          "version": "repo-lines-v1:sha256:b4422caa890bfcddd7b82092e5bf70643b9419325f55a933eddda74ef5a8eafc:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5NGZjMGMxNzNkMWVjM2ZjNTAxZDdkZmE5Mjg1NTAxYzUyN2NmYjQ3MTI1ODNkYTNjYzM2MTgwNTY2YjRiZTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNjZTY2ODQ4Yzc1ZDQ4NDczZjAxNWU5ZWI0ZWFkMjk2OWNiNTQwZGI0N2MyNDQxMjU5ODdkM2Y5NjU1NTlhMzgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b10e7863c4ba4f8d9154f9bce0c647e7",
+      "statement": "The real proxy daemon lifecycle integration test isolates `CODEMIE_HOME`, starts the detached compiled daemon without real credentials, verifies state, PID status, and shallow health, then verifies stop cleanup.",
+      "evidence": [
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L1-L42",
+          "version": "repo-lines-v1:sha256:3605d0b3cd4a6d00096d9287fdb10ba543e73c31013c88f48a430417c89e6190:eyJzZWxlY3RlZExpbmVDb3VudCI6NDIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzYjllZGNkMWM2MzA0OTc4MmVmMWUwNjFmYTBhMmViNGRiNWJmZjM1OGJlMTA0YTUxYzFhMDM2ZDAxMWYzMjUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjBiZWQxMDA1OTk1NDU0MzljOGFkOWZhNGM0YmQ4OTY4YzRmYjg5YzhhYzU2ZTE3NDJkODI2NDZhZGY2NzQyNWEifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L74-L187",
+          "version": "repo-lines-v1:sha256:a4679cdf0a62c051a178a9c60a053378326253314062afe46b05024baab30bdf:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3YzRjZDY0ZGQ5MGY4OWU3MDI1ZGRiZGI2OGIxNjExYzgwYmVlOTVmZTgwOTJhMjUxNmE1Y2IwYzdkZTJlMzg2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlNjA2MTkyMWYwNDgwYTdiMDBjM2Y0ZjRhMzVmMTMyNjZlOTkwNDk5NmMzODJiMDJkZWI2ZWJkOTlkNjc4MjdjIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/quickstart.json
+++ b/openwiki/.claims/quickstart.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:b67dced5935a91f2a0e36dc3719a8b8930b8956c7a24409023fd44c8838e60f3",
+  "claims": [
+    {
+      "id": "claim_14b902065ada4ba38d0bba67bf1330e5",
+      "statement": "The package is an ESM Node.js package requiring Node.js >=20 and publishes the `codemie` root CLI, built-in and per-agent shortcuts, `codemie-mcp-proxy`, and `proxy-daemon` through its `bin` map.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L188-L190",
+          "version": "repo-lines-v1:sha256:61e2536f49f4f187a161e8ed7c7a55149cb5ae98d7efe9ecf0dbcf04a363c72e:eyJzZWxlY3RlZExpbmVDb3VudCI6MywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNWY2MDE1NTQxMjJlZmU4NTVkNTZlMTBjYzliYWYyMDMxY2EzZjRhYjExY2RiYTIyZjFlYmM1ZDM5YTc1NTgyNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNjI5ZTQ1ZjQ4MzYwMWY0MGM0Nzc0ZGY5ZDUyNjhiNTA2ZjAxMTg3Y2NkOTBmMGY3MDAwYWM0YTE4NjU2NjkyNCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjEsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDEyY2EzNDVjY2Y3NWJmOWMwODA2YmNlNjk1YmU4ZGU4MDhiNzk5ODQyNTFhN2E1NGQyMDJjZjYxMDFkZDQ1MSJ9"
+        },
+        {
+          "resource": "repo://package.json#L2-L22",
+          "version": "repo-lines-v1:sha256:932e30a5c0c7cfe1671350b5458844cfd7e4de4d3e1ed200a144c399b23058f1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ2OGQ0YTYzZmY3MjkyYmZmNmZiYTg1MjBlOWFlY2JhZTZmYzZjNjkzNjk1N2RjMTdjOGNkOTY2MGQ3ZDBkZTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoxLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2ZmIwOGZkYTFhY2I5NTdiNjExNmJkMzc4MTFhMWZlNDFhMDE2MTFjMDYzMWVkYmY3ODZkNjg4OWEyN2E1NWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMzNGNiYzVkZWI4OGY3NjE4NjdiZDJiOTQ2YTdlMTY4OGYwNGI4YjQzZDU0NzJlZjU1ZGVhNzcxOWJiZWE1MmQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_2ad3190a0ca74eefac520fc446ae1abd",
+      "statement": "The normal `codemie` wrapper runs pending migrations with warning-only failure behavior, performs a non-blocking update check outside test environments, and then dynamically imports the compiled root CLI; failure to import that CLI exits nonzero.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie.js#L8-L39",
+          "version": "repo-lines-v1:sha256:ac50537cb1c125c1c161b6d9921d80a4421b377ebdc39eea9390390a8a0cb783:eyJzZWxlY3RlZExpbmVDb3VudCI6MzIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQzMTVjZWU0ZDczZGJmNjA2ODhhNDNhNzdhZmQ1NGIxMTczYzdmYTc5Njg2ZDZhNzZkYmY3ZDk4ZmYzZDJjYmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3Yzc1OTk5NjkwZWIzODAzNGFkNmE3YzIwZTY3M2ZiYzczM2YwOWZjYWZmOWI3NzZjZGQ5MzM1MTU2YWZlMTQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f778839537b44c1589961017cc92a368",
+      "statement": "The MCP proxy wrapper deliberately skips migrations, update checks, and plugin loading to protect its JSON-RPC stdout channel; it validates the server URL, writes boot diagnostics under `~/.codemie/logs`, starts `StdioHttpBridge`, and treats invalid input or bridge startup failure as fatal.",
+      "evidence": [
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L19-L61",
+          "version": "repo-lines-v1:sha256:ee175b28f8192bd839e782a2f5a803e77fb2d460a0a8fe5f6efd9b8a60a77054:eyJzZWxlY3RlZExpbmVDb3VudCI6NDMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI3Y2U1N2Y5ZjU2ZTE3ZGFiOTM4NjA2ZjQ2NmMzYzBjMzYxMTY2YjIwM2JkZTE0ZjU5YzQ0ZDZmZmJkOGZhYjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJkMWJiNDYxMGU0NjZkNzk0YWUzZTc3OTNhYTg0OTJmZTI2NTI1ZWNjOWNhZWE3YjUzZGY3ODVjY2JlOGFjOWYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkxYWM4ZjQ0NzU0NzIwNjMwNDM4Y2JmYzE0NDQyNzU3NzViMzg1YTZkOWFkM2NlMmM5NTZiMTUyYTBkZTU1ZWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQxYzdhZGJlMTczZmJhOWUyMjA3Zjc5MjA3Yjk2OWQ5NDhjZWFlNGIxYTI0OWY0YmVlOWRjNmM2OWI2ZjZhMTkifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L3-L13",
+          "version": "repo-lines-v1:sha256:ef9c88b8436874fc4ac571a8d7b413185a74dd5839dab963681d6e5d10a408b2:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkN2IxNzBiZjUyZTA4OTUxMDA4YmYzZWNjYmJiODcwYTI2YmUwYTFlNWI4ZTVmMDIwYmFmYmNmMzU5OTk3YzkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY1Y2Y1OTFjZDM1ODBiNjYzMWY3NWEyYThhNDZiM2I5ODMzMzYwY2NiNmJlNTZkOWYxYmRhMzFhMWZmMTRjOWEifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-mcp-proxy.js#L63-L90",
+          "version": "repo-lines-v1:sha256:a9975422657e35da26e3ea114960c5021be7bc2c99fb90e3b0e0f336f9350a6e:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdmY2MzOGQ3MDljNzIxNmNhMTgxODg0OGEzOTkwOTRkZTE4NzFlZjRlNWVkODk4Y2NhODEzZTcxYTQ2MTlhOTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU0ZWEwZjRmOWEwNDJhZmE0ZmYyYjkyMGUzZDY3NTVlZTFmYzRmYjA0NzAwNmZmNDNiMGU0OGJjMTI4MGM3NTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE5NTk1NTBmZmE4NTg4ZGQ1N2NmOTY3ZTY5MTY3OWU2ZDMzZmE4MzNhMjFkZDNhNjU5OGQ2YmNiNjk5MjM5ZTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_00d1b86777524a4dbbc467ab48354ffa",
+      "statement": "The root CLI imports provider and framework plugin entry modules for auto-registration before assembling Commander command factories, and its `--task` fast path resolves the `codemie-code` adapter through `AgentRegistry` and executes it with `AgentCLI`.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/index.ts#L78-L125",
+          "version": "repo-lines-v1:sha256:febca20555bc2f98fc76a7e7d955319ca33e62046e01a2060c16ca4e83f680a1:eyJzZWxlY3RlZExpbmVDb3VudCI6NDgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImViMDM0MDM2Nzk4MzljNmRiYjdmN2EyNDhmZDU5YTQyNDA1Y2RlNjEyMjcyZmZjYzhiZDcyZGFiMmZlMDI2N2MiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijc5ODAxZDUwZTdiZjhiYjE5OTZhNjlmZTE0NDU5NDRmMmNjMTQ5ZmZkNzM1ZDhjNzBlNmZjYWEwZWE5ODI1M2UiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjEyNDI5NjBlMWZmMWQ2YjU2NTIyOTQ3NWFlMTA1NGI4NDU2ZTg5OWEwMDAwNzQ4MjY4YjdmODRlODRiNjRmMTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZmNDU2MWFmNjNjYWRhOTczNmI1NDkyYWQ0N2RiMzE4YTE3OGNjMDE1OWE0ZWVkOWVlNTlkMDI0NzI1YmE0MzAifQ"
+        },
+        {
+          "resource": "repo://src/cli/index.ts#L8-L40",
+          "version": "repo-lines-v1:sha256:b24c3ad2a6428f458409d8edcb36d3b53a303ac0fe20f8c3a0fc2cb9d46ba5a4:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxYjZmZDFiZjZjYTc0OTM2YWMyNDg1ZDFiNmY5MDRiMTYwNDNiMmE3ODZhNjQ3MjIxNGNkMjAwZTQ3ODRiYmUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY1OTIzYTRmMTc5NjMzYTI2MGU3MGFlMmY2OTRiZWUyYjgxYjE1YjgwMWEwZjBjYmVkYWI3MTczYzE1ZDRmMGYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyZDA3ODQ5ZTkzNmNjZmViZDE5NGM4NDQ3MzAwMjc3YjI5NDMyZDZjZjgzOWMxNWJjNTBhZDNmMmNiYmI2ODYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNmMTQ3YTE1OGEzZGYyOWYwZGI4MGExYjU3OGU2OTEwMWJhNmI1Nzk4Y2YzNzMzNGQ5OGJjYWVmZDgzM2U0ZGEifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/plugins/index.ts#L17-L20",
+          "version": "repo-lines-v1:sha256:a2a663b098ad38936fe77972d1c1b546ca80f7c6a161ae8717cf15e1229e95de:eyJzZWxlY3RlZExpbmVDb3VudCI6NCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiMzliZGJjZmY3NDNkZTkyZTNmYWI3NzU2NDgwZWEwMThhMTNmYWE1Y2EyMjljZDMxNTIxYjQyOTI5NWJkMmJjNSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiYTM4YjM2NDdkZDM3ODE4ZWFjMGU0ZjIxMzhiZTg5MjNjNmMwMDhmN2I4Mzg3ZmQ1MTNkMzFjZWZmNWE1ZGNlNyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNDZhODE5NGYyMmU3ODJmN2VmODAxZDc5MzZjOTEwZGQ4YjEyYzdmOWI1ZmM3YzQxNDUzZjNkMGYzNDYyM2IxOCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjAsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NSJ9"
+        },
+        {
+          "resource": "repo://src/providers/index.ts#L32-L40",
+          "version": "repo-lines-v1:sha256:9d2fc4e3234a3ede8aefa22d3e4d3cca716cf29507d91aaa88ae46eed11b5fbe:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiMjJjODgyYTE5N2NkNzk1MzEyM2JlY2RhYjIwYmM2OTM3OWE5NGJhODBiZGM1NTJiZTM2MjhiZjViYmU4NDAyYSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMDZhNDFkZWQ3NGJkNGUxMTJlNzYyZTM0M2FiOGUxZDc3YWJiZWFjNzE0OTQ2YTFhMDdhMDlkY2Y3OTczZmZiMyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiNGY3NzUzZWNjMWVlZTA3NWUwNGRmMzYxYzdmZWUxNDVmNTIyZGUxODU4NzI3MzQzNzZkNDMxZGQ4ZTc2ODFhOSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMWY5NWQzZWMzODRkOTlmNWFlZjY1YWZkZTM5MGQ5ZDVlYmU0MDI5NWE0ODA0YjIwYzk3OTIxNmZkYWUzMTY2ZiJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_3a26b1083a454e0a964a586eb3b5332a",
+      "statement": "Agent shortcuts resolve a named adapter from `AgentRegistry` and execute it through `AgentCLI`; the registry lazily registers built-in adapters once and separates analytics-only adapters from management surfaces while retaining them for telemetry lookup.",
+      "evidence": [
+        {
+          "resource": "repo://bin/agent-executor.js#L11-L24",
+          "version": "repo-lines-v1:sha256:7776d98e2133ee733c12ea0a4eb4dd5dd8ab51b58ccbaf37511299ffebce825e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzMTYzNGJhZWVhODM3ODE1MjMzZmExNzRkMTZlY2MxODk5N2FlNGFmNGYxNmU3N2E5NzcwMjRjNGQxMGFlYzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQwNTdjOWNiYzg2NGJlZjE1MTQ1YzgxNTc4YjdmMGM1ODY1ZTgzYjEzYWMyNGE0YjAzNDQ0MWUwY2FkODllNmMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://bin/codemie-claude.js#L8-L18",
+          "version": "repo-lines-v1:sha256:e300bde7322b64fb2a0789510a4e632cc05334aae8e170bbaa7eaa2e7785b37e:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMzMTYzNGJhZWVhODM3ODE1MjMzZmExNzRkMTZlY2MxODk5N2FlNGFmNGYxNmU3N2E5NzcwMjRjNGQxMGFlYzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNmE5YTQ5OGI4ODFjYjcwMDBjZmQxZjJiN2YwNjI3NzFmNmUwODM1YWZhOTE3ZDIxNTM4ZmE3MGMyZmUxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc1Zjc1MzE2NzNhZjNkNzJlMDJiZWM3MmI1NWRiMGEzMmM5N2ExYWI2N2FlYjRmMWIxNTZiNGZlNGQwMDhhODAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L21-L45",
+          "version": "repo-lines-v1:sha256:573ac68e80ec9d4adf79d45518aea102f2c5acfe13c9fc741a5bc012c62b201e:eyJzZWxlY3RlZExpbmVDb3VudCI6MjUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFhYTRmNTI5YmIxOGE5NDQyODQyMDJiZTc3ODk0YTEyMjI1ZjIyZTQ1YThkNTkyYmQyNDA5ZDVmZGUyODZjYjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVjYTgyOTYzZGFjZjk3YTUyMDdmNWI5ZGYyYjhlYTkwZDkyNjg0ZGRkZDJhODc2Y2E2ZTAzMTJkYWM0YmYxMzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3ZDk5NmEwODFhMDhmZDZkM2Q2M2I1YTZkMTA0NzcyYTY0M2M1NDMzZDE1Yzg5NzMyMzQ5NmExNTFlMDhlNmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/registry.ts#L76-L129",
+          "version": "repo-lines-v1:sha256:12d9b58f332cd297ec4f53d337bb51c0013eced77d9d1047cb96102d5321d725:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxN2UyNDQxNWY5MjZlMTAwOWY0MTA2YzdkMzFkYzdkMTE4ZjA3ODBmMTQ2NDRlZjkyNjJhZDdlZWMyZjRiNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI2MzE0ODFhZTIwMDUxNDgwMzk2NjgxZGE3ZWM4ZmRjYTRmOWU1YTBkNjI5YzdlYTVjYjljM2MwNGU1MWZkNTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmNzM5YTA2YzFjYmIxMjQ0ZTMzNjNkMzhiY2Y5ZmE1MGNlODRmZWQzOTljMjE5M2EzYzdmMDhkNTk5MThiMmEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_c909d990209e4611948dd592660c2dc8",
+      "statement": "Before an agent launch, `AgentCLI` checks installation, loads configuration with CLI overrides, gives an explicit JWT token precedence, normalizes SSO/JWT API URLs, validates required configuration and provider authentication, and validates provider/model compatibility.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L158-L280",
+          "version": "repo-lines-v1:sha256:a992487a5a065ba445b278162728e4e48f78c1e124fc7cbd8a6718ad29bf90d9:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjMDViYzhlYzAyNDkwNGY4ZTk1MTJlMDA1MGM3YzcxODk3OGEyY2QyNzhkMWVjYWJjMzIyMWM0NjM0OGYwNjFmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyNWRkMjM5MGE2NmM0ZmY3YWYwZWU2MWVlMGVkNzRlYmRiMTU1MTU3MWZkOWRhNjg2ZmYxMjgwOTZjODNlNjE0IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyOTZjNmFiNzAxNzUxYTlmNDcxOGMyYmZlYzU5ZjE4MjE1YWQzNTUzZjBjYjEyYzk1MDBmNTFhOTFiNzM3MDJiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwMDMyOWE2NjMxMzUwMjE0ZDBjMWI4ZTEzZDI1ZmNhNjJiNmQ1Y2U3MmE4NGI4MzQ1ZDM0OWZmZDZlZjVkZDQwIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L283-L345",
+          "version": "repo-lines-v1:sha256:0f41b31ad1074490c46760cb0bb8589cd7b28d4430e32acbb6ec7447c29c5fcb:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI2MGI2MjA3YjQwYTc2NjFmZDcwNGQxYzZhMDZlYzQ1NWIzMzI5OWNlMGYzMTRlZGY1YjdjMDUxMWNhNzYxZTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNjJmNjBkODU5MGE1NzljZjQ2ZjhkNjczNzhjNGM1NzJiOTYyY2VjY2RiOTBjN2E1ZjdiNDJiOTYwNzgyYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFlNTRhOGMxZjJiZTg2ODFmMWE2OGMxNzdiOWIwOTY4NDA3Yzk4ODFjNTBhMGVkZTMwOGJjMzJiYmQwZWQ3ZmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNmNGEzYjVmZDg1NWQ2OWZhMjg2MDBmOTQ5YWRlOGFmMWQ5OGZlNGQwY2FmM2ZiMzEzZDE2ZWVkNjViYjk1MDkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_95723872ccf94ad38476a411c1d8efdd",
+      "statement": "`ConfigLoader` applies configuration in the order CLI arguments, environment variables, project config, global config, and defaults; project workspace context is resolved independently as a whole-object local-over-global override.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/config.ts#L203-L221",
+          "version": "repo-lines-v1:sha256:50ea1a4df09fbe4a757c4e56f9bae67768a018c8db80c2cd996c45454732011d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIxYzQ5OTU4YzMzOTY4ZTllYmZmNzlhOWM4MGZjNTc1YjU1NTVkNTRkMzc5ZDAwOGE0MGNhZWFmMGU1YmUyOGYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYTRkMzNiMTdjZTFhNmIyNWE0NWM0MjdjZTFhYmJjMTQ5YjU0NDY0MGFmOTI4ZjJjZmExZWNmMTBjNzk0YWIifQ"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L29-L36",
+          "version": "repo-lines-v1:sha256:a85687d7202edd96582067b6cb4dff3dfc2dd9219e4a103c14a8ac3bff036159:eyJzZWxlY3RlZExpbmVDb3VudCI6OCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiOTcyYTQyOTM4MmIyZTE0NzE4ZTBlMzdiMDU3MGE4YTE3MDI5OTFmY2Q4NDk4Y2Q4NDA2MGE4YmY0ZjA1MDE3YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjA0NGQ3MjViOTRhMmE1ZDIyZjY2YTU4ZTg0Mjk0MDQwZDZlZTE0ZmMyZGY4M2YxZjZhZWE1YzdjYTUwZTJkYSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDk2NmI4YmI0MmI3MjZkOWRiMzJmMTNjNGQzYmQ5ZTU0MDUxMjVlOTdmNGM4NjkxOWEyMDQ0YWU0YjlhYzAyNCJ9"
+        },
+        {
+          "resource": "repo://src/utils/config.ts#L87-L200",
+          "version": "repo-lines-v1:sha256:6d1807a1f94ff4b374dc88c17d12b647ec3aa82ef4097d67b8d69ed1d4817618:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0ZjJhMmY5OTZmMDhlNjgwYmQyOTIxMzVhNmZhNDk3OGJkYTI2ZTYwMmQ4NGYzM2NiMWQ1OTQ3NzVkNDMwNGI1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2ZDlhZjUzNDQwMmY3NDllY2Y3NDFjZjYxMmU4MWU3ZWZmZDY4YmIzNWEzODYzZjE3ZTM1NThjMjk5YjdhMDdiIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI5N2Q4NjMyZTU0ZTkyOThhYmI5NTg3MjdlMmQ1MTQwOGFiYWYxMzY2MDM1Mzc5MTAxNDBhYmY2NWIzMGFiNjEzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_8eaafd061ec8419699c0ca74fda07c00",
+      "statement": "CodeMie local state is relocatable: `getCodemieHome()` uses `CODEMIE_HOME` when set and otherwise `~/.codemie`, while `getCodemiePath()` derives paths beneath that resolved home.",
+      "evidence": [
+        {
+          "resource": "repo://src/utils/paths.ts#L327-L376",
+          "version": "repo-lines-v1:sha256:529f018994c74f14c207867df44d64f287f6a1ae731c0bf0d24cb772aef6bedf:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3NTk2ZjVlMWUyMGIwZDFmNzgyZWQxMDY3ZjcxMTJmOGNlYjg4Y2UwOWEwMWIyMTlmNTkwZjRmYmZkZWYyYzQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5MDJhMGYxM2Y2OTVjODcwMTg0NDI1M2JiYTVhYTU4ZTFkOWQ1MWNkNGU4ZmFkZGEzZmRmYmUxODNhZDlkY2IifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bb1f143cdac04a6a888a2ca0a66b790d",
+      "statement": "The library barrel intentionally exports the agent registry and adapter type, logging/process/error utilities, environment manager, SSO and proxy APIs, proxy-plugin registry, hook processing, and `ConfigLoader`.",
+      "evidence": [
+        {
+          "resource": "repo://src/index.ts#L1-L28",
+          "version": "repo-lines-v1:sha256:29f352fabb7fd1863329253909290a9260fcaa59a6a59c91ab4c45f17a3d4b73:eyJzZWxlY3RlZExpbmVDb3VudCI6MjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIwODhlOGQ1YjY0M2VkMzM5OGMxZDJlYjIyMjg3YjIxMWRhM2U3MmQ5MmQ0MDIwNmNmMjlhNTFmZTE2YzFhNmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMzZWVjNjdmYTlkN2VlMGEwOWEyZGM0OWE0MzkzNjUwMzNlMWZiNjJlYzUwNTgxNDU0MTA2Mzc3ZTNmY2U5YTciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b926a3a0de874b0987b049c62ed60690",
+      "statement": "Vitest defines isolated `unit`, `cli`, and networked `agent` projects; all receive a process-specific temporary `CODEMIE_HOME`, while the agent project uses build setup, longer timeouts, and bounded workers.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L37-L45",
+          "version": "repo-lines-v1:sha256:cba7e80024e44dbe3285bdff8c0c37da7b77f31ae8be3cff6ecbbdfab54d3b3c:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiODI5MWU4NTRlYmY5NzRhMGY4MDdiZTQ2OTM3NGM0YTkwZTI2MDYzNDIwNjhjZDZjMjNiYzc4NmY0NmNjNTBmYiIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMDViNmU2ZTRmYjY1MGVmZDQ3ZGQxNmI3M2U0MDhjNjQ5MjBlN2ZmYTIwNTI5OWY1YTY5OWYxNGJhZWEwNWJiMyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiM2ZiNTJiMTMzM2JhMGE1MzhhZTM4ZGNhNWIxMzEwNmIzNmE0NDhkOTExOGYxYjVmMzkxMTU4ZTM0YjA3NmQxYyIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiNDFkZWE4YjE4MmFlZGUxOGVlMDM5YTg0N2I4ZDE4NjVmYjRjNmExYTIxODBmYzVhMjQyODY5Y2U4YWJlOGU2MyJ9"
+        },
+        {
+          "resource": "repo://vitest.config.ts#L17-L97",
+          "version": "repo-lines-v1:sha256:7aea62709c233df468e5196454122dd4acf81a13fdd8d1cf84703b6db95b0bf1:eyJzZWxlY3RlZExpbmVDb3VudCI6ODEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU3Y2FkZTg3ZTc3MWFhMjhmOTUzNmZiNDhlMGIzMmNiODhkZjI2YmIyODQxOGRjNWY3ZDcwYzFiZjFhNTZhZjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU2NzdkMmYwMzFlOThiNWU5MTFjNWFkNGZiOWIyMTg2YTkzMjUyMmU4ZjQ2ZWU0MGJhYmZhZTNkYTAwZmMxMjEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJhYzA5MzM4YWQ2MWI2YTUzNjQ0MTM2ZmQ5NGI2NTU0ZDU2NGM3MmMyZWJlYmVjOTlhNjZjYTkxMjg3ODM0MWUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmZmFhNjQ1NzcwZTJkN2UyODgzOTNhZGQwMjJjMTI1NzJjYjYzZjAwZDI3MTM0YWMwYjZlYzAxYjBmYThmOTUifQ"
+        },
+        {
+          "resource": "repo://vitest.config.ts#L5-L13",
+          "version": "repo-lines-v1:sha256:a2d6dc33545d81e00a86edb716ac655b2bae2158c8e685904a0dc2fe8ebe2537:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiMTA3ZmQyNDk4ZjVlMTMwMjE5Zjk2YmExMDQ3MTE5YmUwODRiMGVmYjIyOGFkZmU5YzVjNTk5N2UwM2U3YTE3YyIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMDFiYTQ3MTljODBiNmZlOTExYjA5MWE3YzA1MTI0YjY0ZWVlY2U5NjRlMDljMDU4ZWY4Zjk4MDVkYWNhNTQ2YiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiOTFmNGE4MTNlNjRmZGI2Y2EwMjc4MDExYWJkMjdlZTgzYzI5NzZmOGUzNDNiYzMxMDgzOTBjNWFjMGEyZDJmOCIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiYmFjMDkzMzhhZDYxYjZhNTM2NDQxMzZmZDk0YjY1NTRkNTY0YzcyYzJlYmViZWM5OWE2NmNhOTEyODc4MzQxZSJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_bafc76a6ea9f460c87a41729dff9b398",
+      "statement": "Repository instructions require task-relevant guides to be checked before code search, prohibit writing or running tests unless explicitly requested, and prescribe the CLI-to-registry-to-plugin dependency direction along with ESM `.js` imports and derived CodeMie paths.",
+      "evidence": [
+        {
+          "resource": "repo://AGENTS.md#L12-L37",
+          "version": "repo-lines-v1:sha256:5a1784f15dcb78bab0372d7a792124f2d7c7e71bbb8b0ef5a17454ed383edd7a:eyJzZWxlY3RlZExpbmVDb3VudCI6MjYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjExZTBkNTRmNGI5YjZmODhlZjBlYjc3ZDgwMjQ4ZjNhMGZlYzlhYzdmYzhkYmU3Nzk2OWFhMzY5ZjA4ZjE0MTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRlZjE5ZWUzOWRmMTNkZmI1NzhkM2ExZDBhOWQyZTYxMmYxMTE5ZWI5M2MyMTZkOWM0YWM0NDQ4ZTZmNzg5ODMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQ2YTUxNDk0YThjYjIwNGJhYzVjMDMxMzU5Yjg4YjE2ODk4ZWU5ZDQ4ZWIyMGYwMDZlNjFkMzVkNmViZGJmNTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImE5YmFiY2RmOGVlOTY3ZmU1YjNiOTg3MmU4ZmM0NTZlNzIwNzk0MGM5N2Q1OTE3OGIwZGE2OThjNDcyNjJhYTQifQ"
+        },
+        {
+          "resource": "repo://AGENTS.md#L163-L178",
+          "version": "repo-lines-v1:sha256:f841fec7d759aa167ec3cda48556cef9f6ec57ee4e620baabe22cb3179ac23d6:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjUwZjgxMzc0NWM0MmI2YjNiNzQ2YjhlYmEyZjczYmRhZTk0NDJkZGZiYTliYjI0OTk5MWZkMjAzYjI2ZTYwOGMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg5NTcwZjNlYzI3NmUwZjg2NTczMWJjYjE3Mzg3ZmQyMWE2ZDNmZGUzZDNkY2Q4MTBlYzQ4ZTAyNTkxM2E0N2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMwOGFkMjcxYzk3OWY2MWUwMzdiODFhYjI5MGI4MDFlYTE5MDRjYWQxODI5NjY1YWQ3Y2UwZTllZTM3MGJlNjYifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/testing/test-strategy.json
+++ b/openwiki/.claims/testing/test-strategy.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:643002ac4019c66ed8769c065428818357afd3f35e87b42741afb1865167d891",
+  "claims": [
+    {
+      "id": "claim_78d1f8677d1b4983aafc5fb27d49b4ae",
+      "statement": "Vitest defines three isolated Node projects: `unit` for source tests, `cli` for non-agent integration tests, and `agent` for `agent-*.test.ts`; all receive a PID-scoped temporary `CODEMIE_HOME`, while the agent project has global setup, longer timeouts, group order 2, and a configurable worker limit.",
+      "evidence": [
+        {
+          "resource": "repo://package.json#L31-L61",
+          "version": "repo-lines-v1:sha256:b83146f3662339b238c51ba70a157aab9c28790ec4772732af3b6a1e92ba86f1:eyJzZWxlY3RlZExpbmVDb3VudCI6MzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM0ODMzZDU5NDljMDNhNDBjYTk1MjQ5MTYxMGE2NjU5NjQ0YjNhYTQ2NjM2MmY3OTkwMjBkYmYxOTgxNTQ3ZGIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZmYzc5YzAwN2QxMjA3NWI0ZmQ3MGIzNDg2M2U2MDkyN2U0YzBlOWIwMjRkNjQ4ZmRlOTI0ZDY5YjQ5ZjhkYTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjNjMTg5NDZlOTUwNzAzNjY5Yzg3ZWQ3OTRmNjcxMzI1MDc5ZGI3ODk5MDg3NGU0ZGI1ZTAzY2M4ZmM1OWI4YTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAwNDFlN2YwOWZiNGJmNmVlYTJiY2ExODZhMDU4MjY1MTQwYzMyODBjNzZjOWE3NDU5ZTUzZTNmZWUyYTcxMWYifQ"
+        },
+        {
+          "resource": "repo://vitest.config.ts#L5-L97",
+          "version": "repo-lines-v1:sha256:39789be3bddb842644b6509787fcf5c21b8ad6561131f90aa616a43480f2a88a:eyJzZWxlY3RlZExpbmVDb3VudCI6OTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEwN2ZkMjQ5OGY1ZTEzMDIxOWY5NmJhMTA0NzExOWJlMDg0YjBlZmIyMjhhZGZlOWM1YzU5OTdlMDNlN2ExN2MiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU2NzdkMmYwMzFlOThiNWU5MTFjNWFkNGZiOWIyMTg2YTkzMjUyMmU4ZjQ2ZWU0MGJhYmZhZTNkYTAwZmMxMjEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkxZjRhODEzZTY0ZmRiNmNhMDI3ODAxMWFiZDI3ZWU4M2MyOTc2ZjhlMzQzYmMzMTA4MzkwYzVhYzBhMmQyZjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmZmFhNjQ1NzcwZTJkN2UyODgzOTNhZGQwMjJjMTI1NzJjYjYzZjAwZDI3MTM0YWMwYjZlYzAxYjBmYThmOTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_652bac13c8bc4f37ab9a52a34e1001f0",
+      "statement": "Tests that create CodeMie state must isolate and clean it: the isolation helper temporarily sets and restores `CODEMIE_HOME` and removes its temporary directory, while workspace and agent helpers create separate temporary working/home directories and clean inherited CodeMie environment variables for child processes.",
+      "evidence": [
+        {
+          "resource": "repo://tests/helpers/agent-smoke.ts#L48-L97",
+          "version": "repo-lines-v1:sha256:a48edfc811bff2280846290408c0df695a420f1b712d817b6063d970000d3a9d:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNmNjY0NWI1N2QwOTEyM2ZlNDQ5NDAzMDFmM2Y3ZTViNDAxYjdmYjNlMTMyZWQ4OWE4MmMzZTBhOTc4OTExNDkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIzZDNjYzVhZTI0NjQ5ZmFmODE1MDg0YjBlMWNjNDkyYWQ5YjNhY2NkYjJkOWFhYjUzNzgyNjEyNmUxNmY4ZmEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI1MzRhZGI2M2IxNzNiYjFmY2ViM2E2OTQzMjQ0M2VjZDUzNDIxZGQ0YzIyNDllMGE1OWM4ZDgxODI4MWNiYzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://tests/helpers/jwt-auth.ts#L51-L69",
+          "version": "repo-lines-v1:sha256:facc9d70b65c56763ee318f8b0a1e1baa68da27f59fac3620a01f68037544a20:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyYTJjYjI1YTEyMmI0NDIyMWE2MjM0ZWM2NjBhN2I1ZmI3ZjliZGU3YjNiOWUyYjNjNTU5YTBkOTZmYWM3MzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY4ZGQ5NmFlMzdhNGRkYmYwYmZjM2NjOWUzNmVhNzRjODg3NWY0MDBlYjhiNzRhMGZiYzExZGQ1YmYxZTMyMjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjhkYzE4MTM5OGI1OTk1YWUwZTZkMWU4ZmFiMDYyMjAwMjQ0NzUwYjA3ZjdiM2JkY2NjZDkwYmRlZDI3OGE0NjYifQ"
+        },
+        {
+          "resource": "repo://tests/helpers/sso-auth.ts#L42-L57",
+          "version": "repo-lines-v1:sha256:71124eb9dceeea35700d86915cab70d2de1c37fb7c847448a24fc21e876ed025:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImFmZjk5OWY0YTEyN2FhZWUzY2I0NmJkYWU5ZTg2YmI0MzM0NDUxN2EwZDk5YzVkYWZkOGY3OTdiNWQwODJlNjMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEzOGMxZTM5ZTdkMjdjOGM5YzlmOThlMzIzNmU3YzMzYjJlZGE0ZjRmMDAzOWRhZjE0ZWY3MWIyOTNlNGY0M2QifQ"
+        },
+        {
+          "resource": "repo://tests/helpers/temp-workspace.ts#L11-L117",
+          "version": "repo-lines-v1:sha256:33f52de960472c8b5960ce5f791ddb0359e9b76886deb2cb125b32e2f4ab8e26:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyZGVjYmRmYTYyNDYyNzFmZjBhMmMxY2RiZTI0OTE3ZGFhYTBjYzQxYWIzNDk5MDc0MTZhMWZhZWMyMDkxMzBmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhMTliNGM5N2Y2MzEyMDgwNTQzODg4NDYzZmM4NGI3MTY0Yzk0MjNkODdlMmE4Zjc0M2U2NDVkNDZhMzJmODhiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJiMjExY2ZjMDkxMjQzYjdhNDNkZDkxYzQyNzQ1MzdmYjliNjJkZDRlYjg3ZWNkMDYzMzM0NGEwMjVjZjRlOGQ3In0"
+        },
+        {
+          "resource": "repo://tests/helpers/test-isolation.ts#L33-L87",
+          "version": "repo-lines-v1:sha256:263c48c994e16c24729c700089193febb57c9bd063b113013a4f5b111324fdc1:eyJzZWxlY3RlZExpbmVDb3VudCI6NTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjlhMDM0MGMzZjI4OGEzNThlMDMxMjY1MmEwMDdiM2JmZGQ5NjM1NzgzOGU0NDkwNjM0MGRjNzQ0OWIxNWYxMTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxODViYTJmYWZkMjc4ZGQ4ODk5YzNkMzFmZmI0ZjkxZTc5NDk5MjMzOGZhZjgxODgzYTA5YWMzNThmYjcwYzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY1NTk3MGE1ZmJhOTZjODgxMDc5NzQyMThlMDFlMzRiZGUzODM0OTFhZGE1NjBmNTNkNjI0YTE4MWVhOWIyOTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_124881f215e24a3f9abe249fcf2aa443",
+      "statement": "When environment-derived defaults or singleton registries are evaluated at module load, tests must establish environment/mocks first and use reset plus dynamic import as needed; the daemon lifecycle test sets its temporary `CODEMIE_HOME` before importing `daemon-manager` because its default state path is module-derived, and desktop connector tests reset modules around `CODEX_HOME` changes.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts#L9-L29",
+          "version": "repo-lines-v1:sha256:1be7c748208c15db399ab18d844c058624a80e3aab6e33ba3e916d48ee20cf2c:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQxNzllMjllZWY5YTk4MmJhNWY1NWI3Y2EwMDJhZDc5NDMxYjRhNGY4N2FiYmE1ZDMzODMxYzBlNjFjYTkyNWEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBmYTRjZDNkMGFkNWQ0ZjI4NGNhNzdkMjIyZGEyZDIzOTUwYjc5ODdkZWE3NWE0MTBkNWE4MmNkZTgwNzA2ZDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4MTIzY2ZmNjZmZDA3MGI1ZDEwMzQ4MTZiMjQ0ZDk2N2YzN2I1YTI1MzkwYmYxMDdjOTk3NzRiODA3NjcyNTMifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/registry.ts#L139-L151",
+          "version": "repo-lines-v1:sha256:65287e9efa5a1b5916d0ea356929180b8d19e27cd5a6e569cf9169bf930f6a81:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRjOTkxZDhmZGVkY2JmYWRmOThlMDIxNmIzOWY3MWQ1OWY4NTQ5MmRjMDhlMDVjN2RjYjZlNTQwZWQwYWY0NDEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L74-L88",
+          "version": "repo-lines-v1:sha256:aa4d3cb3f08e3b76417e273615ab87260c1352304abfa5413223f92af7994989:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdjNGNkNjRkZDkwZjg5ZTcwMjVkZGJkYjY4YjE2MTFjODBiZWU5NWZlODA5MmEyNTE2YTVjYjBjN2RlMmUzODYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjkxNmI4YTMxNmUzMmI3Njc2ZjZjNzNiNjcyMGU5YjZhNWYwMjEzMzFlOWRiZmUwNDRlNWYzNDZhMWI1ZWM4N2UiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImU2MDYxOTIxZjA0ODBhN2IwMGMzZjRmNGEzNWYxMzI2NmU5OTA0OTk2YzM4MmIwMmRlYjZlYmQ5OWQ2NzgyN2MiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY1ZmU4YWE5NTUxNmIyMDk1Y2IwMTY5ZmJiNmEzYmZjNzEzOWY5ZmFiNjI2MDNmMzg4ZDUxMjNlNjRjZmQyYjEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d921a324592e40c79cff23db121a54d0",
+      "statement": "Focused unit tests protect extension and launch boundaries: the agent registry asserts expected built-in/plugin membership and adapter interface behavior, while BaseAgentAdapter tests prevent stale JWT environment state from proxying no-auth providers and cover SSO/JWT proxy selection, auth-method mapping, dry-run proxy cleanup, reasoning effort, and Windows command quoting.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/__tests__/registry.test.ts#L10-L177",
+          "version": "repo-lines-v1:sha256:da4aaa848d40d8af6748110d10b51affd39bc1b200a798ca1965b436736a9930:eyJzZWxlY3RlZExpbmVDb3VudCI6MTY4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjM2Q1MzYzMzY2NWQyZWZkYTI0ZmM4YTVjN2ZmMzVkYzk5N2ZmZGQzOWVjODk1ZjVjZGZhZTMyZGM2MGI0OGU0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIxZjNmYTVkNjM0MmQwNzJhZDkwNTQzMWU4MWQ1NjRmMmM3ZTg5Y2Y0MzVmZDdmMWFhODJhM2NmMGFkOWQ5ODIzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MiwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkODE3ZmJiNzNjOTJiMzZkNWU0ODk2ZmY1MWMxYjU4ZWVjMzMwYmJlOTYxYmEwNWZjNjIwNWY4NjdlYTFiY2Y2In0"
+        },
+        {
+          "resource": "repo://src/agents/core/__tests__/BaseAgentAdapter.test.ts#L241-L370",
+          "version": "repo-lines-v1:sha256:d1847da3cfafc269383f450f9d4d9cf46f0f4158739c0d4ac417ac5ff7ce9dbb:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0MDA4YmE4ZTc2NTczZDIzN2ZkOGEyNmZhNjEwMzkzNGJjOTgyOGU1ZTQ5NzdjMWRiMjlkZGQxOWExY2I1ODRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMTY0OGJjMmFhMjg5ZDZjNmM3MGZkNmYyMTJmNThkMDA1OWJmMzI1MzFlNGE0NTNkZTc3NjYzMjk2ZmQxNTMwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzY2RmMGYzYzExMTk1MDdhM2EwY2ZkNTY1ZGU3ZDJjM2NjNWMzYTYxNjk3ZjMwMGE3MWI1OTBmNGY1MTZkNWE0In0"
+        },
+        {
+          "resource": "repo://src/agents/core/__tests__/BaseAgentAdapter.test.ts#L576-L687",
+          "version": "repo-lines-v1:sha256:51db6fecbb6550dd5b558c5af6c510631a95cb1fa2ba670102568554a9815786:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5ZDU1NGVlNjYyODllOGIyOTZiOGZmNzQ5MzgzOTkwOTU3ODM1NjA3YzIyNDgwYmI1MzliMjk5YzNmY2U1MjQ0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMTY0OGJjMmFhMjg5ZDZjNmM3MGZkNmYyMTJmNThkMDA1OWJmMzI1MzFlNGE0NTNkZTc3NjYzMjk2ZmQxNTMwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MiwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkODE3ZmJiNzNjOTJiMzZkNWU0ODk2ZmY1MWMxYjU4ZWVjMzMwYmJlOTYxYmEwNWZjNjIwNWY4NjdlYTFiY2Y2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_7962203c54d247318bc468400cd1d8ab",
+      "statement": "The proxy's security and ordering contract is priority-driven: core plugins include early endpoint blocking and gateway-key validation, authentication and request transforms, header injection, and late session synchronization; an end-to-end header test verifies that a valid local gateway credential is stripped and replaced before forwarding, while a wrong key returns 401 without contacting upstream.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/__tests__/gateway-key.plugin.test.ts#L76-L116",
+          "version": "repo-lines-v1:sha256:0af0b225490ce4c48428bca27241cb7ecebc9ada8aa0a7f852525fbd4a7bbc99:eyJzZWxlY3RlZExpbmVDb3VudCI6NDEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFmZjc4ZTgxYzlkNjc1ZDcwNGU4NDhhMDQ5ZTViYjQ2NzRkYjc4YmFlMjg4NWUzZDM5N2JmNWI5YTYxYTA3OTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIyZDExY2FmNDNlOTdlZjM2OWU2YmVlZDFhMjY4YmQwNTgzOGYyOWI5ZGQyNTRiZjY5YmE2NDg4NDE0NzIzNGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIxNjQ4YmMyYWEyODlkNmM2YzcwZmQ2ZjIxMmY1OGQwMDU5YmYzMjUzMWU0YTQ1M2RlNzc2NjMyOTZmZDE1MzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ4MTdmYmI3M2M5MmIzNmQ1ZTQ4OTZmZjUxYzFiNThlZWMzMzBiYmU5NjFiYTA1ZmM2MjA1Zjg2N2VhMWJjZjYifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/index.ts#L29-L51",
+          "version": "repo-lines-v1:sha256:a2b50f1f6cbed44bc3071f349ef44da9c3610a7f479d4e4e68032569c6d6199d:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRjNGI0NDBlNTUyZDgyMWFiYjBhNTEwNDkwZDE3ZmYwZjFiMmNhZjI2OWJhYzdkZWE4Mjk0NGQ1ZTg1M2NlMmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg2YTQ1ZjhkMTk2NjJkNjQ3NTZkYTk5OGZlNmI5NmQ5ODA0MDdkMDg3MGU1NWM4OWUzNTY2YjY2MjMyYTUxOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI0MDMxYTY2YWQxZWFhM2Q3NTUwMmFkZDM4ZGYwMjc2ZjIxMjE4NTMzZjc1MDc5NjI2OWE3NWIzNzQyMmJjNzMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjMTM0MWJjNjE1NDc0OTU5NzhmYTI2ZmUwMDQ4YjM2NzA2NDc4MzViNzRjNzUxYjQ4MzBiZWRhNWExY2M0YjQifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/registry.ts#L35-L81",
+          "version": "repo-lines-v1:sha256:6dff2e6b1ce0a8bbb44409b845a90b09d10292d0e5d11d0491e7ec1d3640af29:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjkyNmVkNzE2YzA3MjZmMmE4MzA0ODc5ODNhY2ZmZDgzNTk5MmQ2MWM5YWZiMmRmNTRjYzg1Y2Q4NDQzNjcxNmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRjZTE3N2E1MjY0NDRkZmEzY2I3MjEwMTM0MWZiMTUzNWI3NjQzZjljMzBiYzU2NDA1YWQyNzI3MDQyMWRiMjciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-header-contract.test.ts#L85-L133",
+          "version": "repo-lines-v1:sha256:0a9ce0173fb9fa5336f3218267cae95dcddaa3b001c87109fe23786f8fb4f7b8:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZiODRlOTBlNmZkY2Y1MDgzZWEzMjZhZjNhNzk5MmIzYjNhOTZjZDg3YjZlYmIxMGQ3NjkyNDJmZTI4NzJkOTIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkMGYyZDNhM2FhZGEyNzU4NjQ1NzhkMGE0MzkxNTYzOGQ1NDNmZWNhMmM5NDg1OGRiOTQxMjExZTg2Y2VmMmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8296647ab8a840b59c1db5e2cc2baa1f",
+      "statement": "The credential-free daemon lifecycle integration test exercises a real detached proxy daemon through state persistence/readiness, shallow local health, status, SIGTERM shutdown, state removal, process reaping, and unavailable health after stop, using a temporary `CODEMIE_HOME` and dummy JWT because the health endpoint does not call upstream.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/sso.proxy.ts#L244-L255",
+          "version": "repo-lines-v1:sha256:8f367075ce61d66a89c08ad6417e7b6d0143dd85973b9323f968fb89ed06c038:eyJzZWxlY3RlZExpbmVDb3VudCI6MTIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzZTBhNmJmZDhlNmIwODgyY2ZlZTRlNjVmMDA0NDg5ZjUyYjhkZDRmNzY4ZjZlMTI4OWM5MTg1NDY0MmI3NGYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE3OTJmODQ3YmIyMWNiMjkyZGQwOWY3ZmE2ZTdjYWM0YThjMTRkOTdkMzg5NjMzYjNkMTUyMGVhMTRiNWIxZGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU3NjdmMDg5ZTI2ZjI5MWI0NGFkOGQ4MzViOTkyMzZlNzdiNmNlZmI5ZjFlYmQzZjcwMzZiYjk5ZTA2YjI1NjciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEyMjZhZTE5Zjk1YjFkYTg3ZjA2NTFlMzVkOGQ1OTE2YTU3MTUwZmRmZWU2ZTYyOGZjZmQ5OGJjZjAxNzZmNzMifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L4-L40",
+          "version": "repo-lines-v1:sha256:6386572f6764a3bcb4b423f03cd251e8852fae18efe263144cd2902929f0708d:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZiNmVhYWZkZTE4YjhiNTFjNDk4MzhlNzdjNTUyMDk3YWM0NzA5NjA1OTRlMjBkMGYwYzUyMGNkMDY1MWE4NGIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM4YzQyYjI1YTZkYjhiZWVhZGFjZjM2MzVjZGNlOWIwYmMyNjEyYzU3NWFkODk2OWFkYjZiN2MxNWIxY2YyMTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE0ZTM4NTY4N2IyY2U3Nzk2YzYzNmIxYTM1NTIyMDQzZTM4YjBjNDE1YjVkZTM1ZjMzYTNiYjdkYzIxNmEzZmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImMwMjY1MTkyNGFkZjU5MmRiZGI3Y2Q1YjE1ZDFkZDk2OTkxNGMzYWYzNmEwZWMxN2FjY2YxMDAwYzkzZjQzZDcifQ"
+        },
+        {
+          "resource": "repo://tests/integration/proxy-daemon-lifecycle.test.ts#L74-L187",
+          "version": "repo-lines-v1:sha256:a4679cdf0a62c051a178a9c60a053378326253314062afe46b05024baab30bdf:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3YzRjZDY0ZGQ5MGY4OWU3MDI1ZGRiZGI2OGIxNjExYzgwYmVlOTVmZTgwOTJhMjUxNmE1Y2IwYzdkZTJlMzg2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlNjA2MTkyMWYwNDgwYTdiMDBjM2Y0ZjRhMzVmMTMyNjZlOTkwNDk5NmMzODJiMDJkZWI2ZWJkOTlkNjc4MjdjIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_020a83e2bebf480b8a9dc1fc7939e579",
+      "statement": "The networked agent task/session test verifies a real local `codemie-claude` distribution run, generated work, and eventually durable completed session, conversation, and metrics artifacts correlated by UUID; it uses JWT temporary-home or restored SSO-profile modes and requires additional sync evidence for SSO.",
+      "evidence": [
+        {
+          "resource": "repo://tests/integration/agent-task-session.test.ts#L56-L97",
+          "version": "repo-lines-v1:sha256:ec48327ece5b7ecf12b3df6e7df1d87ddef50506da7434f9cb2be29869fee64a:eyJzZWxlY3RlZExpbmVDb3VudCI6NDIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEwMTdlNDNkYjI5NTJmZDhmMzZlM2E2OTI2OWI3MDg3ZmFkZTMyYjc1MzQ2MjIwZmYyYWY1NGUwNDJkM2I3MzciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE5ZWM3ODQ4YWRjMGQ4MGZjY2VkZDY3YjNkZjRmOGE4MWNmMjJjNTkzNDY1ZTJjMDA5ZmNlYTIzMzI1NzE0ZjQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQwYTJmNDQ3ZWI2N2MxZGVkMTQyMTg4NDZjOGZkYmU0YzljYzk4MDQ3NDAyYTBjNWZjZmFiOTVkYTkwMTVkNDcifQ"
+        },
+        {
+          "resource": "repo://tests/integration/agent-task-session.test.ts#L99-L253",
+          "version": "repo-lines-v1:sha256:b7cda7ca2e41b7287c6566c2ed29c79d95b4ff182e6264e837d9ee2cfe593ddf:eyJzZWxlY3RlZExpbmVDb3VudCI6MTU1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3ZjVjODQyOGQ3MTlhOTlhMzBkNTg4YTFiOWVkYmU4NjE5YWNhNzg0MzU3MjI1MWQyOTA2OTVlYWFkYjMwMjhjIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI1NTUwZjFmYzY5MDYxZTg2ZTljOTBlZjQ3ZDlhYzhiZjIxM2Y4YTdlOTFjOWI4NmFmNDM2NzkyMWExYmNmZDMzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI3MjBmYzllNjdkYjA3ZWQyMzliYjNhZDIzMTJlYWFiOWE3MGUxZjZmYmEwMTI4OGIwYmE2ZTYxZDdmOGVlNzg4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        },
+        {
+          "resource": "repo://tests/setup/agent-build-setup.ts#L151-L179",
+          "version": "repo-lines-v1:sha256:c9e50968ce7496ddb51886de31e13b520a8ff983e713f3026eba145dd1c8f7dc:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE1MWY0YzJiNzg2OGI1OGZhYzFiM2IyZWQ1NzFkNWQ0YzkzNWEyNjBiODlhMzAzOGY4ZGI2NWVjNzA3YzkwZjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://tests/setup/agent-build-setup.ts#L29-L50",
+          "version": "repo-lines-v1:sha256:bcdba62a69abb7f354d403b71cda06ace8dcd94bf561545878037db7dee3945e:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE2MTI4ZmFkMjlkZjc4OGIzNTI0NzAyOWViZDc3MzgwOGVjNjdiNTBhYTA5YWQzNGRjYjM0NWU1NjliMWVkZjgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJkM2M4NzgzMmUxMTcwMDk3MGJjYjExZGRjNDViOWMyZjNkZDI0ZjY5OWJkOWZhODc1MmYwNjFhZWUxZmYyMzgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU4YTgyNDc4ZmUwYjBmYTQzNTgzYmQ0Yjk2YmFkNDlkODc1ZmQ1NjczZmJmNDRlZmEwZDk4MmM5N2YxNzIwNjEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjkxY2QzNDkyNzRlMDgyMGEwNmRlYmI3MmQxYTQ1MjNjNTFiNWE1ZTM2MDM4OTBiODE4MzI2YzY0NTcwNjQxYWYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_bd83ae5c9623485d80d19fd412eb1503",
+      "statement": "SessionSyncer integration tests use a mocked sender to establish that pending metric JSONL data is aggregated and sent, success marks records synced with metadata, already-synced data is not resent, and a processor failure leaves pending work for later attempts without necessarily failing the overall sync.",
+      "evidence": [
+        {
+          "resource": "repo://tests/integration/session-syncer.test.ts#L140-L218",
+          "version": "repo-lines-v1:sha256:4d3a3dedd6963c2c11ca193a6f9244ae06f0edde059e62dddcd6769d09424ead:eyJzZWxlY3RlZExpbmVDb3VudCI6NzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBjY2U3YTdkZTFmOTc0Nzk1NWFkMDE3YTIxODgwNmUxMjI5ZTY4NDgzNjQwNDQ3OTYzODRlZDhiODRiNTZhZWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjcyMGZjOWU2N2RiMDdlZDIzOWJiM2FkMjMxMmVhYWI5YTcwZTFmNmZiYTAxMjg4YjBiYTZlNjFkN2Y4ZWU3ODgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVlN2MyMjg3MTVjMDFlZGEzOWM3Njc0MDYzYThiNzUxOWMyYzMwN2VjNGVhYjg4NmRlMzBhMWEyOTIzMzllZTAifQ"
+        },
+        {
+          "resource": "repo://tests/integration/session-syncer.test.ts#L220-L266",
+          "version": "repo-lines-v1:sha256:3404b88679dd28a3b017fd319ce61cf566c82682fcba7a95d9afe63acc7094d7:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJlYjdiODgxMWI3ZjUyMDBjODgxOTNmZDkyODM0MDM5NGZiOWFmOGE3MmQyZTUzNzRkZjE0MzAwYzdmMmZhNDkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMzNTNjMzcxYmY4M2UwMTQ5N2M2MzRmODRiMGRiMTY5Mzc1ODNmMWMzYWU5YzhkYmY4YzU5ZGNjYmVmMjcwODkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZlNzQyNTM3YWU3MTBjZmYxMThiYWZkNTU5YmNhNjI4OGY1MjJkY2M4MzBhNzRiZDM4ZDJjZDMyMWJjYTIwZmUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImMzNDU0ZjA4NTZkZWI2NGRiMjg3YTUyZmNlOTM5YjdhY2IyYmE2ZDJhNzg5Y2IzM2QzY2QxMGU4M2QxYzk2YjgifQ"
+        },
+        {
+          "resource": "repo://tests/integration/session-syncer.test.ts#L27-L46",
+          "version": "repo-lines-v1:sha256:031dcc03e98523df83f4f3a2a2a76494f80e67049a189bdb3efa5c233005244f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjlhYTQyYjU3OWIwNTA5NWE2MjMyNmNkZWFjYzE3YzgwM2MzMjk4YjcwMDhmZGE0NzgyNDkyOGQ0YTdkZGI4NTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjViNzQxZDJjMDhlNmY1MTBiN2U5YTI2NGYzNzhmOWNlMDA0OWE1MDRlMGU3ZWY1ZDY3Y2QzZWE4MTNmODU0NzQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE5ZjM2ODk1NTgxYWYzYTk2Njk4MzU1Nzc3ZGJmZGI5NjU3MGVjMDJiYmNiZTY1MzZhNzM2ODk5Nzk2MTkzNjAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI1ZDhkMGRhNTg2MDg4NjQzOGMxZGY4M2MwZDVmMGE1NzhhOGNhYmQ5Yjk1YWY1ODVhYWM3NjU2YjE5ODJkYTAifQ"
+        },
+        {
+          "resource": "repo://tests/integration/session-syncer.test.ts#L319-L358",
+          "version": "repo-lines-v1:sha256:b2b09069fa555a03ad25c6f9cc255209324eeb0e7aff209445eb6f9a6687a8f4:eyJzZWxlY3RlZExpbmVDb3VudCI6NDAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVmMmI5ZDkzMjdjNDlmNmJjYTA1ZjJkY2VkZGU3YjBlYjVkZDlmMjFiNDkxZDFjZWVjMjA2MmY4ZGIxZDM1OTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIyNzkwNTFkZDA5MDhkYzQxNmVlNWQwMDIzNDkwMGFjYTkxZmJiZDM0OWZiZWZiMzMxY2U1ODhiMjBiMjgyMDgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjUzZmIzMGFiMzM4ZDhhZGEyNDA5YWY1NzdhYTA3ODkwNDZlMTA1NmYwY2Y0OTE3ZGQ0ZjhjNzdiMTg5Zjk5ZmMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7282164aadc94cb4a80c4d92828bad81",
+      "statement": "Desktop compatibility tests protect both configuration ownership and client traffic: Codex tests cover environment path resolution, backups, TOML preservation, discovery and marker-write ordering; VS Code BYOK tests exercise its supported-model matrix through an in-process proxy and assert credential stripping, normalized requests, and encrypted-reasoning recovery after replay rejection.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts#L140-L180",
+          "version": "repo-lines-v1:sha256:0c7dd594f4431fac8c2dd02145ffe8d58407de3e972374b5ac17216320b4bd1f:eyJzZWxlY3RlZExpbmVDb3VudCI6NDEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMxNzIwM2QyYjM2MjBmN2U4MGIyMTI2OTFiNTNhY2I0NDcwMzQyZGQ1MDc0ZWZjNjAxNGZkYTA0ODJhYTQzZmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjIzOGIzMjJjNTI2N2NhZjU5MmUxN2EzMTRkNGY1ZDg1ZGFlOWE1YTA4N2M3OTQxMzNhODY4YTdiMGY3NDczNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI3NzlkMTE4ZDZlM2NiZjQ1MDUzOTc0OGRlZTdhNDMwN2FjYmU2NDQ2Y2JhMjk3ZjI3NjBmYTVkMGJiYTFiYzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjBjMTA1NDU5NjJhYjUyMGFkY2M3YWRiODMzNTk5YzFiYjAyODcwNWU2OTYyM2IwOGY0NTM5ZWVjYjhkMjZhYzQifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts#L9-L137",
+          "version": "repo-lines-v1:sha256:fc387de5b70686af675f0148bdeaf3d289547f3b96bba6e8ac861ee1033d56d5:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJkMTc5ZTI5ZWVmOWE5ODJiYTVmNTViN2NhMDAyYWQ3OTQzMWI0YTRmODdhYmJhNWQzMzgzMWMwZTYxY2E5MjVhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwZmE0Y2QzZDBhZDVkNGYyODRjYTc3ZDIyMmRhMmQyMzk1MGI3OTg3ZGVhNzVhNDEwZDVhODJjZGU4MDcwNmQ1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0N2YzMDYyNmNiZGZlNjc1MjM5ZjcxMWQ3ZTcxNTZhZGE5MTYxYTdjZDc2MjVjZmViZWJhMmVjNTVlYzM3OWZhIn0"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/__tests__/vscode-request-normalizer.plugin.test.ts#L72-L200",
+          "version": "repo-lines-v1:sha256:2571b379bf54b1b15da2e7b6e18dbc9c0bc1a3a68cde95165f9118dbcfb06f59:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhN2JlZWQ5ZWZhMzRkMDlhYTMwYTg1NmNlMTI1NGI4Y2ZlNmVkYjVlMTE2MGU5ODc4ZDM3YTdiYmE1ZmQ3ZDgwIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyMmQxMWNhZjQzZTk3ZWYzNjllNmJlZWQxYTI2OGJkMDU4MzhmMjliOWRkMjU0YmY2OWJhNjQ4ODQxNDcyMzRhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlZTZiOWMyYzJjZmQwZjlhYzE4NTZlYmEwMGM2NzJhM2JiOWM3MWRlMDIwMTg1ZmQ3YzUxNjJjNjMzOGIxODA4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MiwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkODE3ZmJiNzNjOTJiMzZkNWU0ODk2ZmY1MWMxYjU4ZWVjMzMwYmJlOTYxYmEwNWZjNjIwNWY4NjdlYTFiY2Y2In0"
+        },
+        {
+          "resource": "repo://tests/integration/vscode-byok.test.ts#L159-L201",
+          "version": "repo-lines-v1:sha256:23fe44f14c6d9eae4f8dae40b9337962c35bb64fdf488e8f16045e12ef4a56a3:eyJzZWxlY3RlZExpbmVDb3VudCI6NDMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQzZjQ2Mjc5OTdhNTRjZWRkN2Y0MThmMmI1Nzc5MzdjYmQxN2MxNzZmMjIzZDE5ZWNhNDMzZDBmOWZkYzFmMTEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNlNzc5ZmNmZjE5ZWZiNzllMjExMzg3OGE1Yjg5NDgwMmQzZTNkY2I0NWQ5ZDRiMGVlYTlmOGVhNGJmMjQ3NWUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZhNDEyMzM3N2U5YjU5ODZhY2M1MDlkNmVkYmY3MjI3YWZjZmY5ODhkODg0ZWZiNWY4ZTY4ZWNjOTg3MTZhZGEifQ"
+        },
+        {
+          "resource": "repo://tests/integration/vscode-byok.test.ts#L203-L278",
+          "version": "repo-lines-v1:sha256:052cbfbf4b9de9f3163608129877ae31fe5f1599f2343c41bb3b7edfa16cd652:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk5ZmNhZTM5Mzk2MWE2MGVhYTg5NzBhZTFmZjZkNzI0MWMyYWRhZTA4NmI3NDAyYjIwNjg3YTkyYTk3NjI1NjIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU5ZjI4NTY0ZTM3ZTliZTY2YzI3ZWMyYWEwMjg3ZTg1NTExMWI3NTFhNGU4MjRkYzljYWExYWJjMDk3Mjk2YTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImE3NTNjNzhhMDk3MWM2YWU3YWZhMzNlMDg5NzkwMGQxNzJjMmM4YTMzYjc0YWIwMGJkZDAyNmE3MDBkNjM3OTIifQ"
+        },
+        {
+          "resource": "repo://tests/integration/vscode-byok.test.ts#L355-L428",
+          "version": "repo-lines-v1:sha256:714c2b76efc467d11cb74f6a60562718dc771bc5d43365f0f2323a911eebba32:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA4NDZlMWNlZWUzNzNmNjkxZjEyYWQ5OThmOTAwZmI0NTJhOTQ3ZDU5YTZlZjkwMWE1NGU1OTVjNWRlN2M5NzciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNhM2U0NmY5NDI3NmI2ZjZmNGVkMWYwMmFmNzhiZWY2YTJlZTFjNDM5ZGQ1NTg0Yjk3Mzk0ODMxMzIxNGQyYjciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU2ZDM5MjQzNjdhMzUxYjU5OGU5NmJiZTZkOGE5NDljYzE2NGZkNmU3NDFiOGI4NDkzZTkzY2EwOWJiZGU5OGEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/workflows/agent-launch-and-session-telemetry.json
+++ b/openwiki/.claims/workflows/agent-launch-and-session-telemetry.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:e2fbbe521e00202d5ba81ea02da41e8199241e287e03d4c4d229d8d5278831f6",
+  "claims": [
+    {
+      "id": "claim_f52ed439c61049c5a463830a310fd93e",
+      "statement": "AgentCLI resolves profile and CLI configuration, validates installation/authentication/compatibility, exports provider environment overrides, and passes them with collected arguments to the selected adapter; its `--no-analytics-report` option sets `CODEMIE_SESSION_ANALYTICS_REPORT=0`.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L158-L202",
+          "version": "repo-lines-v1:sha256:9be943e1d33b37f734cf60830a42ff0e239340b365e74f722b81fd2c0e205a60:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMwNWJjOGVjMDI0OTA0ZjhlOTUxMmUwMDUwYzdjNzE4OTc4YTJjZDI3OGQxZWNhYmMzMjIxYzQ2MzQ4ZjA2MWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxN2FmMTEwMWM5N2I3YzJmNTI1NDA3ODJlNjM0Y2M0NDQwZjBlOTcwMzQxZTUyZjk3NTIzMTFkNzhiN2Q3ZDAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI5NmM2YWI3MDE3NTFhOWY0NzE4YzJiZmVjNTlmMTgyMTVhZDM1NTNmMGNiMTJjOTUwMGY1MWE5MWI3MzcwMmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg0YzEwZjVjMWNkYWY4N2YwMjYyNDEzOTQ1YTBjY2JjZjJmNTkwZjNmM2IzZjk1MDQxOTk3ZjkwYjAwYmNjYjYifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L258-L374",
+          "version": "repo-lines-v1:sha256:9400af6d93970b74ddfc13c779436de62e176f8ced22cd0fcdee490e2875a69d:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2NzQ3NmU4NTYzZWYwNjk2ZjllOTA4NzRhZjU3YTZiOTM5MzJmMmUyNDVjYzJiNWJhODk1YzRkMzI1MjIyZTk3IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI5MGQyY2RjNzg1OWMxOTg2YTRjMGY3MjBkOTc3YWRkMGZhZmEyZTVlMDJmOWMyN2E2MjdjOWY3MjA0NDRkMTVjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhZTU0YThjMWYyYmU4NjgxZjFhNjhjMTc3YjliMDk2ODQwN2M5ODgxYzUwYTBlZGUzMDhiYzMyYmJkMGVkN2ZmIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhMGVhYTgzOTMzZGFkMjlmNDRlYzNlNzc1MDFlNGYyNTNlYWZhMzA5MTdkNTU2YzgyNDI5NmJlMjQwZjQyMWUyIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L450-L470",
+          "version": "repo-lines-v1:sha256:bdbb9d652e84bdbe8feb9b328c19ad9e7b971e16968c684224902181fd0f37ed:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA3NGM0ODFjNmI3ODRhOTk5OTkwN2Q5NDBmMmFmZTcxM2IwMzQ1MTA3NjExM2I0N2FlOGZkNjhhYjI0NjNlN2EiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk1M2JiNDFhZjFhYzY0MWE4ZjY2NWIwN2UzZTY5MGExZmNmYmFkNjdjOTZlZGViYWE3ZWE2ZmUyYzBlMmEzM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjAxMzQxZDBjNTg4MmU5MWE2NmM2MGNiODYwMjBiMjQ3ZjBhZmMzMzZjZGY3NmMwYWUxOGJjZDIwYWM4ZmUxZDUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8aba53c91c874be5841e7a4ba7622301",
+      "statement": "BaseAgentAdapter creates a UUID as the source-of-truth CodeMie session ID before proxy setup, propagates it along with one-time repository/branch detection through the environment, and initializes logger session context.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L518-L557",
+          "version": "repo-lines-v1:sha256:7233fe0cbc097f48f7a45478ec30a5f3f7a077c890eaee4313f8bb0c5f577693:eyJzZWxlY3RlZExpbmVDb3VudCI6NDAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI0ZGMxNDgzNWUwMzhiNzA3MWU4MWFkOGRjOTEwM2FlZjVmYmY3NTlmNjNhNmJhYTUxYmEzNDM2MmNlMTA1MTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg5OWFkYjZkODU2NTIwNTExZWRjM2I4NDI2Y2MzOTQ2NTE4NTdjZjA1NjJmZmRmY2Q2ZGY2MDNjOWQzODYyMGQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA0YjlhMGIxNmI5OTEwYmFhNWQwYTRkY2FmZjhhNjBjNDI5NjMzYmYyYWUzY2JhY2M4MjAyOTA3NTgwZDEwY2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNmNTExZDZhNTAyMjA1YTY1ZDFkN2ZjYjU3NTY2YTcwOWM0NTYwNWI3ODI5MDE2NDY1ZDQ4Y2U0NjRmOGUyM2UifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9eb02badb5b9471cbaf5b76d75a94d0b",
+      "statement": "The adapter only routes through CodeMieProxy for SSO or JWT authentication when agent metadata enables it; the proxy receives session and repository context, and its local URL replaces the child base URL while the child API key becomes `proxy-handled`.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L1020-L1040",
+          "version": "repo-lines-v1:sha256:e8cbd49cc589643e3f11acfbf2915df360159f98b4d81933eb28daf91b911eb6:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxNDE3ZDQ2ZjlkMTI3NDdmZDBmMjA3NTJjZDdiNDU4NjdkZjZjYzkyZjE3NWVhOTZkNjYyNmM5MDYwYjNkNjciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjlkYmZkNWM0NGIxMTI2NGNiZmZhYjgyZmFlNGRlZWNiZjljNzZkMDU1MDNlNDJiYWE1OTMyYzg0NzcxNjAxODgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L939-L1013",
+          "version": "repo-lines-v1:sha256:36858783aa8d099c671f8a0b26835f4f2f342c1bc3fbf55a679800a6ec083620:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE1ZWQ4YjU4MDMyOTI1MjQ5MGE1MDYyNGU5YzBhOTRmOGUzNmJmMWEyNGJiYzI0MTU2NjllMzBkYjBhMGUxNjAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFkOWUxMjU0NjQyNTU3NmQzZGVhZThjOWI5ZGJmMTI4ZDVkNmRkYWY1ZDdmZTg1NzkzNDkyN2RlZmZhM2I5ZGQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_5ffb68bc13c740c1aca868a1f21c89b9",
+      "statement": "Lifecycle hook resolution composes provider wildcard and agent-specific hooks in that order, falls back to agent lifecycle hooks, and the adapter executes start, environment/argument preparation, session-end, and after-run phases around agent execution.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L556-L625",
+          "version": "repo-lines-v1:sha256:515eff23f71ef2591d4e2d408fb90067f45ce9d0c54bed6e0f86ea0a81b73d3b:eyJzZWxlY3RlZExpbmVDb3VudCI6NzAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjA4YThiZGRjNGE4OWI2MjlkYzU2MmIxOTYzMzM2ZDhkZTA1Njc0NjgxNzZiOWU2MzU1ZWNhNWM4ZTVlZGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUyZTJiN2FlYmMyM2FkNjA1YWQxMjUwMzFkZjFhZDE5NDc3YzkyODIxOTE2ZmY0MzZlMjA0NWNmZTk0YzAyZTkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjdlZWE3YTU2YzgxY2Q2ZGEyNjkwOTkzNWU0ZWRiZTNmMjRmODJjNWNiZjczZTYzZTE3M2NhMDY5NTBjYTdlYTciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ2MzMwNmE2MGY0Yzk5ZWJiMGMwZWY0YTBmYmQzY2I1NTI1NGNkOGU3ODAyOTUyOWQyYzI0YWQ2OTg4MjM3ZmYifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L141-L190",
+          "version": "repo-lines-v1:sha256:b14e1815d866a814a7785176c42dd45f8819029319394240092fd5dadae6d502:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM3ZjUwZjE3MTc4NThhZGY2Y2IwMTUyNmRlMWY0MzgzYjFlNmVlMTliYWI1ZGY2M2ZlZmZjODBjNmVmNDRjOGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMyZjg5OTYxMjhkNmVlODQ4ODI0YzZmNzRjOTJmYjJjY2MyZjNkZmI5MjlkZDhhZTZiNDBjMTQzNmQzN2JjOGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBlZjc0ZjRiMTYyMmIzMjc5MzIyYzc0OTY0NmY4NzlhM2MzMzFlOTFkMWRjNDZlZjkwN2MxODNhMzY0OWI3NzciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L205-L279",
+          "version": "repo-lines-v1:sha256:0c2b8d5987c7bc376a036bf291b47ab62437ab1eb82740c08ca54afe8cebfadc:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI2ZTM0ZDcyNmMyMzRhMDk2ZTM1MjQzNTExNGIzM2ZjNmJmNWQyYjdmZjdiMzgxMTg4NDVmYTdhZDhiODlmNjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjlmOWYzMTk0YWRiOTk5ZWIxMWFjMTM2YjJhMzEyODhmM2JkODFjYmQxMTY1YzBkNjk4YmVkOGY0NGRiMWYyMTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/lifecycle-helpers.ts#L51-L127",
+          "version": "repo-lines-v1:sha256:3a4504b2390e3eb93e3f2b9c7882582a53a2315b1f60c3adb14da629399151bc:eyJzZWxlY3RlZExpbmVDb3VudCI6NzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjYyMWFjZWUzMGEyYjQwOWM2Mzg1MjZlNWZmNjdhNTk0OGIzMzdhNjEyNDI3Mjk2NWQ2YjhlZjExYjkzMzI3M2UiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjljNjNjNzUxNjYxZTczZTNlZmU1ZTUyYjc3YjIwMTBlYmY5MTBhMGU3MDVlOWU2YmQxYzdkYTU1ZmJjZDA4ZjkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b5f89c4855fe437f80f2adc1c37e3ec6",
+      "statement": "The adapter protects proxy cleanup across built-in-handler errors, child spawn errors, normal/nonzero exits, and signals; session-end hook failures are non-blocking, child exit gets a proxy grace period, and registered signal handlers are removed after termination.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L699-L753",
+          "version": "repo-lines-v1:sha256:8fbfab3ae1cd29d304cc3dd30be6e66126c1154aa968ae85bd50d6299169ee23:eyJzZWxlY3RlZExpbmVDb3VudCI6NTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA5OTUxYTdmMGZlMWQ3MjJkZDk4MzEwYjAwZWNlZWYwYTVlYmNlOWRiOGQ0MTVhNjNjNmIwYjllOWE0ODhkMmMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNjJmNjBkODU5MGE1NzljZjQ2ZjhkNjczNzhjNGM1NzJiOTYyY2VjY2RiOTBjN2E1ZjdiNDJiOTYwNzgyYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMyZWYwZWYwODA0Zjc5N2RlZjBmNTIzNTQzMjNlY2NmYTY5YWI2NzBiNzk0ZWIwODNlMTQzMDg1OWYxNTgxYjQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ0MWM4YTc1YzM5YzE2Zjc3MzEzMmY3NjQ2NGE1N2I3MDMzNWUzYjc1OTU4OWZiMmRlNDk5Mzk1OTJkZjY0NjkifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L836-L925",
+          "version": "repo-lines-v1:sha256:bae586c7d5623c1d31df55a751347618dd3bc702a35ff7ba013d4fa08050ce1e:eyJzZWxlY3RlZExpbmVDb3VudCI6OTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxYzc0NTIwMmYzMjIxN2RlOTBlZDM3MGY4ZTk0YzVjNTQ1ZjFkZWFlNzNmN2QyZjcyZDViZmVlYzAxOTE4OTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjcxN2FmMTEwMWM5N2I3YzJmNTI1NDA3ODJlNjM0Y2M0NDQwZjBlOTcwMzQxZTUyZjk3NTIzMTFkNzhiN2Q3ZDAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMxNTBlMGQwOWMxY2I3YjVjOWU2YWU5ZGUxMDQxZDA1MGQ2OThmZjc1ZjFiMzFiZGRiNjgxN2Y2YjE4YTFlYWIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImM1YWZiOTBkNTVhMDdlMWZkOGE4MzAwOGMxOWNhZWQ2YmJjZTk5ZGJiN2JhNDM2NzBmOTNhMmFhMThhYjFjYmUifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L926-L935",
+          "version": "repo-lines-v1:sha256:41ea05eb47d900293d8e15f489387889c560abb523c6cf56dd32aeeeffa78773:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA4ZGI3NDYwODE4MmNiN2NhNGQ5ZmJhNDlhMzk0OTlhN2YzOTA3YjRlYTAzM2IxNDkyYWQ1Y2YwYmVlZWVjZWQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjcyNmVmNThjNmM1ZTdhYzM2OWJmNWUyZTJkODM3OWJhODJkNzE2NmI5NzM5YzVkNjE1NzlkNTZjNzhiNzQ5NGYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_50d6ffc7134e45c68aecda9177cd2b6a",
+      "statement": "SessionStore persists one JSON record per CodeMie session under `~/.codemie/sessions`, falls back to `completed_` records during final-sync races, and guards activity timing from double-starts or accumulation with no active period.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/session/SessionStore.ts#L1-L75",
+          "version": "repo-lines-v1:sha256:3a1c09f68d33cb4b3dce4baf97ae3fd5cea6667776476599e400c326601f5c97:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/session/SessionStore.ts#L142-L198",
+          "version": "repo-lines-v1:sha256:715b2ca215eaf3c86afd5d7201f10da04fb3c5cec6027f575efa80e9a3e47769:eyJzZWxlY3RlZExpbmVDb3VudCI6NTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUwNTRhYzM5ZGEwMjRiMmVlMzFhMWFjYTFiYmNhYjU4YWFkYjI1ODYzOWNhMjYzYjNhNWVjNjJiMjM1MjhlOTQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/session/types.ts#L125-L158",
+          "version": "repo-lines-v1:sha256:6cac12a0433c2078f2892fa292cf4ad60984b4f22170bf02751d73652fbea92d:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFlOWI0NThkYTA0YmQ1NjQ0NmYzNGU4YmFhMzk0YjgzNTc5M2NlMmU2ZWM5YTFiYmQxMGI4MDA5NDE0OWEyN2MiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM4ODFmMGI3MDkyOWJlZjBiMjlmZGQ5NGFjMDBmZmNlZjA5OWQ5MTE5MjE4NDg1NzA5YjQwNTM5NzhjODVkMDgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_82ee04cfc629462b910d9475cda10383",
+      "statement": "Hook processing creates correlated session records from native SessionStart events, preserves active state on re-entry, processes transcript paths incrementally through the registered agent SessionAdapter, and on SessionEnd transforms and syncs before sending end metrics, completing status, and renaming files.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L1102-L1175",
+          "version": "repo-lines-v1:sha256:a87d530d8e0c663442e34cbbe0cee28b803f3fa78e4b9920fde49bd315bdbd71:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjdiYzgyYTI3ZThjOGI3OWFkYmQzYTI4NmQzZjY1MWJlMDc5NzFhODgyYmYwYzViNmY4N2MxZWM4Y2NmZGMzZGUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L167-L229",
+          "version": "repo-lines-v1:sha256:b87e1a3c7221042f4914037c4dff9c817783e2e04bbf21c02cac68d971e04cf4:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5ZjkzMDgzYzE5NzEyMWI5ODI3MDBiYThhZmFiZDE3MjJjZjFkM2U3NDA0NTA5ZTgwZWZhMjcyNDdmNjJmMDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNlODc2NWQ2NGJlNDI0MjMxOWUzYmZlNzBiYzgxZjZmMGFlYmM4MTg2ZWEzNWRmYjg5ODgzMzlkODFkMGZjYzEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L293-L377",
+          "version": "repo-lines-v1:sha256:dfee3e710dfb3c0d58f40412d0cc500294ffc27b1dd3aa05f773159570ed4e43:eyJzZWxlY3RlZExpbmVDb3VudCI6ODUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU5M2M0Mjk0MWI2MWI3ZDE2MmI4OThiZTgyZjZmYjIzZmJjMGVmNjc4YzcxMjZlYzA1YmZhOTc3Nzg0M2NhZGUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ3ZDlmNDQxYWM1NDE0YThlYTU2NjI3MGNlZDQ2Y2U3NWE4Y2MyYjg4ZjU1NWM3Y2NjMjJkODk4NDI5NDA3MWQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L784-L887",
+          "version": "repo-lines-v1:sha256:cccec9aa12df91582dd7239c6bca88c8a007742190e7657a22c9441e84934e58:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI1OTBjNTg3OWIxYTkxZDVjZGQ5NzYyNWMzMjk0NjJkNWU0MTUwYTBmZTlkMDlmNjIwNWE5OWFhZDQ4OTM4ZTY1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4NGU0MjA4Y2Q2ZmZiOGM0YTM1NDdiMmY1NGFkYTE5OTc4YzNmMzY1ZTc4Zjk1MDJlZjUxNDVjZGQyYWE4NTQzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmN2JjMTZjNjlhYzYxYzM5ZTFiOTA4YzMyOGEwZTg3YjcyYzVkNWNlOTM2N2JkMjRiN2ZlNWUxMGFkMGUyMTIwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI2ZmM1NWIzMWFhMjQ4NmU0YTQyMGNjYmUxOTIzOTI3MDdmYzQ0ZWYxMGVmYWMxOWI4MDRmM2MzYzBhZWE5Y2Q2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_11939287a78540dda95abef197b9d71c",
+      "statement": "A confirmed external resume is persisted as `external-resume` and is excluded from transcript ownership markers, lifecycle metrics, and centralized metric/conversation synchronization; the persisted origin decides when present and the environment is a fail-closed fallback.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L376-L445",
+          "version": "repo-lines-v1:sha256:bc869fea9acd5c41041309b06858eda6c81d4a17f80da5faa798eab4538d463f:eyJzZWxlY3RlZExpbmVDb3VudCI6NzAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBhNWU4MjgwMmFlZjRlZTMzNjQwNzc4M2QyYjA0MzA4MzhiZDlmMTNiYjkyNTU4NjAxODMyOGI1YzIxMjc5NWUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyMTg4MTU2YzYyNDNiZGM1NGU3ZWMzOTk1ZWU1OGMxYTFkNzdkN2QyOTY0OGRkMTliMGM3MjQ0OGIzNTQ1MzYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjczMGY5ZTUyNDAzNTUwZDlmMzEyOTBjMjgyY2Y0ZmYyOTRkNWI1YTljNmYwNzU1NmM1N2UwYTIyMTg1Y2Q0NmIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY0OTllODhhNDBmMjhhOTYxOTg2OTUyOWEzZDZlYmZiZWM5YzMzMTcwOGQ0ODIwOTUyNjQwOWFkMGM0Zjg3MzcifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/session/session-origin-audit.ts#L11-L27",
+          "version": "repo-lines-v1:sha256:52aa71f3beb5a9115adda3b20bb98de20e2ab85c646a1c5ffea3f245f8fff373:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjBhNDg1OGFkODE1NTc2YTBmNjI4NzVlN2EyYTQ5MDdhNWQ1MzU4YzQxMzBjNmVmZjhmYzYwNmM5NzJkZjQwNDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjE1MmI4NDcwZjc4MmIyYTQ5NWMxYjE3NjVjYWFkNzcyNmY0MDE2MTM1YjgyYjI2NTc5MTliMDUxMjk4NmZjNGIifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/session/session-origin-audit.ts#L62-L126",
+          "version": "repo-lines-v1:sha256:a52d809fcf7be939e420b20cd1ce337e79896d9b4e1bba77f70f9111c7049554:eyJzZWxlY3RlZExpbmVDb3VudCI6NjUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMxMmI0MzFkOTg5MWJiMDRmZGRjYWQ1ZjY3ZWZmZTE1NjczMjQ3MGZjZmUwMWMwMDE4OWE4OTAzYWZmOThjZTkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImMzMGYwOTk2Y2Y1NzEzZWQ3YTZiMTUyMDVlN2M4ZDVhOGQ4MTFmMGRkMmJlYWNjNjZhYTc2MDc0YTE3NjZmNjQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/__tests__/hook.session-origin.test.ts#L69-L173",
+          "version": "repo-lines-v1:sha256:542abe2e241580c2e6aa16f72cdaac5412c596b6d80385b0e86218ac038065d0:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA1LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2MGFjMDhlNzljOThlZWNmMjk0YzBiZjZmNzlhMTYxM2U0ZjNjMzUxMjRmZGQ4ZGNmYWJmNWYyZDZlODBkNjhkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzYTNlNDZmOTQyNzZiNmY2ZjRlZDFmMDJhZjc4YmVmNmEyZWUxYzQzOWRkNTU4NGI5NzM5NDgzMTMyMTRkMmI3IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJlZTZiOWMyYzJjZmQwZjlhYzE4NTZlYmEwMGM2NzJhM2JiOWM3MWRlMDIwMTg1ZmQ3YzUxNjJjNjMzOGIxODA4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNmY1YjQwYjE1ODQ1N2QxNzg2NGYyMTc5MDc4NmRkNWEyZWNkYjY0YjY2YTY1MWY3ODhkNGUyNWNkMzMwM2QyIn0"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/session/SessionSyncer.ts#L85-L121",
+          "version": "repo-lines-v1:sha256:932746ced92afbdc8a5f81d0082e79cd6ee14c4c87c8b5023161465b563bc5b1:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgwZTVjNDQ3N2I3NzU0MWNhZDk4YmE3YTVjNjQ2MzM0M2I0YjExZTY2MzI3Nzg5YjJmY2Y3YzAxYmY2ZGE4MzAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjliNjJmNjBkODU5MGE1NzljZjQ2ZjhkNjczNzhjNGM1NzJiOTYyY2VjY2RiOTBjN2E1ZjdiNDJiOTYwNzgyYTQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc1ZmFhODQzYjRmOGNmNTdmZGVmOWFkY2NiNmZlNDI3N2E1YjA2NWMzMDYzZDAzMDJkZThmZmM1YzNmZjdiZmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjMzY2NmYWJjYWE1NGQ2MWE0NzcxYThjYjc5ZTY1MTU1ZDJmNDJiYWNlYTNlNWFlZDk2MGIyZTBhYzhjZGY0OTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9302f687580247d6a32d06b5e519d5a5",
+      "statement": "SessionSyncer requires stored matched correlation, runs metrics and conversation sync processors in priority order against pending JSONL, continues collecting per-processor failures, and persists combined synchronization updates once.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/session/SessionSyncer.ts#L123-L218",
+          "version": "repo-lines-v1:sha256:9f2f4f15c0c24e25e64c8b1641fd247dd4aeff4b56a581303477b2c13b62dcda:eyJzZWxlY3RlZExpbmVDb3VudCI6OTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY4OTNhZTc5MjExZTc2NzhjNTE2NWM4ZDc3NDAxNDM0ZTY1ZjQyYzYwZTAwNTg1MDJjYzM0MzA5NTg4Zjg1MjQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkOWM1MTIyYTgxZmU2ZTE5M2VlNTAzODUzMmU0OTliMmVkZDgxMmIxYTEzZDE1MDM1ZTA1YzJiMTE5ZTBhMmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmNzM5YTA2YzFjYmIxMjQ0ZTMzNjNkMzhiY2Y5ZmE1MGNlODRmZWQzOTljMjE5M2EzYzdmMDhkNTk5MThiMmEifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/session/SessionSyncer.ts#L32-L75",
+          "version": "repo-lines-v1:sha256:c2a5f61cdb8525ec644b17bb7ff0671d44a444cbd28007425b0c1791570ef759:eyJzZWxlY3RlZExpbmVDb3VudCI6NDQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM3NDY5ZGQyNzU1NTcxZjMzN2IwNTAzYmRiYzQ0YjQ2MzEyY2Y3NjE5YmMwYmU0NGFjODRkZjcyYTAxYTM2NWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg3ZDk3YjNiYzk0ZTgxOTk2YWYxNDA2OGY1MmVhMDMyNWEyOTAxNWI4NGRhYTVjNmQwNWJjNjlhZTAyMTYyOGYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjRhMjBkNmZiZGE1MGNjZDcxYWNlYjliMGMwNjhjYzMwYWQ5ZDVhNDI2YzlhYzJmZjI4YjE2MTEwZjBjZmJlYjUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9ca6b1d7a45544a28decaf6f733c7def",
+      "statement": "The SSO session-sync proxy plugin is enabled only with a session ID, SSO credentials, client type, and enabled configuration; it schedules nonconcurrent background sync, and proxy shutdown clears the timer and attempts a final sync.",
+      "evidence": [
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts#L185-L260",
+          "version": "repo-lines-v1:sha256:887bc152615ecde7d73f928b1fd1a88bc42a97298dd41381590bfb3cbc855477:eyJzZWxlY3RlZExpbmVDb3VudCI6NzYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFkYjNlN2NkMGMzYTYyMzA0NzY2ODE2MWQxMDRlOTlkODYyMDljYTNlNzc1NGEyNWIxMTlhNDkwNzg3ODA0MjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI0MjEzN2NhNTk1OTRlOTY3Nzk3ODJmYzFjNjkxYzQ4ZGNhMzExZDFkOGEwNDI0Mjc2MjhkNTFjYjNhMGM5ZWIifQ"
+        },
+        {
+          "resource": "repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts#L37-L123",
+          "version": "repo-lines-v1:sha256:9b7c6f00d476bfaad6ac0900ebcbfc7dd7826a5f9895dc77c1ed9cd675dc3e87:eyJzZWxlY3RlZExpbmVDb3VudCI6ODcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVlZjM5ODgyMzk0NGNlZDZjYWRlNjU1MzJmMWYwYWQyNTkzNWRmNGEyNTgzMzkyYjE1MTMxMjBjMmU2YjNjMTgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImJkNWQyN2IzZGIxZGI2N2JkNWJjYzE3ODczNjYwYzUyNWM4YjRhZDBjNDU4ZjA2ODM2Njk0MDRlMjdlZWIxMTEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQ3N2MyODQ3MDljNjQ1ZGY4NzZhZWIyNDVmMjcyODc5YjQzYjUyNTI1MjAwMjRlNGRkNTM1ZDBmMTMyODUzNTgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_053cbf9a981a436faea7cb628267f31e",
+      "statement": "DesktopTelemetryRuntime polls local adapter discovery, creates or updates CodeMie correlation and runtime checkpoints, processes and syncs discovered records, and finalizes sessions on inactivity or runtime stop with final transcript processing, sync, and end metrics.",
+      "evidence": [
+        {
+          "resource": "repo://src/telemetry/runtime/DesktopTelemetryRuntime.ts#L161-L205",
+          "version": "repo-lines-v1:sha256:559581739de60e95435bbbb7e0b5880a4cbf94a2600540bf97d49d0559deb137:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ2MzQ4NDVhOWMwNmUxNmE3OGMxODlmMmViMjU4OGUwNjgyNjQ3ODM0NWExMzE2M2RmNmRkOTcwZDIyN2FmOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk1MDQxNDMzMjZiZDQ5MGEwNjFmYjgzMzdhMmFiM2ExZWU5NDZmYjFkMmIwODI3YmUwMTMzNzdkYmJmMmY2YWYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImZjMGM2MDI4MmY1YTA4NDdhOGViNTg1YWM1ZWUxNTc0NGMwZjdiZjcxMDJhOTQ2MWIxNGQwNDA0YmM0NTA3MDUifQ"
+        },
+        {
+          "resource": "repo://src/telemetry/runtime/DesktopTelemetryRuntime.ts#L36-L92",
+          "version": "repo-lines-v1:sha256:91ca748f580c1a8945bf6472a357da82557b0f3ae198daaa49960a11479783e3:eyJzZWxlY3RlZExpbmVDb3VudCI6NTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmNjA1OWY2MTEyODMxNzViNjEwZTY3YzA3YzdhZDNmNDI4ZDNiYjBjZTNiNjViZGI2NTdlZjQyYjBmZTFiN2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNjMWMwNDI2ODIzYjA3NWNhYjJiZjZiYzViODc1OTdmZTc5OWE3NjBkYjM0ZTk0OWQ3MWU4YzBmMmZhYWUzOTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY4MGU2NmJhYTNkMjljNjc0NDM1ZmU5NTgyMzk2YzZiMjMzMzBmNjQyZTdjNmI1ZGMxZTA2MTZhYTA0YWM3ZjMifQ"
+        },
+        {
+          "resource": "repo://src/telemetry/runtime/DesktopTelemetryRuntime.ts#L95-L158",
+          "version": "repo-lines-v1:sha256:82c00e5ae24862aa3e2f36cd2cde52c71941d23500bc743f3b9a0fd0912c8bb5:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI5MTEzYmJlMDk5ZWJhOTZhNGZmMDQ2N2Q0MTg0YzQ4YTcyYWZkNzU5NWRkYmM0ZDg5NjIxNDM4ZTUwNjU0NjEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxOWY4MDMyNzE1NmFkNTg0NzAzNzYwODZiZDVlZDc3YjMwY2Y1YzgwYWM5YTJhM2M4Zjc1NjJlOGViYzA0OTMifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_77742d5d0c60466bb519329441857d1f",
+      "statement": "The analytics command uses CodeMie-tracked sessions plus native-agent discovery by default, supports explicitly including unmanaged sessions, filters, export, and report generation; per-session reports are opt-in by agent metadata, kill-switchable, and non-fatal.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/BaseAgentAdapter.ts#L57-L103",
+          "version": "repo-lines-v1:sha256:f1dcc2e50781f20545a8a28de49c0827fddd65095e3bd3c6f1163ab78e10624d:eyJzZWxlY3RlZExpbmVDb3VudCI6NDcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ0MjMzYTUwZGYyOTI4ZDUzOTViYmFlMDEzMjVjNGYzMTdhNDBiMTk5OGU4MzU4NTI2YTZkMGViY2E5ZDU2ZTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEyZjQ4M2I1NjA4N2ExNmFlYzQ3ZTIwMjQxYWYwNzA1Mzk5ZDgwNzY1N2VmZThhMTgwOTI3YzI3ZmM1M2JlMjAifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/analytics/index.ts#L18-L62",
+          "version": "repo-lines-v1:sha256:7cb6a73f01de7a79dda6c7256404d37d5f1edad3f6518e69f76719163151449a:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA4ZTg3NzU2ODA2MTNlZTg0YzUxMDIwY2Y3YzFmZDk4Y2Q4MzljM2I0OWNhMjI2NDRjMjRmMGJhOGY5ZTBjYjMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ1MTJkNDA2MzYyNDkzYjdhMWY4MWJjNDJlNGUxNjA0OGVhYzJjNDQ2ZmIwNWQ0NzU4MDhlZmY2NTVhMmZkMzgiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIwMGQ3YmViYzRmZjExYTMyNTNmZWViZTQ3Nzc1YWI3OTJiZmY2NGY4MmJlMWE5ZmNhZDk2MGVmNTA2MjA2Y2EiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVlYzA1ZjE4ZTNmNDEwMjJjYzdlMzEwMzE4OGUzNmZjMGY1ZTkzZWJjYWUzM2YzNDQyOTNhNTQ1YjhhZWE2ZGIifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/analytics/index.ts#L65-L143",
+          "version": "repo-lines-v1:sha256:b03211cbd5f3fc555ae4192c6b93c22f4dc8a6cb2ad37135388465332b333b19:eyJzZWxlY3RlZExpbmVDb3VudCI6NzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgxOGE3NzE3ZTNhY2NhYTMzY2Y1ZjM5OTQyMDFhNWQyOTcxZGE4MTgyY2I4ZmNlYzY3Y2JkYzRlOTVhYzZlYzQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFlNTFmYmRkY2Q4ZWUxNTFiNDM0NDZhZTU1M2FkYTJkMTQ5ZTBmOTUzNjM2OWVlMDJjMzAwMjg2MjAwNjRlZWYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjYxNGVhOTgxNmI2OThhMjA1YWNlY2M3M2QzZGM4MDg3MDc5MDhlN2I3YjQ1MTg4NjdhYWNhODlhZmI3ZGM5ZjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImNjNWZjMzE2ZjAyMjhjOWI1Y2M0ZmI0NTU4MDYyMjliMmViZjE3ZjI0OGNlM2M1ODNmODljMGFmNWY4MTY3MDcifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/analytics/native-loader.ts#L1-L13",
+          "version": "repo-lines-v1:sha256:0a2fb55d4555963ea8e496596e5f2b8a3e133912fb07faf8227b6c1d646aeb2f:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijk3MmE0MjkzODJiMmUxNDcxOGUwZTM3YjA1NzBhOGExNzAyOTkxZmNkODQ5OGNkODQwNjBhOGJmNGYwNTAxN2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc0MWQwOWJhYTNhZGNiMTVjOTk5ZTJkYjIyZGFmZmFhZjk4M2UzZDIwNDMwMGExZTMxYTY1NDQ1MGVkYmUxMWMifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.claims/workflows/hooks-skills-frameworks-and-automation.json
+++ b/openwiki/.claims/workflows/hooks-skills-frameworks-and-automation.json
@@ -1,0 +1,338 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:ffb67568cd9f45bc4bc42d4da62a43af35e768338040bb48650901c841ef7cd3",
+  "claims": [
+    {
+      "id": "claim_77da99dbd077402e9d776f31e0f12de5",
+      "statement": "The configurable HookExecutor is a distinct hook engine: it accepts a lifecycle-event configuration of command or prompt hooks, builds event/context input, and returns an aggregated decision/context result.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/executor.ts#L45-L112",
+          "version": "repo-lines-v1:sha256:d705915cff4af64841d883d79cc18dba42d63226709bb9cb6d185582a04affb8:eyJzZWxlY3RlZExpbmVDb3VudCI6NjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVkOWI2YzdiNWM2MjhjNTZiYWMxOTI2ZTVkYzA1NjEyMThiZmVhYzYzMmM2ZTNiYzFiN2JkYmJjNDQyYmI5ZmEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUwYjczODBkMjI0NDA2Yjg1ZTM2MDZkNGYwYTdkOGVlNDNmYTViZTE3MTQyNDM5YjM2ZTUwNzY3M2I4YzlhNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImU0MWY1NTU3YjkzODY4NjIyZThjYTI0OTc5YmE5MzBjZWI5ZDhkMWY4OTFlN2M2ZjAwYzVkMDU3NjRhNzk0MzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/types.ts#L95-L197",
+          "version": "repo-lines-v1:sha256:b2444c91db3a874e596e603e97d20ae0609da33290017a7d9f84274b3ff930e3:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI1MTI0M2I2OGZmZjFmNjY1Mjg2ZDc3MGQ3MGVkODY0YzE3OWQ2YjhmNWUzOTQ3MzMwYjQ2YWRjNTU2N2ZiMGY2IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1ZTc2ZDlmM2RiZTdhMzA2MTEwMjYxY2M3ZmY5MjM3OGM0M2RlN2UzOTRjZTUwNDFlMWIxMWY5OGU3YmIyYWEwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_ae5a974a7ef045dcb5bced3548f296ef",
+      "statement": "Tool hooks use literal, wildcard, or anchored-regex matcher selection, whereas UserPromptSubmit, Stop, and SessionStart flatten and execute all hooks configured for their event.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/executor.ts#L165-L188",
+          "version": "repo-lines-v1:sha256:85238a57c24c13e46d5e4c582734e8127dcad5dd800bd208cfb87d2b6f1a99b1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA2YjY4NzRmZTU2MzQxYmEwYWVjMDI2ZmZkNTFhNWRiNTU0YjEyNTc1NjMxNzAxNTQxNzAxZDk3N2Y4ZmY4NzUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhiZDk0NDQyZjFmMDgzNmZjMjViOThlNTIxNDI3YmY1YzQ3YzkzMjhlYmY3YjE5MjNiZTJlMDU1YjFiMDA1OGYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjNhMTIzZDNjYmQ5OWI2MjlkYjU5ZWQ5MDJlODE3YmQ3MTc4Njc5NzIyNDQ2ZmEyOTEyN2VjNGQxZDcwNDQ2NDQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L199-L275",
+          "version": "repo-lines-v1:sha256:5d54bafbfdc11a989ee9f39ce264bd8b3b7ac4ecbc7ee8984c229fbe67ac695d:eyJzZWxlY3RlZExpbmVDb3VudCI6NzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYwYzgzNjYxNDdjYWQ4NjYzNzg3Mjk3NTFiMTMzMjU5NDAxMTA5YzhjMDhiZmU1M2Y4NjZhY2MzNjk4NmExY2IiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhiZDk0NDQyZjFmMDgzNmZjMjViOThlNTIxNDI3YmY1YzQ3YzkzMjhlYmY3YjE5MjNiZTJlMDU1YjFiMDA1OGYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUwYjZjYmJlNjBlMzUzNmM5MmM4NTUwOTVjZjEyMmU3MzAzN2Y3OWM2OGRkMTY2NjNkNzlhN2ZkODE1YmNmMjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L285-L300",
+          "version": "repo-lines-v1:sha256:8c4fd7cbab75a51c1c568df64a319b655c500177da6c757d232adae7564eabac:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjU3YTdiNDQ1MTlhNmNjMjE1NDM4MzNkY2MxOTAwMWUzNzlhMzJjZjBkZWViNDljNDRjM2ZkMTA4Njc1ZjM5ODMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIwZDJlY2U2Y2NkMDhjNjZkZTA0Y2E3NTkxMWIyZjljY2RhZTNmNjE5ZjkyNDQ2YTkwZTRiYjRjZGYzMDJjOGYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg1NGRmZmMyZTgzMzM2N2E5NGNjZmU1OGRjMGVlZTU4MGZiMDczYzQ2NGQ3ZGYwMzhkZThjM2ZjZmM0ODgxYWIifQ"
+        },
+        {
+          "resource": "repo://src/hooks/matcher.ts#L24-L50",
+          "version": "repo-lines-v1:sha256:57dd15fc58456e95592445d9054adaf20a442bf50cbdbba6b82c156482071972:eyJzZWxlY3RlZExpbmVDb3VudCI6MjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjVhYzRhMTZhZGM5NDU3YjU3YmQxMmZmYjYyYmVkNDgyMDY2ZGNjZmI4MTA2MmRkM2Y0NGIxNWQ1ZTAyMWEwNDEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY0ZWZjNDk0MThkMjZkY2YxMjliMjJhNmFhMjExMDhjZWVjMzc2NzdhMzJkMDhlOWQ1ZmVlMzVkZGE2NmJiOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjYwMzE0YWExOWJmM2NkNDVmNzliZWE5MGNhMjI4NWM4YzA1NGE2OTcxMGMwMDE3Mzg1NzEyNjA5YTlmNWZjMjEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_c40a157db5f04b71a016345475e5fb09",
+      "statement": "HookExecutor deduplicates configurations by a SHA-256 hash, runs unique hooks concurrently with Promise.allSettled, and merges their results.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/decision.ts#L125-L209",
+          "version": "repo-lines-v1:sha256:1f7835f64248442b213220f5988c3a989dea2d6500fd4f07d02e705507704dd6:eyJzZWxlY3RlZExpbmVDb3VudCI6ODUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFlNDUyZmZlZDI0YWViNTMwNTVmYmU1MDMwOGUyY2U1MDgzZDY4YzU2MTU3MWM5MjQ0YzdiNjA2YWE4MWFhZTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFlNzUwNmQyZmNkYzE4ZGJjM2E3YTE3MjM0OWQ3OThhOWNmZDRkOTdjNzQ2MjQ3YzNlOGU1Y2E5MzcxZTI0MDMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjhhNjQxMzA4ZmZlZGNkOTgxZTI4Njc2NmFhNzI4YjUxMzJjZTcyYmFlNGNkMWZjMmI1MTViMzFiOGE2ODIzZmYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L309-L377",
+          "version": "repo-lines-v1:sha256:e52275a4262651051e2f6a3f0692474489373289c17c864160d739e066dae762:eyJzZWxlY3RlZExpbmVDb3VudCI6NjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBhMDkzMjc5ZTE5Y2U3OWQ1YzIyMGUxMjExNjlhYTgxZDY0ODZjN2M2YTVkOTcxNDgwODc3ZjQzZGZkMTViNmYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI0MDA5NjgxNTkyMDQxMWYxMGJlZTc1OWEzMWJkMThiMmM4OWVjMzc2NmFmNDBiYWQ4NDg3M2I3Y2NjNTU3MzYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVjMzExMDI4M2ViZDMzMWExMjliNjdlNjBhY2U4MjNiYWY1ZjZkNjZiZmU3ZTljZTY3NjhmNGVlMjY0YWFjYmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_e24f9010fe6349dba7ca3e6543fc1e66",
+      "statement": "Command hooks sanitize tool input/output before serializing them into CODEMIE_HOOK_INPUT, execute in the configured working directory with CODEMIE context variables, and use a 60-second default timeout.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/executor.ts#L25-L28",
+          "version": "repo-lines-v1:sha256:3b940f970649e65352baaf1e0f9a1318d9b63417552a7d14e4a153e2ae21938e:eyJzZWxlY3RlZExpbmVDb3VudCI6NCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZWFmMjJjZjA3MzI1OTJjMjQ3MTQxY2JlNjFlZmExMTAxMjYxMmY1YTMxMjJiOWFmOWJiYWY1MmY1NzI0ZDE5NCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMTAzNDZlOTM1ZDMyOTY3OGI0YWQ2MDQyYjc1MTkwMzBmOWFjZTMzOGExZGZiNmMxYzUxZGI5MWMwNmZmY2U2MyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYTM0MGY4YWM5OGZmNjVhZTM1NjI1NDZmMjc2OGZiNjU2YzRiZTBkZTQxMTIyYzBiMjkxYWYyOWY3MzgwZThhYiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiODI2OGQzNTFlZGJiYTJhNzBjMTc5NzBlNGZjMWVhNGQ0OTk4MGIyMDdlYjljODk0MjNjN2MwMzVhODA3NDcyYyJ9"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L426-L475",
+          "version": "repo-lines-v1:sha256:4285fe6ac37e15d567d07b726a1a10c8559a4766182e0c40128c02dbb1208aab:eyJzZWxlY3RlZExpbmVDb3VudCI6NTAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImNlMTJjY2FhN2M0YmNmZjQyNTI2NjYwMDEzZDY0NGVjZjcwY2IzMGI0N2FkZmJmYWEyNDQzZjM2OWVmYzA5MDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEzMGZlYjk2MmZmOWZlY2IwYmEyYjY3YTFjNDQ0MTIwODY5YWQzNjEyOTM5YzVmZjY3NTVlNjhhOWFmYzk0MzEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjhlMjJiN2JmMTc5NjcwYjE3OWExM2U5MGQyOWNlMTJkMDEyYjg1NmUwNzI4MDRiNWJlYTNkMzg2YzgzNDk0NTAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L508-L525",
+          "version": "repo-lines-v1:sha256:bab4f7d3731e1d890e41575267aa589482e37636f37b7b8328252f4289bb13f4:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVkOWQ4Y2EyYmNhNmJiZDE2YjU5Y2JmNTJiNDM1ZDNlNzY3NjA3MTk4NjQ1Njc0YTdjN2ZiOGMyZTA1NjA2YTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM2MGI4OGEwNWQ1YjUzODQ3NjAyMjliZTYwNTcyZmU2MmIxYzI5Y2RjNTdlZGI1ZTY5NTFkYWE0ZmQ0NmM4MDMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImI0YTE0YTE0ZWQ3Mzk0Y2MwYjE4MmZiOWMzZWM0M2E4ZjIxNTBkZDE0MzQ4OTk0NTk1Zjk2NGM2Y2I3MGIxN2QiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_4766b35ae68846a585da8e19f66ebfed",
+      "statement": "Hook output handling fails open in most failure cases: exit code 2 becomes block feedback, other nonzero exits and non-JSON output allow with context, and decision priority is block over deny over approve over allow.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/decision.ts#L113-L209",
+          "version": "repo-lines-v1:sha256:23764e24d1042deffbd10effb66395fa24f22630778f127194b2621e2ac0b2fd:eyJzZWxlY3RlZExpbmVDb3VudCI6OTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVkOWQ4Y2EyYmNhNmJiZDE2YjU5Y2JmNTJiNDM1ZDNlNzY3NjA3MTk4NjQ1Njc0YTdjN2ZiOGMyZTA1NjA2YTMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFlNzUwNmQyZmNkYzE4ZGJjM2E3YTE3MjM0OWQ3OThhOWNmZDRkOTdjNzQ2MjQ3YzNlOGU1Y2E5MzcxZTI0MDMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ4ZTU2NGE1NTYxMTExNmU0Y2U5N2E1ZjYzMDlmNTJmMDM4ZTBiNzZmNjJkNDQxYTAxYmVkNDNiZWVlOWEwM2MiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/decision.ts#L20-L64",
+          "version": "repo-lines-v1:sha256:4f37cddacf86cb26576bed4ef2656817c53ba276b96e0924480d23901e84db23:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdjM2VkNmIwOTI4YjgxOThiNDJhNTJhYzlhNzQ1ZWIzYjlmYmQ5N2M3MGVlMjg0MzA3NzMyNDE2ZTQ2YzVlZDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY0ZWZjNDk0MThkMjZkY2YxMjliMjJhNmFhMjExMDhjZWVjMzc2NzdhMzJkMDhlOWQ1ZmVlMzVkZGE2NmJiOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNiN2EyNzQxNTdkMWQxNWQ5N2UyZWM3ZWIxZGQ0ZGNmNzZhOWZjMjU0NzAzYjc4YjI4MzRiMzU2MjQ2MGRlZDgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/executor.ts#L387-L416",
+          "version": "repo-lines-v1:sha256:062630c02105ade0b114c67e55fb64989b61ac1f5e7b679b61bfa9a9fc8c67a7:eyJzZWxlY3RlZExpbmVDb3VudCI6MzAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI2YWRhM2RmZjUxNjBlZmQyOTRiMTllYWRmMWY0MTJjNDdhMWY4YWNmYmQwZmQxOGI1ZmU3NGI0YTY4NWM2ZjAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY0ZWZjNDk0MThkMjZkY2YxMjliMjJhNmFhMjExMDhjZWVjMzc2NzdhMzJkMDhlOWQ1ZmVlMzVkZGE2NmJiOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY4M2E3OTg5ZGYxZDUwNTQ1YzU0ZDY3NmUxZWEzMTEyYTIyYzM1ZWEyNzRiNDU4MjRiYjY2OWVkNjk4MzRlZGUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_55c5ec0c74bd4cd4a35c79be782423af",
+      "statement": "Prompt hooks resolve documented input placeholders, invoke a deterministic ChatOpenAI configuration, and fail open when invocation fails or LLM configuration is absent.",
+      "evidence": [
+        {
+          "resource": "repo://src/hooks/executor.ts#L485-L505",
+          "version": "repo-lines-v1:sha256:a10077a5d63e8ecd95ebba7515548fc1c1e5803e3c178081158906151fff51b6:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBmZjQ4YjYyZTU4ZDlkOWYwOWJiZGQwMTdhOTI3NTFiM2E4MmNkOWNiMGVjMzViYWU4YWQxMzY3OWZlMTljMTAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjExYjIzOGMwNWJkNzY3N2I0MDgxZWVmMGZjMWRlODU4OWY1YTM5ZTY5N2U3ZDlhOTlkM2Q5NTZiMzA4NWQ5YzIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjhkZWY4MTNhYWNmMjM1MGFiYzQwOWI2NTIxN2Y2NWExN2FlZmZlNTYwMGRlZGJlZTc5MDczYWU1Yzc1MzNkMmMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        },
+        {
+          "resource": "repo://src/hooks/prompt-executor.ts#L100-L181",
+          "version": "repo-lines-v1:sha256:93a1b0ccf807ec8363fd4399809c6b5002e4b6e362087940b92c337fc19eb131:eyJzZWxlY3RlZExpbmVDb3VudCI6ODIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUzNTRjZWNlMDY1ZTBlNGUwNDhjYzUxYmFkYmViMjhhZDMwZTE4MmJhMjA1YTk1NTE4YTk5MDU3ODRjMWU4OGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY0ZWZjNDk0MThkMjZkY2YxMjliMjJhNmFhMjExMDhjZWVjMzc2NzdhMzJkMDhlOWQ1ZmVlMzVkZGE2NmJiOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2Y2E4MzI5YzdjYWNjNDE4OGFlMDJkMDZhZDIyYTNiNTk2NmYyMmU0YTA5MWNkMTI5MzE5OWVjZTBiMTAzNmQiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQwMzk5NDVmNzEzY2VjY2MyYTJiZTk4MWFiNWM1ZWVhMzdmOTVmOTc2OWU1NzVjZDhlZDlhOWZjYmFmZGYwNmEifQ"
+        },
+        {
+          "resource": "repo://src/hooks/prompt-executor.ts#L42-L90",
+          "version": "repo-lines-v1:sha256:5b8783331a637b26153184f80c4b79b0dee54d3cba91850726e272f6daac7b77:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYzOTExZmE4ZDliMzc2NmI5OTVjZjdiMTc4MDRkMjA5YzBjMDYyZmIwNTRmMDY1ODRjMzgyNDU5NGQzZTQ2NGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY0ZWZjNDk0MThkMjZkY2YxMjliMjJhNmFhMjExMDhjZWVjMzc2NzdhMzJkMDhlOWQ1ZmVlMzVkZGE2NmJiOWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJjNGZmNTI3YTRmOWFhNDFkOTM3NmRlOGYxMWNlYzM2MjU1ZDIwNTUwZGE5ZTVkOGFiY2M4OGQ5NWUwMTRiMzUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk4ZTIyN2VjMzU5NzEyMTlmMGRhMzkxNTExNWQ5NWZjYmFkNWZhYTQzMDQwMjQ3OGY4ZGI2Mjc5MTY2YmQ5YTcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_8c9ad0e1c3f94c48acd553c2e2b2d7cb",
+      "statement": "The codemie hook command is a unified agent-plugin event entrypoint: it reads JSON from stdin, initializes context, lets the registered agent transform the event before validation, normalizes its name, and routes the supported lifecycle events.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L1376-L1448",
+          "version": "repo-lines-v1:sha256:115340304251624eb7225462444f8eb6e778e63931ce1176bf6e2a257a05872d:eyJzZWxlY3RlZExpbmVDb3VudCI6NzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY2YWQxODNiYWMyYWRlOWYxYjIzZTBhNGMxMzc1NDUxOGFlYTk0OTkyNmMzMzg5ZGMyNmNhYzQ0YjI5NTJlMDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc5OGFmYjRlOGFlMzBjNmQ1ZjdlYmFlNmU3M2ZiOTYzZThjZTBkOThhZTJmMDVkOTEzNDhmNTU4Nzg1ODlhZTMifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L1450-L1552",
+          "version": "repo-lines-v1:sha256:f0cd4a0fa53d9b99426fba6a3b1081fba8f1934870089b90e068bc8e895354d7:eyJzZWxlY3RlZExpbmVDb3VudCI6MTAzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJjMDgzMDAyYmZkZThhMGJiMzY4NDdkNWI4N2IwY2NhMzJjMTQzYTdiYmJjMThkOTZkMDgwZDI2YjIwOTBjM2M4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MCwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L607-L738",
+          "version": "repo-lines-v1:sha256:7ab1c6a46c0f4e344e5563fbaf4a6529b4974a38078778d3a21509e9b287d365:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0NDYyNDg1NTJhZjU0ZWE4MzI3ODY1YzdlNzg5NTI2OGNhMTFjODI4OTlhN2VhYjhiY2JjZjE5NzAyNjlmZGE0IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_b56ae04f365e4f74a85bddba1ff356f8",
+      "statement": "At SessionStart the agent hook creates or refreshes correlated session state and non-blockingly syncs skills to Claude; Stop processes transcripts after active-duration accumulation, while SessionEnd performs final processing/sync, updates status, and renames local session artifacts.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L1051-L1176",
+          "version": "repo-lines-v1:sha256:fa3033af04a3abdf2fed8af876e1cd106efd2d9874af32439fa6d3cfddf2dbcb:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjNTFiY2Y3M2JiMTNmMjJjMjQxZGRmOGUxODU1YWFlY2NiYWRhOTFhYzVjYTg0NjdiMDlkZmZjMjA2MWYxOGM5IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmZGQ3ZTAxZDU1ZTQ3ZmE4ZDZmNzU4ODUwZWUyOWI0OGM3ZDhjNTBlNTdjN2NmYmJiMjlmNzcxYTIyYzhhOGJlIn0"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L167-L229",
+          "version": "repo-lines-v1:sha256:b87e1a3c7221042f4914037c4dff9c817783e2e04bbf21c02cac68d971e04cf4:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjA5ZjkzMDgzYzE5NzEyMWI5ODI3MDBiYThhZmFiZDE3MjJjZjFkM2U3NDA0NTA5ZTgwZWZhMjcyNDdmNjJmMDciLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNlODc2NWQ2NGJlNDI0MjMxOWUzYmZlNzBiYzgxZjZmMGFlYmM4MTg2ZWEzNWRmYjg5ODgzMzlkODFkMGZjYzEifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L580-L598",
+          "version": "repo-lines-v1:sha256:5b407038b1ceb75c416e85abfbcae93f1f6f3861d75e5ae8fa8d92a5d831420b:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjA5MmUyYmZjNWFiOTY0YzU3ZWY5MTEzZGQ3NGU5YzJiNjVkNDRmYjZjY2EzMWFkMjEyMDM2M2ZhZjk3NWE1ODMifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L749-L892",
+          "version": "repo-lines-v1:sha256:84d6c468e9805d9791b4cb3d7b6142fbd2e26742c8d46300119b20f5bc11aaae:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQ0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhOWE1NjlhOTZjYWJkYzBkNDhmMDY5OGIyMDVmY2M0YmQzOWQwNDA1ZmVjMzRmYjdhNTQ4MThkODMwYTE0Zjg4IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmNzNmODFiMDFiMjIyM2E3ZDBiNTFhOWQ4ZWZlZGUyNDliZDRlMGFhNjI2N2UzMGVmYzEzYzVkZjA1OWM2MDNlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_37240b9cda224ba79b186574fd6d113b",
+      "statement": "When analytics is configured, UserPromptSubmit checks for valid SSO/API-key authentication and a prior invalid-auth marker; invalid authentication blocks native CLI prompts with exit code 2, while programmatic callers receive an error.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/hook.ts#L494-L578",
+          "version": "repo-lines-v1:sha256:e9554e77d898c7137e424239f1760b8a26a08b6978b2ce595ad2683cb43a2981:eyJzZWxlY3RlZExpbmVDb3VudCI6ODUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZiNTgwZTk2NGY4M2E0NzNmNDNkNDQzODQ2Mjk0OWQ2OGI1NjAwZmRhNzg3ZjE2Mzc0NWQwMGRlODljYmYzNmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAwMjFiMzNiZWFlOTgyZDcyZmMyZGQ2MzljMWQxMzQ0NTBkMzEyNDk0MDZkNzYxMzg3Yjc2YzliYjM2ZTFkZDkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9a1afbdf7d5f4eee90dc219b3eef5855",
+      "statement": "BaseExtensionInstaller provides version-aware extension installation: subclasses define source/target/manifest/critical files, changes use a clean replacement copy and structural JSON verification, and hook-command localization is non-fatal.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/extension/BaseExtensionInstaller.ts#L520-L602",
+          "version": "repo-lines-v1:sha256:1dc20b7c4456dcc7fc36b2fb691928e91de0790b529512196888bfc1372de24b:eyJzZWxlY3RlZExpbmVDb3VudCI6ODMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI1YTgzODQ0ZDlmMDE4NjQ3NzVhNDgzOTFiNzlmODc5MmIzOWI3YWMyZmFiNTIyODNhMDQxNWIyNTgwODMwYjIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY4ZDUxMGZkMTI3NGM4NjM3NTA2NjY3MTZkYTgxZTZkNjJkMjFjMjQzMGZmOWU1ZDk3OWZjODUwYzUyNDVlZDUifQ"
+        },
+        {
+          "resource": "repo://src/agents/core/extension/BaseExtensionInstaller.ts#L618-L779",
+          "version": "repo-lines-v1:sha256:633402000c7c06053b4ba5329b8589f4009748fb5401ae6fb4383eb9e5f4fd32:eyJzZWxlY3RlZExpbmVDb3VudCI6MTYyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJjZDljZDczMDExNDlkYjkzYjg0NDY2OWViZmFmNTE4MDA2MDk0NGE3MmM0NDViODU3MDgxMjhhZDkxZTEzYTg4IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2U1Nzg4ZDVkOWQ3M2QyNGE4MWRiYzBhNWE3NGJmYTgyYzljM2IzYWY5OWU1MmFmNzk2ZTkwYjQ2OGE4YTNkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmYWRmODM1Mzc0MmEwOWQzYzlmZGEwNDc0ZmM0MTc3MmIwNTY0Y2I4Mzc1N2UyZTE2NDYxZTMzZTc5YmVjMmQ2IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/agents/core/extension/BaseExtensionInstaller.ts#L93-L165",
+          "version": "repo-lines-v1:sha256:a46e8cad4450451b6c4aa010d52f385b324a02effeefa427502c5ef6c7ecc063:eyJzZWxlY3RlZExpbmVDb3VudCI6NzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImExYTBiYzdhYTJiNzgzMDZkZjU0YTQzOWJmMmYxOTk4YzVmZDZlNzgyZjMwOWY0NjM3ZTNkZjgwMTMzMDdlMjkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjA0OGU3YTYxMWY0NjIwN2ExYWI0ZGVjMGFhYWRhYjBjMDYzMmQ2NTA5YTE5ZGIxNjNjN2JjMTI0ODBiMjEyZTUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkzNjQzZWM0ODdhMGI0MDRkNzI5OWIyMDYxMjEzM2JlOTEzZDFiZTU2OGU1M2FmMjJjOTAyZTg2MjE4ODU1NzYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5ZTQ2YmEyNDYxYjBjYzk4N2ViYzI3YjBhY2E5ZDQ2YWQ2MDVlNjc5MjUwY2Y4Mjg4MDA2ZDQxZDhlNTljNjgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_91b904c15caf47ca8ec7ae3a8c3efa78",
+      "statement": "Skills are discovered from project, mode-specific, enabled-plugin, and global sources; source priority plus metadata priority determines same-name override and sorted load order, with optional agent and mode filtering.",
+      "evidence": [
+        {
+          "resource": "repo://src/skills/core/SkillDiscovery.ts#L17-L81",
+          "version": "repo-lines-v1:sha256:26ba49e66b628945671a5d0c4387a885f5e2a4bc606ae332e3b6c3a2a90db0fa:eyJzZWxlY3RlZExpbmVDb3VudCI6NjUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFkMmMwOWQ0Y2JlZWM5YjBjMWFkNWRkYWZmOGFhYjhkZTQ1YWFmN2U1ZTgyZmUyNGM5ZjFlNzFlNWFkNTgyNmEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijg2NTkzY2I2MTk3M2QxZDE5YzkwNjRkMDcyNjQyMjRjNzY4N2JiZDZlZWJlNDgyYjJmNmI0MGIxNGU0OTViOTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/skills/core/SkillDiscovery.ts#L263-L325",
+          "version": "repo-lines-v1:sha256:d91f28dbcac6615adee6e9d1481a04a05cf96113a89566327527cb596539ced3:eyJzZWxlY3RlZExpbmVDb3VudCI6NjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEyYjRhMTZiY2U0ZTcxZDAxNzBlZTAyNTY0YjUzOWNkOWE4NmYzY2Y4ZmUzZTUxMGNjMWNkZmVkZTcxZWZhMmUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/skills/core/SkillDiscovery.ts#L84-L142",
+          "version": "repo-lines-v1:sha256:51ef570a4e8d28b4fd8cd5885ae63bfe8800799d6f4ae81ce0018003b272047b:eyJzZWxlY3RlZExpbmVDb3VudCI6NTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY2ZGUyYTRlZTEwOWNmOGYxYmE0MmY2N2FmZDQyNTY0NjFlMjdhNDYyZWQ3NDM3ZDllYWQyMTZmMDFhNDJmYzAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/skills/core/types.ts#L3-L20",
+          "version": "repo-lines-v1:sha256:d8baa21575762ff08d776632ba93397429ca613707f06409b40db88fda84f39b:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2ZjViNDBiMTU4NDU3ZDE3ODY0ZjIxNzkwNzg2ZGQ1YTJlY2RiNjRiNjZhNjUxZjc4OGQ0ZTI1Y2QzMzAzZDIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjoyLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUwMGZkZjRiZjYxNmMwNTdmYmQ5MjhkZDJmYzczNDUxNjU0YTcwNTg1MDMzMzFmZWNmZTZmMjBmMzk1MDBhNWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQwZTdiYjQwZmFiYTY3NzdhMWQxODY2NmUxYjZhN2Y3NjhiMjQ5MjUyOGYwMDJlYzRiNDVjOTQ0YWQwYzkwMWYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_efc6c3e2101b4b2d9e1fe278283bd24c",
+      "statement": "Skill discovery parses and validates SKILL.md frontmatter, excludes malformed files without failing the whole discovery, and caches results by working directory, mode, and agent until reload.",
+      "evidence": [
+        {
+          "resource": "repo://src/skills/core/SkillDiscovery.ts#L175-L260",
+          "version": "repo-lines-v1:sha256:189ec3efc7db4359f9c5849d107744565acece99de7603e226945fa32f9c0572:eyJzZWxlY3RlZExpbmVDb3VudCI6ODYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI1ZTFjOTU0NDE0ZTNmM2VlYThjOGNjYzQ1M2IyMzI0YmE5ODU0NTM3NzA2ZDVkNGVkZTU0NTg5ZTk4MDk1NGYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc5Yzc1NTJiMGNiMTVjYjEzNWRlZThiY2RiODc2MjZjMDZmOGJkMTA2YjBlOWM2ZDU3OTFlYjAzMTI4MjQ0MTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjVhOTI5M2ZkODA1NGI2ZTQ3MjQ4MzczZjM5ZjRkZDc3ODAwMTA1ZWI3NTgzNDg2ODcyNTQyODVjZDEyODJiNzgifQ"
+        },
+        {
+          "resource": "repo://src/skills/core/SkillDiscovery.ts#L328-L350",
+          "version": "repo-lines-v1:sha256:29c2f1528b172731b8c8b9a32e889f796bc45a1b6ace8da10e1bdde96fa58305:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFkOWUxMjU0NjQyNTU3NmQzZGVhZThjOWI5ZGJmMTI4ZDVkNmRkYWY1ZDdmZTg1NzkzNDkyN2RlZmZhM2I5ZGQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE2MzYyOGJlZTllYmY3N2M4ZGZjZDVhMzBkYjBjYWVjNTIxNWE4MDRmNmY5MmMyNWM0MzYzMDI4ZjgxNzg2OTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoyLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImRmNzM5YTA2YzFjYmIxMjQ0ZTMzNjNkMzhiY2Y5ZmE1MGNlODRmZWQzOTljMjE5M2EzYzdmMDhkNTk5MThiMmEifQ"
+        },
+        {
+          "resource": "repo://src/skills/core/SkillManager.ts#L128-L135",
+          "version": "repo-lines-v1:sha256:752e22f2117bf04aaf5dacef95a1f03025dcca3cc8c15d82ebf3467828ac4bfe:eyJzZWxlY3RlZExpbmVDb3VudCI6OCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNGYyYTJmOTk2ZjA4ZTY4MGJkMjkyMTM1YTZmYTQ5NzhiZGEyNmU2MDJkODRmMzNjYjFkNTk0Nzc1ZDQzMDRiNSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiMjdlNTc4OGQ1ZDlkNzNkMjRhODFkYmMwYTVhNzRiZmE4MmM5YzNiM2FmOTllNTJhZjc5NmU5MGI0NjhhOGEzZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiMmNlZmI1ZjBlMWUxYWE1OTIzYmQxZDBhNmIxMTZjMzQ4NjVlZTI0YTc2Mzk1OGU3ZjAwMTM4MWM5ZTc4YTIwZiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMGJiNjFhNGE0YjkwY2JjZWJkYmRjZjc3N2RlMTFkZmQ4ZTA1NWM0ZDBlODBiZWNiYTQ4NWM0NzhkZGFhMzQ5NCJ9"
+        }
+      ]
+    },
+    {
+      "id": "claim_365718307f054adb901af8c05d299bf1",
+      "statement": "SkillSync copies complete discovered skill directories to .claude/skills, tracks source path and SKILL.md mtime in .codemie-sync.json for incremental sync, supports dry runs, and optionally removes manifest-tracked orphan directories.",
+      "evidence": [
+        {
+          "resource": "repo://src/skills/sync/SkillSync.ts#L219-L244",
+          "version": "repo-lines-v1:sha256:c67fe788cb0802808a6122cab83e8f8ea1a264ac91d37e574655311192177c52:eyJzZWxlY3RlZExpbmVDb3VudCI6MjYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQwNGU1MmY2MGY3NGY1M2E4ZmE0OTU0MDFjN2NlN2FhMTE4NTEzMzdkOGNlOGY3YjQ4ZDM5N2E1NDMwYjI5YzIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/skills/sync/SkillSync.ts#L48-L190",
+          "version": "repo-lines-v1:sha256:892ea3dc065a821fb34d1da31a431aeafe14f5feb5f0ef98888a3ab9669f8a03:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlYWYyMmNmMDczMjU5MmMyNDcxNDFjYmU2MWVmYTExMDEyNjEyZjVhMzEyMmI5YWY5YmJhZjUyZjU3MjRkMTk0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJkZWJkYjM2NWJjMGI1NzlhNzcyNjhhNmE2N2I2MGU0MGMwMGFmMTAzNzgwZWMxZTc1NjIzYTE0ZWRmMzdmZmFhIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJjNjljOTNjZDYwOWFjYWMwMjk3NDEyZDljYjUyZWJmYThjMzk4MTNiYTE2MjQ2YTc5MDZkNWYxYzk1MzVhOTU1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1YTkyOTNmZDgwNTRiNmU0NzI0ODM3M2YzOWY0ZGQ3NzgwMDEwNWViNzU4MzQ4Njg3MjU0Mjg1Y2QxMjgyYjc4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_c2a8367a87bf47c7b5eae4df6a065db0",
+      "statement": "The singular codemie skill CLI manages internal discovery/validation/cache/sync, while plural codemie skills delegates catalog operations to the authenticated upstream skills CLI and applies source sanitization, agent selection, noninteractive Git credentials, and lifecycle metrics.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/skill.ts#L36-L303",
+          "version": "repo-lines-v1:sha256:62778d5475120dc692b73f8f350e268caa078d70c5a18507d8a9a873f7a8d665:eyJzZWxlY3RlZExpbmVDb3VudCI6MjY4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIwYmM5Yjc2YzYyZDJjOGI1ZDliMDRmODE5NmE5OTNjM2Y4MDdjNDhmNTgzNjQ5OWE5ZDA0YjNkOWI4OWQzNDRlIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4YmUwM2M5ZWFjMDhkNmQ5ZTU2NjEyMzZlMmMxY2UzMzNiNWMyYmE3NDRhNDNkZTY2NTlmOTZjNWZmZjFhZmNmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIzNzkyOWU5MWUwZjk5YzNlODI1ZGU2OWI0MzVmYjY0ODRkMWIwYTFkZjJmNDY1NjFhYmYxYTI5ZjA0MTg4Yjg4IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MSwiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIn0"
+        },
+        {
+          "resource": "repo://src/cli/commands/skills/add.ts#L36-L149",
+          "version": "repo-lines-v1:sha256:40382fd04a060498dfee187c7fd05a5c1e60fb669c00c17d3415e30a28bb0079:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJkYzU4ZTJmNmQwOGNlOWUwNDg0OTA0NTdhMzgyYjVmYzNiNDM3NTU1MjMwYjliNDQ2Y2Q1NjQ4YjYxNzRhZGU1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI5YjYyZjYwZDg1OTBhNTc5Y2Y0NmY4ZDY3Mzc4YzRjNTcyYjk2MmNlY2NkYjkwYzdhNWY3YjQyYjk2MDc4MmE0IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJkNmFlMmYzNzIzZDk2OWJjODA5YjYwNjI2ZDcxZmM3ZTUxMGFkYzRmOGJlMWUyYmEwYzMxNTFlMGNmYjJkNmUzIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJkZmFiNzEwZGRmNzg1OWU1NzU3NjRhOTEzYTAwMmM3NDU4NWZmYTcwMDE1MTBjYjg4MTFkYTgzZDJjZjc0YjM0In0"
+        },
+        {
+          "resource": "repo://src/cli/commands/skills/index.ts#L1-L27",
+          "version": "repo-lines-v1:sha256:4af2e5e316e1965c0bf63a586f34d74f464d5ca60bb88b7c1133f3b45bec19cc:eyJzZWxlY3RlZExpbmVDb3VudCI6MjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUxNmNjNzM4YjliMDFkMzM0YzcxNWI1MDZjOTBjYWU3MzI1MzJhNWI1MDIyYTk0OTU4NmRhNzQ1ZDg1YTI1NmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_58da7cf6b5d9494fbd2e74938d7c2ac3",
+      "statement": "Assistant setup selects and registers server assistants as target-agent artifacts, persists registrations in the chosen scope, and generates Claude subagent or skill wrappers that invoke assistants chat with a task-specific conversation ID.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/assistants/setup/generators/claude-agent-generator.ts#L50-L124",
+          "version": "repo-lines-v1:sha256:c98e9d6fc62d30fdf462639a994215326fcb615e428c7ca21a3e61523bc736d2:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhkOTJkYjU0MDhlMWYwMDZjYjQ5OWVkY2IwMDI5MzA1ZWZkNWRkNmJjNTkzNDk2ODZiNWYwYWYxZTQ1MDRhNDYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjE0ZjY4ODMzMzk5ZmYxYWM4Njc2ZDdkZGFmNjU2MDAxOWY5YWI3MDE4YTIxNjA1YTE3NjNiNDU4M2FkOTQ0ODEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFkYWUzOGVjNmIxMGE1YmYxNTE3ZmQyMjhiZThmNThjMzI2YTBhNTJlZmEwZmYxODVhZGI5OGY4NDlkNjk2MGQifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/assistants/setup/generators/claude-skill-generator.ts#L90-L110",
+          "version": "repo-lines-v1:sha256:c42287287e132443e8d71d86cd1469f275d7b309908bd50981e0d5e4903a3376:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjFhNzZjMjBjOTI0MjkzNjhhYjIzN2EzY2Y1ZTIxZjFjZTYyNTY5OGQ3NThmMGUyZWJlZmM4NjdkM2YyODIxMmEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/assistants/setup/helpers.ts#L38-L126",
+          "version": "repo-lines-v1:sha256:da6831a8adc4c30f15ffc6d8a9cc5388d51ed804fa840919d6fbef9eb37d7475:eyJzZWxlY3RlZExpbmVDb3VudCI6ODksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVmYmNjZmZjMmQxZjVlYzBiOTJiNmM1NWMyNjBjODlhZWVkMGUxNWEyNDkwYjhkZDc0Y2FiOTVkOGI3MWJmM2QiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyYTJjYjI1YTEyMmI0NDIyMWE2MjM0ZWM2NjBhN2I1ZmI3ZjliZGU3YjNiOWUyYjNjNTU5YTBkOTZmYWM3MzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjU4Njg2ZGZhNDFhYWY0NmY2Mzg1MmQwMDBmMDRjNGVjYmY4MTU1NWIzOTM0MDFlNmY1ZGI1YWU5ZDFkZmQ0NWEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYxNTY4ZDg4ZjVhNzMyMDY2OWYzYThlYmJiYjc0Yjc1ZDc1NTZkNmQ4NWY4YjVhNGI4OTdkMDQzOWE3YzgzNGUifQ"
+        },
+        {
+          "resource": "repo://src/cli/commands/assistants/setup/index.ts#L62-L203",
+          "version": "repo-lines-v1:sha256:06f56d921bcc589cb4f82be4aceef28cc11033e1fb435d816c5ab8ebc3219ab0:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI1Y2Q4ZmNkODBhNjYwMWQ2NzkzZmU5NDE5YzlhZjliYTg4MDBiMjcyMDExMDYzMWQ2ZTM5NWY5MzNhYzA1MDJjIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MmEyY2IyNWExMjJiNDQyMjFhNjIzNGVjNjYwYTdiNWZiN2Y5YmRlN2IzYjllMmIzYzU1OWEwZDk2ZmFjNzM5IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1OTgyZDBkNzg1NzU0NDRkOGZmMTNmZGFlN2NiYmVlMjYxZTdjZGYwMDE0YTU4N2U1ZmNjNWY5OGM0YzE5ZmVlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI3NzZhZTUzNTg5MmY3ZjM4YjJjNGExN2ZhYjk4NzE5MzJkYjNhYmM3ZDAwNWQ1MTQwYmM3MjgwNTU4ZjJjMjc0In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_d70f2cc88d274b0a873b87da19d193f0",
+      "statement": "Importing the framework entrypoint auto-registers Speckit, Bmad, and CodebaseMemory adapters; the registry supports lookup and agent compatibility filtering, and agent initialization uses the registry to reject unknown or unsupported frameworks.",
+      "evidence": [
+        {
+          "resource": "repo://src/agents/core/AgentCLI.ts#L507-L584",
+          "version": "repo-lines-v1:sha256:66c7b71bc614e9b5668a8881e0274c9f8bf608daac9ec6327ef6aba1b57372d1:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmMmEyZjk5NmYwOGU2ODBiZDI5MjEzNWE2ZmE0OTc4YmRhMjZlNjAyZDg0ZjMzY2IxZDU5NDc3NWQ0MzA0YjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ4OTNmNDBlMzc4MWViODk2YzgyZDA0NmEwODA2N2ExMWUzNWNkZjJmMWRmYWYyNmZlYTkwYjhkYjY2NzY0MTMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDg2MzJlNTRlOTI5OGFiYjk1ODcyN2UyZDUxNDA4YWJhZjEzNjYwMzUzNzkxMDE0MGFiZjY1YjMwYWI2MTMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImJhOWI2MzE0ZDYyYWIzOGM2NzZlODVhODU5ZTI4MzQwYzQxZmJjOTQ3NTAwNmFjNThlYWFkMjA1M2VjYmRjODcifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/core/registry.ts#L10-L68",
+          "version": "repo-lines-v1:sha256:a2be90a90472bb1bacd058bfa433b6361db166bb350704d3b7f8d9afe2d5688d:eyJzZWxlY3RlZExpbmVDb3VudCI6NTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJhNDMwN2I1NGI0MzhlYjA3N2MyZmEzODI2OTFmZmJmMjk0YjQwNDBkZjNjZWY1YzcxYzllMDlmNmE2OTMxM2YiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjI3ZTU3ODhkNWQ5ZDczZDI0YTgxZGJjMGE1YTc0YmZhODJjOWMzYjNhZjk5ZTUyYWY3OTZlOTBiNDY4YThhM2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZjZTU2M2ZkZGFhMzA5N2YwNzNhMGVmMWRhODliODQ1Y2RiYjE0M2Y2M2I0OWRmOGVkMTM5MTA2ZjFkOWIxNTgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc2MzZhNzFhZjM3MTM3ZTcxYzE0NWIwMzc3ZThmNGYzZjFjNzUwNGI1MjJhMDk2YzAzZGMyZjk5MmQwOGM5ZDgifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/index.ts#L1-L14",
+          "version": "repo-lines-v1:sha256:3bbeb3b85647c556e5d26be921d6d8caf30095a2c9e281afce227acefea9e212:eyJzZWxlY3RlZExpbmVDb3VudCI6MTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjMxYTFlMzY5Y2UwYzJlNWI4YTE4NjI2NzgxZThkZjc4MjY4YThkMDA0NTA5NTNhYzhjMjAxNTE3NDhiYWZhMmMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        },
+        {
+          "resource": "repo://src/frameworks/plugins/index.ts#L1-L20",
+          "version": "repo-lines-v1:sha256:d43e9eaa0843016eed7d16b94a2d706830bc3c8b01eaab215cf62e070e4e6da1:eyJzZWxlY3RlZExpbmVDb3VudCI6MjAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEzOGIzNjQ3ZGQzNzgxOGVhYzBlNGYyMTM4YmU4OTIzYzZjMDA4ZjdiODM4N2ZkNTEzZDMxY2VmZjVhNWRjZTciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjowLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7314c8237a0f4172943e705283b04f0b",
+      "statement": "Workflow management detects GitHub/GitLab from the Git origin or accepts an explicit provider, resolves templates by provider/ID, and installs codemie-<id>.yml unless already present or dry-run.",
+      "evidence": [
+        {
+          "resource": "repo://src/cli/commands/workflow.ts#L148-L246",
+          "version": "repo-lines-v1:sha256:c2cbd4e26df217f37976810f611578a438ee85c341a6d484069cb0d56ecab054:eyJzZWxlY3RlZExpbmVDb3VudCI6OTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjYxMWQ4NDViZmRlOWUxMGY0OWJiNzBiMTlkNGUyMWMxOWY0ZmQ5ZDNlMWRmNTcxOTg0MGIyNDc1MmUwMjAwN2EiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAyYjQwNWJhMWE0ZGQyMmNiZDc3OTBjMDczNzJlNDI3YThhMzk0OTJiZmU3NDIyMGQ4MWFiYTIxOWQ3MTZmNGMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjVhZjAwNzYzYmU5ZmYwN2U3YzFjNTdkYTNmMTg0ZThjZmIzYTNjMjBkY2JhZmM5YTI3Mjc1NWIxZGM2YWU5NTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVhMDcyM2Q0N2ZhYjU4NzI5YjM1MzIzMDNiNmExMDg4YjRjM2Q0OTA1ZDRkYTJjM2U1MWY0NmY3ZDU4NzAyNjYifQ"
+        },
+        {
+          "resource": "repo://src/workflows/detector.ts#L10-L87",
+          "version": "repo-lines-v1:sha256:1a512e283e67d6e3f9a3757cd38375c27b2833dd7eb46846d6a37c86420abb33:eyJzZWxlY3RlZExpbmVDb3VudCI6NzgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjUyNjcyYTYwNmY5NTA4N2UzYTcyMDVjNmVjM2ZhZDNlY2VlZjgxMmEzMjQ2ZTIyN2E2MWRkODdhMjk4OTgzZDgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImE1Mjg3ZmVkNDI5ZWFhNGFmYjc0ZmRlMDU2NTFjMDg0ZjJiODU5ODlhNjcyOWU4M2NmMTQ3OWMwODdlMTRlMjIifQ"
+        },
+        {
+          "resource": "repo://src/workflows/installer.ts#L12-L57",
+          "version": "repo-lines-v1:sha256:c160088458e1d043b9b0e7cdce46961ef709e70d7d2a1905dc36dda963e12a8a:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijc2MTJkZTZlNGY0MTliMGI0MDNkNDUzYjU0ZjY3MTdhMjRkYzM1N2IxZWFiYWEzZDMwMmVjMDg1MzQ1MTNmNjgiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjM5NzgyY2E4ZWM5MGY3YjMzNGYyNTM5MzVjN2Q3YjMwNmRjYzRmNDk1ZjRjNDY1Y2JmYjNlM2FkNzYwODI2OTgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc0ZGM1ZmRmZWVhYTFlMWNmZDMxM2M1MmM0NGQwNmMzNThlY2Y1ZmYyNzIxMGY5ZGUwOTVjM2VjMDFlM2E2ZGEifQ"
+        },
+        {
+          "resource": "repo://src/workflows/registry.ts#L9-L35",
+          "version": "repo-lines-v1:sha256:7b3da2c69c428a1625a3ed3b39621a9bdb6932d1b06c8ba4df5255f2f19c2d18:eyJzZWxlY3RlZExpbmVDb3VudCI6MjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjE4MTU2YzI2ZmZhZDczNDA2ZThiZGFhZDNiMDJiMTM5Y2M3OGExNWY4Zjc3MmI4YzJhNjU3YjU3NTcwZGU4YWMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE4YTY5MGRmNGViOTA5NzEwYzJlOTIxNTQ0NDczNzU3ODllZDIzZDUwNGY0ZGMwNWMwN2UxZjVkZmIwMjI1MGEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM3OTI5ZTkxZTBmOTljM2U4MjVkZTY5YjQzNWZiNjQ4NGQxYjBhMWRmMmY0NjU2MWFiZjFhMjlmMDQxODhiODgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_e4c1ad4f73ec4047a925dfb0d8337db8",
+      "statement": "The current workflow registry exposes three GitHub templates—pr-review, inline-fix, and code-ci—while GitLab has no templates; dependency validation only warns about required secrets/tools and cannot verify them.",
+      "evidence": [
+        {
+          "resource": "repo://src/workflows/installer.ts#L117-L153",
+          "version": "repo-lines-v1:sha256:17c80209eff18f9133b6db9558ff5b9c9e2ffc583dcb3b9f94d5fabd8ed3f64d:eyJzZWxlY3RlZExpbmVDb3VudCI6MzcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVhZjIyY2YwNzMyNTkyYzI0NzE0MWNiZTYxZWZhMTEwMTI2MTJmNWEzMTIyYjlhZjliYmFmNTJmNTcyNGQxOTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQyYTJjYjI1YTEyMmI0NDIyMWE2MjM0ZWM2NjBhN2I1ZmI3ZjliZGU3YjNiOWUyYjNjNTU5YTBkOTZmYWM3MzkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRhNDYxNjgxNzhiYzEwNzAxMzY4NjEwOTBlOTc1ZjBkMzU5ZDdmYzdiMTMxNzQ4NGNlNzVhYzM1ZGU1MTAyMjYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://src/workflows/templates/github/metadata.ts#L18-L114",
+          "version": "repo-lines-v1:sha256:5e4a9bbcd9917000a4c88e1b3eb8f07cf623360edc78cfdf1ec5a1d469ec0273:eyJzZWxlY3RlZExpbmVDb3VudCI6OTcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6Ijg4ZDBjYTE1MDdmNGVmMDYxNjM4YmE2MTRkMGFjNmVkYjc3OTFkYzRkZGRlMTYwZDZmYjVmZDJhMTJhYTc2NmUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRkNWNkMmZiNGYzZGY4ODQ1MTUyNTViMzk1MjNmMmY4YjU0NzJiZWVhOWY1NjZmZmNhMjA0ZGI4MDI1NjEwNDEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk3ZDZlYTBmN2IwOTc1YmRjYjZmY2JlMDM2ZWVkN2NiMjRjYzI5ZDAyZGI5NjFiZTMwZjIyYzliYjU4OTk5ZjEiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImIwMmQyYzBkNmRjNWU3NGQ5MmZhMTRiOTFkYmVhMjY0MDkwYmViMzVmZGI5MTg4ZDliMzQxMTgxZGNlOWY0Y2UifQ"
+        },
+        {
+          "resource": "repo://src/workflows/templates/gitlab/metadata.ts#L12-L18",
+          "version": "repo-lines-v1:sha256:11fa8eb92045edd08e0b08aabd1f2bd08cebc9c8da758e580b39902450ffe3fb:eyJzZWxlY3RlZExpbmVDb3VudCI6NywiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiMTk0ZjY2NWI5YmFhZjM5Mjk2YjQ2ZjU0ZDk3MjA5YmRhYThlMTQ2YmZkYzEyMTE2OTQyN2Q0MGEwYjUyMWYzYSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiZGVkOTU4NjU5OWNmMWJlODAyZTM3ODgyNTJlODY1MjlhYWU3OWVjYWU0ZWYxN2Q4MzY5ZTU3NWRlNjRmOWY1NCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiZmRiMjVjZTRkNTI5NWRhZmY3YTA3OGVhZmJiZTI4ZjIwMzQzY2ZkMzFhMzI1NzViMTBlOWFkNGViZTExYTdiNiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjAsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NSJ9"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.3",
+    "at": "2026-08-29T08:09:18.077Z"
+  }
+}

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,7 @@
+{
+  "updatedAt": "2026-08-29T08:28:22.458Z",
+  "command": "update",
+  "model": "gpt-5.6-terra",
+  "status": "interrupted",
+  "language": "en"
+}

--- a/openwiki/INSTRUCTIONS.md
+++ b/openwiki/INSTRUCTIONS.md
@@ -1,0 +1,43 @@
+# OpenWiki Brief — CodeMie Code (`@codemieai/code`)
+
+This wiki serves AI coding agents working in this repository. Prioritize the
+context an agent needs to make correct, convention-compliant changes.
+
+## Scope and priorities
+
+1. **Architecture first** — the plugin-based 5-layer architecture, layer
+   responsibilities, and dependency flow (`CLI -> Registry -> Plugin`).
+   Key sources: `src/cli/`, `src/agents/registry.ts`, `src/agents/plugins/`,
+   `src/providers/plugins/`.
+2. **Agent plugin system** — how plugins under `src/agents/plugins/` are
+   structured, registered, installed (`codemie install <agent>`), and launched;
+   the `bin/codemie-<agent>.js` wrapper pattern; the difference between agent
+   plugins and injected runtime plugins (`codemie-code-hooks/`,
+   `reasoning-sanitizer/`).
+3. **Provider plugin system** — SSO (default, owns the local proxy), jwt,
+   litellm, bedrock, ollama, subscription providers; the proxy plugin chain
+   under `src/providers/plugins/sso/proxy/plugins/`.
+4. **CLI surface** — commander command factories in `src/cli/commands/`
+   registered in `src/cli/index.ts`; entry points in `bin/` declared in
+   `package.json:bin`.
+5. **Configuration** — profiles, ConfigLoader, env vars, `~/.codemie` paths
+   (`getCodemiePath()`).
+
+## Conventions the wiki must capture
+
+- ES modules: always `.js` extensions on imports, no `require()`/`__dirname`,
+  use `@/` alias instead of deep relative imports.
+- Project error classes, `logger.debug()` (never raw `console.log`),
+  `sanitizeLogArgs()` for anything credential-adjacent.
+- Conventional Commits enforced by commitlint; Vitest for tests.
+
+## Do NOT document
+
+- Anything matched by `.openwikiignore` (build output, `.ai-run/` agent
+  artifacts, `docs/superpowers/` working files).
+- Workflow and policy owned by `.ai-run/guides/` — git workflow, quality
+  gates, testing rules, security policies, coding standards. Those guides are
+  hand-curated and authoritative for process; never restate or paraphrase
+  them in wiki pages. If a page needs that context, link the guide path.
+- Hand-written user docs under `docs/` as primary evidence — summarize and
+  link to them instead of duplicating their content.

--- a/openwiki/architecture/cli-surface.md
+++ b/openwiki/architecture/cli-surface.md
@@ -1,0 +1,140 @@
+---
+type: architecture reference
+title: CLI, Binaries, and Command Factories
+description: Published CodeMie executables, the Commander command tree, agent launch wrappers, and the programmatic exports that make up the supported public surface.
+tags: [cli, binaries, commander, agents, public-api, esm]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-8037e2358a2c4f9b2c722a11
+    resource: repo://AGENTS.md
+  - id: openwiki-source-371a6d8a4fcb291e3e8d7291
+    resource: repo://bin/agent-executor.js
+  - id: openwiki-source-a1c6f166318281c1a37e8001
+    resource: repo://bin/codemie-claude.js
+  - id: openwiki-source-b690f1fd41f8ef76f97f6d06
+    resource: repo://bin/codemie-copilot.js
+  - id: openwiki-source-73aafb9bc993302f60627faa
+    resource: repo://bin/codemie-mcp-proxy.js
+  - id: openwiki-source-aa210045b4d9e85b7a7eb1ff
+    resource: repo://bin/codemie.js
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-96d840525cbe08ac0be7a052
+    resource: repo://src/agents/core/__tests__/AgentCLI-resume.test.ts
+  - id: openwiki-source-23c009faa70a994252df8b77
+    resource: repo://src/agents/core/AgentCLI.ts
+  - id: openwiki-source-cf985357c2ea8c403c53e222
+    resource: repo://src/agents/registry.ts
+  - id: openwiki-source-a7ea460809b23828f691a001
+    resource: repo://src/bin/proxy-daemon.ts
+  - id: openwiki-source-a7c3f9c14dd0a4f67d480300
+    resource: repo://src/cli/commands/mcp-proxy.ts
+  - id: openwiki-source-910ed79bcc0bd7b5cc899f36
+    resource: repo://src/cli/commands/proxy/__tests__/connect-wiring.test.ts
+  - id: openwiki-source-beb5bc61c2dd56a7676e2b44
+    resource: repo://src/cli/commands/proxy/daemon-manager.ts
+  - id: openwiki-source-203af971e5106b89f72f1924
+    resource: repo://src/cli/commands/proxy/index.ts
+  - id: openwiki-source-69f1465f9bd0baca2064728f
+    resource: repo://src/cli/index.ts
+  - id: openwiki-source-d1fbef09192ffbab6eff0bc2
+    resource: repo://src/index.ts
+  - id: openwiki-source-68fe9e3f9e3b1f5af7d1b97f
+    resource: repo://src/mcp/stdio-http-bridge.ts
+  - id: openwiki-source-f1d023d8ab3ad497e8711389
+    resource: repo://tests/integration/proxy-daemon-lifecycle.test.ts
+  - id: openwiki-source-98d5ddb014a0fd4d678f6f2a
+    resource: repo://tsconfig.json
+  - id: openwiki-source-fbadcd8591b65031efaaedce
+    resource: repo://vitest.config.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+# CLI, Binaries, and Command Factories
+
+`@codemieai/code` is an ESM Node.js package (Node 20 or newer) whose executable API is declared by `package.json` and whose library API begins at `dist/index.js` with declarations at `dist/index.d.ts`. The published `bin/` directory is part of the package, so the JavaScript launchers—not TypeScript source paths—are the stable process entry points. [package.json](repo://package.json#L2-L30) [package.json](repo://package.json#L188-L190)
+
+## Published executables
+
+| Executable | Published launcher | Role |
+|---|---|---|
+| `codemie` | `bin/codemie.js` | Management CLI: setup, profiles, agents, workflows, diagnostics, telemetry, MCP, proxy, and codebase operations. |
+| `codemie-code` | `bin/agent-executor.js` | Built-in CodeMie agent launcher. |
+| `codemie-claude`, `codemie-claude-acp`, `codemie-gemini`, `codemie-opencode`, `codemie-pi`, `codemie-codex`, `codemie-kimi`, `codemie-kimi-acp` | corresponding `bin/codemie-*.js` | A direct, agent-specific Commander surface created from the registered adapter. ACP variants are editor/Agent Communication Protocol adapters. |
+| `codemie-copilot` | `bin/codemie-copilot.js` | Agent launcher with Copilot-specific model selection/listing and persisted selection before delegation to the common agent CLI. |
+| `codemie-mcp-proxy` | `bin/codemie-mcp-proxy.js` | Minimal stdio JSON-RPC to HTTP MCP bridge process. |
+| `proxy-daemon` | `bin/proxy-daemon.js` | Thin launcher for the detached local gateway daemon implementation. |
+
+The complete executable-to-launcher mapping is the package `bin` field; adding an implementation without adding it there does not publish a shell command. The direct agent wrappers look up a named adapter in `AgentRegistry`, fail with exit status 1 if it is absent, then construct `AgentCLI` and parse the original `process.argv`. Separate entry files avoid Windows npm wrapper detection issues for agent commands. [package.json](repo://package.json#L8-L21) [bin/agent-executor.js](repo://bin/agent-executor.js#L3-L24) [bin/codemie-claude.js](repo://bin/codemie-claude.js#L3-L18) [bin/codemie-claude-acp.js](repo://bin/codemie-claude-acp.js#L3-L21)
+
+The registry is the boundary between launchers and integrations. It lazily registers the built-in, Claude/Claude ACP, Gemini, OpenCode, Codex, Pi, Kimi/Kimi ACP, and Copilot plugins on first access; a wrapper therefore selects behavior by registry key rather than importing an integration-specific adapter. Agent-management consumers must use `getManageableAgents()`, which excludes analytics-only adapters, while telemetry may use the full registry. [src/agents/registry.ts](repo://src/agents/registry.ts#L17-L74) [src/agents/registry.ts](repo://src/agents/registry.ts#L76-L129)
+
+## Root Commander program
+
+Importing `src/cli/index.ts` creates the `codemie` Commander program. It first imports provider and framework plugin indexes for registration side effects, reads the package version with a fallback, and attaches command factories. Factories keep each domain independently constructible and testable; the root is deliberately composition rather than a monolithic command handler. [src/cli/index.ts](repo://src/cli/index.ts#L1-L60) [src/cli/index.ts](repo://src/cli/index.ts#L78-L104)
+
+The root mounts factories for `setup`, `profile`, `assistants`, agent lifecycle (`list`, `install`, `uninstall`, `update`), `self-update`, `doctor`, `version`, `workflow`, `analytics`, `log`, `hook`, `sound`, singular `skill` and plural `skills`, `plugin`, OpenCode and test metrics, `models`, `sdk`, `mcp`, `mcp-proxy`, `proxy`, and `codebase`. Treat the factory return value—not a global program—as the extension seam for a command family. [src/cli/index.ts](repo://src/cli/index.ts#L14-L40) [src/cli/index.ts](repo://src/cli/index.ts#L78-L104)
+
+There are two exceptional root paths:
+
+* `codemie --task <task>` bypasses the management command tree, resolves `codemie-code`, and delegates the entire argv to `AgentCLI`; lookup or launch failure exits nonzero.
+* Invoking bare `codemie` does not immediately call Commander parsing. It presents first-run welcome guidance or a returning-user quick start, falling back to normal help if that detection fails. All other invocations parse normally.
+
+[src/cli/index.ts](repo://src/cli/index.ts#L106-L145)
+
+```mermaid
+flowchart TD
+  Shell["Shell command"] --> Main["codemie launcher"]
+  Main --> Migrate["Run pending migrations"]
+  Migrate --> Update["Nonblocking update check"]
+  Update --> Root["Root Commander program"]
+  Root --> Factories["Command factories"]
+  Root --> Task{"--task present"}
+  Task -->|yes| Native["Registry codemie-code"]
+  Native --> AgentCLI["AgentCLI"]
+  Task -->|no| Parse["Parse command or show guidance"]
+  Shell --> Direct["Agent-specific launcher"]
+  Direct --> Registry["AgentRegistry lookup"]
+  Registry --> AgentCLI
+  AgentCLI --> Adapter["Adapter run with env and arguments"]
+```
+
+This shows the two public CLI routes: the management root and direct agent wrappers converging on the registry-backed agent runner.
+
+### Startup policy
+
+The `codemie` launcher runs pending migrations before loading the main CLI. Migrations are tracked in `~/.codemie/migrations.json`; migration errors are warned but do not prevent use. It then performs an update check unless running under Node test/Vitest; that check is also explicitly non-fatal. A failure importing the compiled root CLI is fatal. In contrast, the MCP binary intentionally skips migrations, updates, and plugin loading because stdout must remain an uncorrupted JSON-RPC channel. [bin/codemie.js](repo://bin/codemie.js#L8-L39) [bin/codemie-mcp-proxy.js](repo://bin/codemie-mcp-proxy.js#L3-L13)
+
+## AgentCLI: common shortcut-agent contract
+
+`AgentCLI` derives its program name from adapter metadata (`codemie-` is not duplicated), sets the logger agent name, and exposes common wrapper options for profile/provider/model/auth/base URL/timeout/reasoning effort, task execution, session resume, status, silence, analytics reporting, and OpenCode config printing. It permits unknown options and retains positional arguments so native agent syntax can pass through. Every wrapper also has `health`; only Claude, Codex, and Gemini receive the nested `setup assistants` and `setup skills` commands; `init` is added only when the native adapter does not own it. [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L29-L44) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L63-L140) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L638-L640)
+
+Before launching an adapter, the runner enforces the operational boundary: installed agent, valid configuration, required credentials (except SSO/JWT alternatives), provider/model compatibility, and a valid reasoning-effort value. `--jwt-token` takes precedence over profile authentication, selects bearer defaults when no config exists, and normalizes the CodeMie API path. `--task` and `--print-config` enable silent mode; config printing is valid only for OpenCode. The runner serializes the resolved profile into environment variables, adds profile/version/status/analytics controls, then calls `adapter.run()` with only agent-facing arguments. Errors are presented and logged before exit 1. [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L158-L280) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L342-L374) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L453-L471) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L591-L617)
+
+Resume is guarded as a telemetry ownership boundary. The adapter may recognize either CodeMie `--resume` or its native resume syntax and resolve ownership. If it identifies an external session, noninteractive input (no TTY or `CODEMIE_NO_PROMPTS=1`) blocks it. An interactive user may explicitly continue, in which case `CODEMIE_SESSION_ORIGIN=external-resume` is injected into the child environment and an audit event is recorded, preventing that session from being ingested as a CodeMie session. Resolver failure is deliberately non-blocking. [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L376-L448) [src/agents/core/AgentCLI.ts](repo://src/agents/core/AgentCLI.ts#L697-L755) [src/agents/core/__tests__/AgentCLI-resume.test.ts](repo://src/agents/core/__tests__/AgentCLI-resume.test.ts#L59-L139)
+
+`codemie-copilot` is the intentional wrapper exception: before registry lookup it parses its model-related options, resolves models using the active configuration, can print `--model-list`, and prompts/persists a selection when `--model` has no value. A saved selection is applied only when neither CLI nor environment supplied a model. [bin/codemie-copilot.js](repo://bin/codemie-copilot.js#L18-L30) [bin/codemie-copilot.js](repo://bin/codemie-copilot.js#L188-L224)
+
+## MCP and daemon process surfaces
+
+The root `codemie mcp-proxy <url>` factory and the quiet `codemie-mcp-proxy <url>` binary both validate a URL, construct `StdioHttpBridge`, arrange SIGINT/SIGTERM shutdown, and exit nonzero on a fatal startup error. The binary logs boot diagnostics to `~/.codemie/logs/mcp-proxy.log` instead of stdout and dynamically imports the bridge only after validation. [src/cli/commands/mcp-proxy.ts](repo://src/cli/commands/mcp-proxy.ts#L16-L56) [bin/codemie-mcp-proxy.js](repo://bin/codemie-mcp-proxy.js#L19-L90)
+
+The bridge starts stdio immediately but defers HTTP transport creation until the first JSON-RPC message. It queues messages during connection, performs OAuth on an unauthorized start or first send, retries queued traffic, maintains cookies per origin, forwards HTTP replies to stdio, and closes OAuth, HTTP, and stdio resources idempotently on shutdown. A forwarding connection failure exits the process, which lets an MCP host observe failure rather than silently losing requests. [src/mcp/stdio-http-bridge.ts](repo://src/mcp/stdio-http-bridge.ts#L87-L158) [src/mcp/stdio-http-bridge.ts](repo://src/mcp/stdio-http-bridge.ts#L160-L207) [src/mcp/stdio-http-bridge.ts](repo://src/mcp/stdio-http-bridge.ts#L293-L346)
+
+`codemie proxy` is a root factory for a managed local gateway process. `proxy start` loads a named profile, rejects a differently configured live daemon but treats an identical one as idempotent, verifies credentials, attempts skill synchronization without making synchronization failure fatal, then asks the daemon manager to spawn and await readiness. `proxy stop` is idempotent; status can perform a deeper reachability check or emit machine-readable JSON. The nested-command design enables desktop/editor connection operations; its aliases merge parent and leaf options so Commander nesting cannot drop `--profile`, `--verbose`, `--force`, or `--insiders`. [src/cli/commands/proxy/index.ts](repo://src/cli/commands/proxy/index.ts#L62-L90) [src/cli/commands/proxy/index.ts](repo://src/cli/commands/proxy/index.ts#L108-L189) [src/cli/commands/proxy/__tests__/connect-wiring.test.ts](repo://src/cli/commands/proxy/__tests__/connect-wiring.test.ts#L101-L182)
+
+The daemon manager spawns `bin/proxy-daemon.js`, polls its state file for up to five seconds, and clears stale state when a recorded PID is dead. Stop sends SIGTERM, waits five seconds, then escalates to SIGKILL and always removes state. The daemon validates required `--target-url` and `--state-file` and a positive port; it binds explicitly to `127.0.0.1`, atomically persists its live state, removes it during signal cleanup, and runs a 30-second health watcher that can restart up to three times on the same pinned port before recording an unhealthy state. [src/cli/commands/proxy/daemon-manager.ts](repo://src/cli/commands/proxy/daemon-manager.ts#L32-L81) [src/cli/commands/proxy/daemon-manager.ts](repo://src/cli/commands/proxy/daemon-manager.ts#L96-L187) [src/bin/proxy-daemon.ts](repo://src/bin/proxy-daemon.ts#L30-L90) [src/bin/proxy-daemon.ts](repo://src/bin/proxy-daemon.ts#L97-L128) [src/bin/proxy-daemon.ts](repo://src/bin/proxy-daemon.ts#L160-L203)
+
+The focused integration lifecycle test is release-critical because it uses the actual `bin/proxy-daemon.js` and compiled daemon: it checks detached spawn, state/readiness, local `/health`, SIGTERM shutdown, PID death, and state cleanup. It uses a temporary `CODEMIE_HOME` and a dummy JWT token so `/health` is deterministic and credential-free; it skips when `dist` is not built. [tests/integration/proxy-daemon-lifecycle.test.ts](repo://tests/integration/proxy-daemon-lifecycle.test.ts#L4-L42) [tests/integration/proxy-daemon-lifecycle.test.ts](repo://tests/integration/proxy-daemon-lifecycle.test.ts#L65-L113) [tests/integration/proxy-daemon-lifecycle.test.ts](repo://tests/integration/proxy-daemon-lifecycle.test.ts#L139-L187)
+
+## Programmatic package API
+
+Consumers importing the package receive a deliberately small surface: `AgentRegistry` and `AgentAdapter`; `logger`, `exec`, and error exports; `EnvManager`; `CodeMieSSO`; `CodeMieProxy`; `getPluginRegistry` for external proxy-plugin registration; hook `processEvent` and `HookProcessingConfig`; and `ConfigLoader`. Importing deeper implementation modules couples callers to internals rather than this supported entry module. [src/index.ts](repo://src/index.ts#L1-L28)
+
+## ESM and change rules
+
+This is ESM (`"type": "module"`) compiled with NodeNext resolution. Source imports must include their emitted `.js` extension. Do not introduce `require()` or `__dirname`; obtain an ESM-safe directory with `getDirname(import.meta.url)`. Prefer the configured `@/` alias over new deep relative imports. These rules matter especially at entrypoint boundaries, where a syntactically accepted CommonJS pattern can fail after packaging. [package.json](repo://package.json#L2-L7) [tsconfig.json](repo://tsconfig.json#L2-L27) [AGENTS.md](repo://AGENTS.md#L163-L177)
+
+When changing this surface, update the package `bin` map and its launcher together, preserve the launcher-to-registry-to-plugin layering, keep MCP stdout protocol-clean, and test command factories under their real root nesting. The Vitest configuration separates fast Node unit tests, no-network CLI integration tests, and built, network-capable agent integration tests; all resolve `@` to `src`. [vitest.config.ts](repo://vitest.config.ts#L14-L97)

--- a/openwiki/architecture/index.md
+++ b/openwiki/architecture/index.md
@@ -1,0 +1,4 @@
+# Files
+
+- [CLI, Binaries, and Command Factories](cli-surface.md) - Published CodeMie executables, the Commander command tree, agent launch wrappers, and the programmatic exports that make up the supported public surface.
+- [Plugin Architecture and Dependency Boundaries](system-overview.md) - CodeMie composes agent, provider, and framework integrations through registries and typed plugins. This page describes initialization boundaries, the public package API, and the required CLI-to-registry-to-plugin dependency direction.

--- a/openwiki/architecture/system-overview.md
+++ b/openwiki/architecture/system-overview.md
@@ -1,0 +1,129 @@
+---
+type: architecture overview
+title: Plugin Architecture and Dependency Boundaries
+description: CodeMie composes agent, provider, and framework integrations through registries and typed plugins. This page describes initialization boundaries, the public package API, and the required CLI-to-registry-to-plugin dependency direction.
+tags: [architecture, plugins, registries, cli, esm]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-025b38a028884ce4ac5ee989
+    resource: repo://src/agents/__tests__/registry.test.ts
+  - id: openwiki-source-029d2ecb6970e7ac12c6f34f
+    resource: repo://src/agents/core/BaseAgentAdapter.ts
+  - id: openwiki-source-820e3288d1d3678265fa6397
+    resource: repo://src/agents/core/lifecycle-helpers.ts
+  - id: openwiki-source-8092609c520e79bd6205b48b
+    resource: repo://src/agents/core/types.ts
+  - id: openwiki-source-05423d560df2f717bd978f31
+    resource: repo://src/agents/plugins/claude/session/processors/claude.conversations-processor.ts
+  - id: openwiki-source-cf985357c2ea8c403c53e222
+    resource: repo://src/agents/registry.ts
+  - id: openwiki-source-724c5898a64141de5385084d
+    resource: repo://src/cli/commands/list.ts
+  - id: openwiki-source-0ee601e1542514d41103da41
+    resource: repo://src/cli/commands/models.ts
+  - id: openwiki-source-69f1465f9bd0baca2064728f
+    resource: repo://src/cli/index.ts
+  - id: openwiki-source-ae701ba4fd4af400e6cf208b
+    resource: repo://src/frameworks/core/registry.ts
+  - id: openwiki-source-73a4c6c9f8098fcf965dbb83
+    resource: repo://src/frameworks/core/types.ts
+  - id: openwiki-source-7c7fa2026b2641d9e184ea9f
+    resource: repo://src/frameworks/plugins/index.ts
+  - id: openwiki-source-d1fbef09192ffbab6eff0bc2
+    resource: repo://src/index.ts
+  - id: openwiki-source-16b9adba62be4d9443ffa3ed
+    resource: repo://src/providers/core/__tests__/providers-core.test.ts
+  - id: openwiki-source-023109980faac7bfe8745e7b
+    resource: repo://src/providers/core/registry.ts
+  - id: openwiki-source-fb49e7ca792739d2d6c63040
+    resource: repo://src/providers/core/types.ts
+  - id: openwiki-source-4e482a9888b381a021765ada
+    resource: repo://src/providers/index.ts
+  - id: openwiki-source-98d5ddb014a0fd4d678f6f2a
+    resource: repo://tsconfig.json
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+## Architectural intent
+
+CodeMie is a Node.js ESM package that delivers both a command-line product and a small programmatic API. Its extensibility model separates user-facing command handling from integration-specific behavior: agents wrap external coding CLIs, providers describe connectivity and provider-specific behavior, and frameworks integrate development-framework tooling. Registries are the composition boundary between those consumers and implementations.
+
+The five layers, from command invocation to the outside system, are:
+
+1. **Distribution and public API** — `package.json` declares the ESM package, compiled `dist` entrypoint, and executable shims; `src/index.ts` deliberately exports only selected programmatic facilities.
+2. **CLI orchestration** — `src/cli/index.ts` configures Commander and attaches product commands. `AgentCLI` builds an agent-specific command surface from an adapter.
+3. **Registries and composition** — `AgentRegistry`, `ProviderRegistry`, and `FrameworkRegistry` hold integrations by stable name and resolve them for consumers.
+4. **Plugin adapters and templates** — agent adapters implement management and launch behavior; provider templates contribute metadata, optional setup/model/health capabilities, environment export, and agent hooks; framework adapters manage and initialize framework tooling.
+5. **External tools and services** — the native agent executable, provider endpoint or local runtime, and framework CLI are invoked only through their corresponding plugin behavior.
+
+The essential dependency rule is **CLI → Registry → Plugin**. A command resolves a named capability from a registry and works through its contract; it must not select, import, or call a concrete integration implementation. Plugins may depend on core contracts and register themselves at an explicit composition boundary, but should not depend on CLI commands. This keeps a new integration localized to its plugin and registration entrypoint instead of spreading provider- or agent-specific branches through command code.
+
+```mermaid
+flowchart TD
+  Package["Distribution and public API"] --> Cli["CLI orchestration"]
+  Cli --> Registries["Agent Provider and Framework registries"]
+  Registries --> Plugins["Agent provider and framework plugins"]
+  Plugins --> Contracts["Core contracts and shared lifecycle"]
+  Plugins --> External["Native CLIs provider services and frameworks"]
+  PluginImport["Plugin entrypoint import"] --> Registration["Registration side effect"]
+  Registration --> Registries
+```
+
+*The diagram shows the five runtime layers and the separate import-time path by which plugins populate registries.*
+
+## Contracts define what a plugin owns
+
+An agent plugin is an `AgentAdapter`: it exposes identity and read-only metadata, installation state and operations, `run`, version lookup, and optional capabilities such as session parsing, extension installation, native resume ownership, and analytics. `AgentMetadata` is the declarative boundary for installation commands, supported providers, environment-variable mapping, CLI flag translation, model compatibility, lifecycle defaults, local paths, MCP and extension locations, and analytics behavior. The generic CLI can therefore build and run an agent wrapper without knowing Claude-, Gemini-, or other vendor-specific details.
+
+Provider plugins use `ProviderTemplate`. A template identifies the provider, default endpoint and authentication type, recommended models and capabilities, and can provide setup instructions. Provider-owned `exportEnvVars` prevents `ConfigLoader` from accumulating provider-specific fields; `agentHooks` supplies provider/agent lifecycle customization without placing provider knowledge in the agent plugin. For a lifecycle hook, resolution checks a provider wildcard hook, then an agent-specific provider hook, and otherwise uses the agent default; when both provider hooks exist, wildcard runs before the agent-specific hook. A wildcard hook can also precede the agent default.
+
+Framework plugins implement `FrameworkAdapter`, including install/uninstall, initialization, availability checks, agent-name mapping, and version lookup. The framework registry filters registered frameworks by the adapter's `supportedAgents`; an absent or empty list means it supports every agent.
+
+This split has an important operational boundary: `getAllAgents()` includes analytics-only adapters so the analytics pipeline can resolve their session adapters, but management surfaces must use `getManageableAgents()` or `getInstalledAgents()`. The latter two exclude adapters whose metadata sets `analyticsOnly`; this avoids advertising install/update actions for an externally managed tool and avoids a destructive global npm update.
+
+## Registration lifecycle and lookup failures
+
+Registration is intentionally a mix of lazy agent composition and import-time provider/framework composition:
+
+- The first `AgentRegistry` lookup initializes its private maps and instantiates the built-in agent plugin set. Registration also captures an agent metadata analytics adapter when present. Unknown agent names resolve to `undefined`.
+- Importing `src/providers/index.ts` imports each built-in provider plugin. Provider templates call `registerProvider`, which stores them in `ProviderRegistry`; the same registry separately stores health checks, model fetchers, and setup steps. `src/cli/index.ts` imports this entrypoint before creating commands, so those provider side effects have executed. A provider registry lookup returns `undefined` if no matching capability is registered.
+- Importing `src/frameworks/index.ts` imports its plugin index, whose module body constructs and registers the built-in framework adapters. CLI code can dynamically import this entrypoint before consuming `FrameworkRegistry`.
+
+Maps key registrations by name. In particular, provider registration is last-write-wins for duplicate names, so a duplicate is an override rather than an error. `ProviderRegistry.clear()` and `FrameworkRegistry.clear()`/`unregisterFramework()` are test/reset mechanisms; consumers must ensure the appropriate composition entrypoint has been imported after a clear. Agent initialization is guarded by an `initialized` flag and has no public clear/reset path.
+
+At run time, configuration selects a provider name and the agent adapter uses `ProviderRegistry` to retrieve its template. An unauthenticated provider is never routed through the local proxy; proxy routing requires an SSO provider or JWT authentication *and* an agent whose metadata enables proxy support. Provider hooks and agent defaults then customize the session around execution rather than requiring a CLI command to understand each provider.
+
+## Public entrypoints and import boundaries
+
+There are three distinct entrypoint types; use the narrowest one appropriate to the caller:
+
+| Entrypoint | Role |
+| --- | --- |
+| `src/index.ts` | Public package API: `AgentRegistry` and its adapter type, logging/process/error helpers, `EnvManager`, SSO and proxy classes, proxy-plugin registry access, hook processing, and `ConfigLoader`. |
+| `src/providers/index.ts` | Provider module API and its composition entrypoint. It exports provider contracts/registry/base helpers and triggers built-in provider registration. |
+| `src/frameworks/index.ts` | Framework module API and its composition entrypoint. It exports framework core and plugins, and triggers built-in framework registration. |
+| `src/cli/index.ts` | Executable composition root, not a general library API. It initializes provider/framework plugins, adds Commander commands, and handles the `--task` fast path. |
+
+For `codemie --task`, the CLI dynamically loads `AgentRegistry` and `AgentCLI`, asks the registry for `codemie-code`, then delegates the argv to that adapter's generic CLI. If the adapter cannot be resolved or execution fails, it reports the error and exits nonzero. This is the desired control flow: the CLI names a capability, the registry supplies it, and the plugin implements it.
+
+Do not treat every source module as supported public API. Consumers that need provider registration should import the provider entrypoint (or use the explicitly exported provider APIs), and consumers that need framework registration should import the framework entrypoint. Importing only a registry core file does not itself load plugins.
+
+## ESM and import conventions
+
+The package declares `"type": "module"` and compiles with TypeScript `NodeNext` module and resolution settings. Source imports must use ESM and include the runtime `.js` extension even when the source file is TypeScript, for example `import { AgentRegistry } from '@/agents/registry.js';`. The TypeScript `@/*` path mapping resolves from `src`; prefer that alias for cross-feature imports instead of adding deep relative paths.
+
+New production code should not introduce `require()` or CommonJS `__dirname`. Use `import.meta.url` with the repository's `getDirname` utility when a module-relative path is necessary. This is a migration rule as well as a style preference: one legacy production `require()` remains in the Claude conversations processor, and some compatibility/template code still uses `__dirname`; do not copy those patterns into new integration code.
+
+## Safe extension workflow
+
+1. Define the smallest applicable contract: `AgentAdapter` plus metadata, `ProviderTemplate` and optional capability implementations, or `FrameworkAdapter`.
+2. Keep vendor- and provider-specific behavior in the plugin. Use agent metadata for declarative mappings and provider `agentHooks` for provider/agent differences; retain only provider-agnostic defaults in agent lifecycle metadata.
+3. Add the plugin to its composition entrypoint: the lazy built-in list in `AgentRegistry`, a provider plugin imported by `src/providers/index.ts`, or `src/frameworks/plugins/index.ts`. Registration is required; merely exporting a class or template does not make it discoverable.
+4. Consume it through the registry from CLI code. Preserve the management/analytics distinction for an analytics-only agent.
+5. Add focused tests: agent-registry tests should assert the complete built-in name membership and adapter contract; provider registry tests should cover registration, lookup, and duplicate-name override. Run `npm run typecheck`, `npm run lint`, and the relevant Vitest project(s) before relying on a new integration.
+
+These boundaries make initialization ordering observable. A missing composition import produces an absent registry lookup and the caller's unsupported/not-found behavior, rather than a hidden fallback to a concrete plugin. Conversely, importing a composition entrypoint intentionally has side effects, so it belongs at a startup boundary or explicit integration setup point.

--- a/openwiki/concepts/configuration-and-local-state.md
+++ b/openwiki/concepts/configuration-and-local-state.md
@@ -1,0 +1,121 @@
+---
+type: configuration concept
+title: Profiles, Configuration Precedence, and Local State
+description: How CodeMie resolves provider profiles and workspace state across global and project scopes, environment variables, and CLI overrides. Covers credential-safe operations and the relocatable CodeMie home contract.
+tags: [configuration, profiles, local-state, security, cli]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-5c9d50c277e23ab2a5c2be7a
+    resource: repo://src/agents/core/__tests__/config-redaction.test.ts
+  - id: openwiki-source-61627618dec02ad08e96ebf6
+    resource: repo://src/cli/commands/profile/index.ts
+  - id: openwiki-source-695d85f5d5d0c2794cb95e75
+    resource: repo://src/env/types.ts
+  - id: openwiki-source-1d3f73d9556cf482cdc8e588
+    resource: repo://src/migrations/__tests__/007-decouple-provider-workspace-config.migration.test.ts
+  - id: openwiki-source-fb49e7ca792739d2d6c63040
+    resource: repo://src/providers/core/types.ts
+  - id: openwiki-source-f4b537b2470604dc8c0e2f1d
+    resource: repo://src/utils/__tests__/config-project-override.test.ts
+  - id: openwiki-source-07cf75292ad1458efff13f97
+    resource: repo://src/utils/config.ts
+  - id: openwiki-source-802ad581431769e819a08862
+    resource: repo://src/utils/logger.ts
+  - id: openwiki-source-ed8a2ce3d6071aa1f213f5aa
+    resource: repo://src/utils/paths.ts
+  - id: openwiki-source-79c0c43a254e62e4a5696710
+    resource: repo://src/utils/security.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+# Profiles, Configuration Precedence, and Local State
+
+`ConfigLoader` is the runtime authority for configuration. It converts persisted configuration—legacy single-provider files or version-2 multi-provider documents—into one `CodeMieConfigOptions` object for an agent or command. Provider identity and repository/tooling context deliberately have different ownership: a profile holds provider-facing choices and credentials, while a scope-level `workspace` holds context shared when profiles change.
+
+## Storage contract and document shape
+
+The global configuration file is resolved as `getCodemiePath('codemie-cli.config.json')`; its default home is the user's `.codemie` directory, but `CODEMIE_HOME` relocates that home. Code must therefore use `getCodemieHome()` and `getCodemiePath()` rather than constructing a home-directory or `~/.codemie` path. The project file is relative to the working directory: `.codemie/codemie-cli.config.json`.
+
+A v2 document has `version: 2`, an `activeProfile`, a `profiles` map, and optional top-level `workspace`, `codemieSkills`, `codemieAssistants`, and `userEmail`. A profile may contain provider, endpoint, API key, model, timeout/debug settings, model tiers, AWS settings, and SSO/JWT material. `workspace` instead owns CodeMie URL/project/integration selection, hooks, plugins, assistant history policy, skill-search endpoint, Claude compaction setting, and metrics settings. The runtime type is the union of these two shapes, but persistence must preserve the separation.
+
+```json
+{
+  "version": 2,
+  "activeProfile": "work",
+  "profiles": {
+    "work": {
+      "provider": "ai-run",
+      "baseUrl": "https://litellm.codemie.example.com",
+      "apiKey": "your-litellm-api-key-here",
+      "model": "claude-sonnet-4-6"
+    }
+  },
+  "workspace": {
+    "codeMieProject": "example-project"
+  }
+}
+```
+
+The example is structural only: never commit an actual API key. `saveProfile()` and `initProjectConfig()` split any mixed input so workspace keys are stored in the scope's `workspace`, not below `profiles[name]`. The first saved profile becomes active. Configurations in the older provider-shaped format are read as an in-memory `default` v2 profile; an invalid nonempty project document is rejected as not being v2.
+
+## Resolution model
+
+The ordinary field precedence is **CLI > environment > project > global > defaults**. Defaults include `name: 'default'`, provider `openai`, unlimited timeout (`0`), `debug: false`, an empty allowed-directory list, and standard ignored build/VCS directories. Before environment resolution, a project `.env` is loaded if present. Supported environment inputs include `CODEMIE_PROVIDER`, `CODEMIE_BASE_URL`, `CODEMIE_API_KEY`, `CODEMIE_MODEL`, `CODEMIE_TIMEOUT`, `CODEMIE_DEBUG`, `CODEMIE_ALLOWED_DIRS`, `CODEMIE_IGNORE_PATTERNS`, `CODEMIE_URL`, `CODEMIE_AUTH_METHOD`, and the integration ID/alias pair.
+
+```mermaid
+flowchart TD
+  D["Built-in defaults"] --> G["Selected global profile"]
+  G --> P["Eligible project profile"]
+  P --> W["Resolved workspace object"]
+  W --> E["Process environment and project .env"]
+  E --> C["CLI overrides"]
+  C --> R["Effective runtime configuration"]
+  LP["Local active profile"] --> S["Profile selection"]
+  GP["Global active profile"] --> S
+  S --> G
+  S --> P
+  LW["Local workspace"] --> W
+  GW["Global workspace"] --> W
+```
+
+This shows profile selection, scope overlays, and final precedence. A local active profile wins selection when no explicit profile is supplied; otherwise the global active profile supplies the default. An explicit CLI profile selects that name. A same-named local profile overlays its global counterpart. If a selected global profile differs from the repository's local team profile, the loader does **not** apply that local provider/model/credential record, preventing the team profile from replacing the explicitly selected identity. A named profile that exists only locally can still load, and a locally selected name that exists only globally uses the global record.
+
+Workspace follows a separate invariant: it is a whole-object choice, not a field merge. A non-null local `workspace` wins outright; otherwise the global `workspace` is used; otherwise it is empty. This prevents global context leaking into a partial local workspace and keeps context stable when the active provider profile changes. Treat an externally written `workspace: null` as absent so global fallback remains safe.
+
+An explicit profile also protects its provider-specific identity from ambient environment values. Unless the corresponding CLI field is supplied, environment `baseUrl`, `apiKey`, `model`, `provider`, `codeMieUrl`, `authMethod`, and `codeMieIntegration` are filtered rather than overriding the chosen profile. Remaining environment and then CLI fields retain their normal higher precedence.
+
+## Profiles and lifecycle operations
+
+`ConfigLoader.listProfiles()` combines global records first and then local records, replacing same-named global entries with the local version; the active marker is local `activeProfile` when present, otherwise global. `getProfile()` is local-first. `switchProfile()` verifies that the name exists in the combined list, then writes the active-profile reference to the local document if one exists, otherwise globally. A local active reference may intentionally point to a global-only profile. Deletion likewise targets local storage whenever a project config exists; deleting the active profile selects the first remaining profile or an empty active value. Rename is a global-config operation.
+
+The `codemie profile` command exposes listing, `status`, `login`, `logout`, `refresh`, `switch`, `delete`, and `rename`. `status --show-sources` uses `loadWithSources()` to attribute effective fields to `default`, `global`, `project`, `env`, or `cli`; displayed sensitive values are masked recursively. Normal status optionally calls provider setup hooks for authentication validation/status and can offer reauthentication. `login --url` takes precedence over the resolved workspace URL; `refresh` is only available to an SSO provider with a configured CodeMie URL and clears old credentials before authenticating again.
+
+`loadAndValidate()` requires a resolved `baseUrl`, `apiKey`, and `model`, and validates hook schema when hooks are present. Use it at a boundary that requires a runnable provider; use `load()` where incomplete setup needs to be inspected or completed. Provider templates declare authentication type/capabilities and may implement `exportEnvVars(config)`, making provider-specific environment projection an extension point rather than loader-specific branching. The generic exporter clears stale auth-method and model-tier values with empty values where necessary, and provides `not-required` as the API-key value only for providers that declare no authentication requirement.
+
+## Credentials, diagnostics, and logs
+
+Credentials can occur in `apiKey`, JWT fields, encrypted SSO cookies, AWS secret material, environment variables, provider-specific properties, and request headers. Do not print a resolved config or credential-adjacent object. Source reporting masks keys/tokens/passwords and nested values, while SSO credential storage encrypts the serialized record, attempts the OS keychain, and also maintains encrypted file storage keyed by a hash of the normalized base URL.
+
+For implementation diagnostics, use `logger.debug()` rather than raw `console.log` debug output. Pass credential-adjacent values through `sanitizeLogArgs()` at the call site—for example, `logger.debug('Provider setup failed', ...sanitizeLogArgs({ baseUrl, error }))`. This is important because log arguments can contain nested headers, cookies, keys, tokens, or error payloads. The logger sanitizes arguments before file writes, but debug console output receives its supplied arguments; explicit call-site sanitization prevents accidental terminal disclosure. The logger's files are placed with `getCodemiePath('logs')`, rotate across dates, and cleanup targets dated debug logs older than five days.
+
+Keep secrets out of project-local config whenever a repository can be shared. Environment variables or profile-specific secure authentication flows are appropriate operational injection points, subject to the explicit-profile filtering behavior above. The `config.example.json` API-key field is a placeholder, not a credential distribution mechanism.
+
+## Other local state
+
+The CodeMie home also contains state beyond global configuration. `getInstallationId()` reads or creates a persistent UUID at `getCodemiePath('installation-id')`. Top-level registered skills and assistants are scoped global or local and are returned only if their corresponding `.claude/skills/.../SKILL.md` or `.claude/agents/...` artifact still exists; combined assistant loading gives local registrations precedence by ID. These are scope-level registrations rather than properties of the active provider profile.
+
+## Change and test guidance
+
+When changing resolution logic, test the observable composition, not only parser output:
+
+- global/profile/local/CLI precedence and field-source attribution;
+- explicit-profile isolation from environment credentials and a different local team profile;
+- local-versus-global whole-workspace selection, including `workspace: null` fallback;
+- local/global profile listing, active-reference switching, deletion fallback, and local-only/global-only names;
+- v1-to-v2 read compatibility and rejection of invalid nonempty local files;
+- redaction of nested keys, headers, and credential-bearing log arguments; and
+- `CODEMIE_HOME` isolation, ensuring no test or feature embeds a machine-specific home path.
+
+The focused configuration tests cover project initialization, precedence, workspace splitting, and source attribution; migration tests cover lifting workspace fields out of profiles. Security and agent print-config tests cover secret redaction. See [CLI Surface](../architecture/cli-surface.md), [Provider Plugins and Local Proxy](../integrations/provider-plugins-and-local-proxy.md), [Daemon Migrations and Diagnostics](../operations/daemon-migrations-and-diagnostics.md), [Test Strategy](../testing/test-strategy.md), and [Agent Launch and Session Telemetry](../workflows/agent-launch-and-session-telemetry.md) for the consumers and operations around this state.

--- a/openwiki/concepts/index.md
+++ b/openwiki/concepts/index.md
@@ -1,0 +1,3 @@
+# Files
+
+- [Profiles, Configuration Precedence, and Local State](configuration-and-local-state.md) - How CodeMie resolves provider profiles and workspace state across global and project scopes, environment variables, and CLI overrides. Covers credential-safe operations and the relocatable CodeMie home contract.

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -1,0 +1,16 @@
+---
+okf_version: "0.2"
+---
+
+# Files
+
+- [CodeMie Code Wiki Quickstart](quickstart.md) - A task-routing guide from the published CodeMie entry points to the architecture, runtime boundaries, operational lifecycle, integrations, workflows, and focused test suites needed to change the package safely.
+
+# Directories
+
+- [architecture](architecture/)
+- [concepts](concepts/)
+- [integrations](integrations/)
+- [operations](operations/)
+- [testing](testing/)
+- [workflows](workflows/)

--- a/openwiki/integrations/agent-plugin-system.md
+++ b/openwiki/integrations/agent-plugin-system.md
@@ -1,0 +1,170 @@
+---
+type: integration architecture
+title: Agent Adapters, Installation, and Runtime Injection
+description: How CodeMie represents coding agents as registry-backed adapters, manages their installation and launch lifecycle, and injects runtime plugins into the built-in CodeMie Code runtime.
+tags: [agents, adapters, registry, cli, lifecycle, plugins, runtime-injection]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-8037e2358a2c4f9b2c722a11
+    resource: repo://AGENTS.md
+  - id: openwiki-source-371a6d8a4fcb291e3e8d7291
+    resource: repo://bin/agent-executor.js
+  - id: openwiki-source-ca5be3ddf6c650192b07d537
+    resource: repo://bin/codemie-codex.js
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-64dc44673911329909428108
+    resource: repo://src/agents/core/agent-aliases.ts
+  - id: openwiki-source-23c009faa70a994252df8b77
+    resource: repo://src/agents/core/AgentCLI.ts
+  - id: openwiki-source-029d2ecb6970e7ac12c6f34f
+    resource: repo://src/agents/core/BaseAgentAdapter.ts
+  - id: openwiki-source-820e3288d1d3678265fa6397
+    resource: repo://src/agents/core/lifecycle-helpers.ts
+  - id: openwiki-source-74e4c0cff42e3b8d2ad1baaa
+    resource: repo://src/agents/core/plugin-injector.ts
+  - id: openwiki-source-8092609c520e79bd6205b48b
+    resource: repo://src/agents/core/types.ts
+  - id: openwiki-source-5f4c50a5d832cb7f4a28d802
+    resource: repo://src/agents/plugins/__tests__/codemie-code-plugin.test.ts
+  - id: openwiki-source-3a0c3a565ea37b84bab47021
+    resource: repo://src/agents/plugins/codemie-code.plugin.ts
+  - id: openwiki-source-3b673d573f7ff0320a3f9686
+    resource: repo://src/agents/plugins/codex/__tests__/codex.plugin.lifecycle.test.ts
+  - id: openwiki-source-725ee7bf4406c835f67362bc
+    resource: repo://src/agents/plugins/copilot-cli/__tests__/copilot-cli.registry.test.ts
+  - id: openwiki-source-57b335657db57300c5fe9370
+    resource: repo://src/agents/plugins/copilot-cli/copilot-cli.plugin.ts
+  - id: openwiki-source-a99980f68efcdaccee402371
+    resource: repo://src/agents/plugins/reasoning-sanitizer/__tests__/inject-sanitizer.test.ts
+  - id: openwiki-source-cf985357c2ea8c403c53e222
+    resource: repo://src/agents/registry.ts
+  - id: openwiki-source-f81de7c4de5c70d2d285345a
+    resource: repo://src/cli/commands/install.ts
+  - id: openwiki-source-b5050a26bf04382d4e191566
+    resource: repo://src/cli/commands/update.ts
+  - id: openwiki-source-5f042317afc8946b4f3866e6
+    resource: repo://tests/integration/agent-codex.test.ts
+  - id: openwiki-source-f1efde2afc592f6bf9eb21ee
+    resource: repo://tests/integration/agent-opencode.test.ts
+  - id: openwiki-source-3e98c758fcbdae28a6e9b123
+    resource: repo://tests/integration/agent-shortcuts.test.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+## Scope and architectural boundary
+
+CodeMie treats an agent integration as an `AgentAdapter`: a metadata-driven wrapper around an external CLI or the built-in CodeMie Code runtime. The adapter owns agent-specific installation, executable discovery, native argument and environment conventions, session parsing, and optional extension or hook capabilities. The common runtime owns profile loading, authentication, proxy setup, compatibility gates, process supervision, and the lifecycle envelope.
+
+Keep the boundary directional when adding or changing an agent:
+
+```text
+CLI command -> AgentRegistry -> AgentAdapter plugin -> native agent binary
+```
+
+The CLI must resolve an adapter through `AgentRegistry`; it should not import an individual plugin or duplicate its metadata. The registry lazily constructs the built-in set—CodeMie Code, Claude and Claude ACP, Gemini, OpenCode, Codex, Pi, Kimi and Kimi ACP, and Copilot CLI—and separately exposes any analytics adapters declared in plugin metadata.
+
+`AgentMetadata` is the declarative part of the contract. In addition to identity and package/command information, it can describe supported and blocked provider/model combinations, version bounds, `CODEMIE_*` to native environment mappings, flag mappings, reasoning-effort injection, data/session locations, MCP and extension scan locations, lifecycle defaults, hook payload mapping, analytics, and installation hints. The operational interface supplies `install`, `uninstall`, `isInstalled`, `run`, `getVersion`, and optional version, session, resume-ownership, extension-installation, and analytics capabilities.
+
+## Manageability and analytics are related but distinct
+
+The registry keeps all adapters available because analytics discovery resolves session adapters through it. Management surfaces, however, must use `getManageableAgents()`, which excludes metadata marked `analyticsOnly`. This prevents `install`, `uninstall`, `update`, `list`, `doctor`, and first-run UI from advertising or altering a tool CodeMie only reads telemetry from. `getInstalledAgents()` similarly checks only manageable adapters.
+
+An analytics-only adapter is a capability classification, not a weaker registry entry: it may still provide an analytics/session adapter, but it must not be installed, launched, or updated by CodeMie. In the current built-in registrations, Copilot CLI is explicitly a managed integration, not analytics-only; it has npm metadata and participates in management while also supplying a session adapter for analytics.
+
+## Entry points and shortcut wrappers
+
+The package publishes an umbrella `codemie` executable plus one executable per supported launch target, such as `codemie-claude`, `codemie-codex`, `codemie-opencode`, and `codemie-code`. Each shortcut is deliberately thin: it imports compiled ES modules with `.js` extensions, asks `AgentRegistry` for its canonical name, exits if absent, then gives the adapter to `AgentCLI` with `process.argv`. A shortcut therefore receives the same configuration, compatibility, proxy, and lifecycle handling as the umbrella command.
+
+The launcher convention is `codemie-<agent>`, except that an adapter whose canonical name already starts with `codemie-` launches as that name. User-facing aliases are resolved before registry lookup; currently `copilot` maps to `copilot-cli`, and its preferred launcher is `codemie-copilot`.
+
+`AgentCLI` builds the shared Commander surface: profile/provider/model/base URL/API-key/JWT/timeout overrides, `--task`, reasoning effort, resume, status, silent mode, report control, health, and pass-through arguments. It suppresses framework `init` if the native agent owns that subcommand, and provides `setup assistants` and `setup skills` only for Claude, Codex, and Gemini. It checks installation before configuration or launch; `--task` and `--print-config` force silent operation, and `--print-config` is accepted only for OpenCode.
+
+## Install, update, and compatibility policy
+
+`codemie install [name] [version]` resolves aliases and then the registry adapter. With no name it lists manageable agents; it never lists analytics-only integrations as installable. The installer prefers `--supported`, then an explicit version; Claude and Codex default to their tested supported version. A matching installed version is retained, but optional `additionalInstallation()` still runs. Otherwise installation calls `installVersion()` when a version was selected, or `install()`, restores the CodeMie bin link, verifies the detected version, and displays plugin-provided post-install hints or standard launcher examples.
+
+The base adapter implements npm global installation/uninstallation for adapters with `npmPackage`, command-based presence detection, and `--version` lookup. Plugins can override this for native installers or special artifacts. CodeMie Code is a special built-in adapter: it checks for and installs the `@codemieai/codemie-opencode` whitelabel binary, and its uninstall also attempts to remove the platform package left hoisted by npm. Built-in agents cannot use the base external-agent installer.
+
+`codemie update` also works only over manageable adapters. It treats Claude as a native supported-version update, updates the built-in agent by updating the CodeMie CLI package, and otherwise queries and force-installs the adapter's npm package. This is why accidentally making an external/analytics-only tool manageable is unsafe.
+
+Before a version-managed adapter launches, the base adapter compares its installed version to `supportedVersion` and `minimumSupportedVersion`. A version below the minimum is a hard stop: silent/ACP mode throws so protocol stdout remains clean; interactive mode offers installation of the supported version or exit. A newer untested version and an older-but-not-minimum version produce interactive update/continue/exit choices. Semver parse failures are treated as incompatible. Claude illustrates the metadata policy with supported and minimum versions, native installer URLs, mapped Anthropic variables, and a lifecycle default which disables its auto-updater so the compatibility policy remains effective.
+
+## Launch dispatch and lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Shortcut as codemie agent shortcut
+    participant Registry as AgentRegistry
+    participant CLI as AgentCLI
+    participant Adapter as BaseAgentAdapter
+    participant Provider as Provider plugin
+    participant Proxy as CodeMieProxy
+    participant Native as Agent binary
+
+    User->>Shortcut: launch with arguments
+    Shortcut->>Registry: getAgent canonical name
+    Registry-->>Shortcut: adapter
+    Shortcut->>CLI: run argv
+    CLI->>CLI: install config auth compatibility resume checks
+    CLI->>Adapter: run pass through args and provider environment
+    Adapter->>Adapter: create session and repository context
+    Adapter->>Proxy: start only for SSO or JWT when enabled
+    Adapter->>Provider: resolve lifecycle hooks
+    Adapter->>Adapter: session start and environment mapping
+    Adapter->>Adapter: before run and enrich arguments
+    Adapter->>Native: spawn with inherited stdio
+    Native-->>Adapter: exit or startup error
+    Adapter->>Adapter: session end then proxy cleanup
+    Adapter->>Provider: after run
+    Adapter-->>User: exit status
+```
+
+This diagram shows normal adapter dispatch and the lifecycle around the native process.
+
+`AgentCLI` loads the selected profile with command-line overrides, normalizes SSO/JWT API URLs, verifies required configuration and provider authentication, validates metadata provider/model compatibility, and exports the resulting provider environment. A `--jwt-token` overrides profile authentication. Reasoning effort is validated before the adapter sees it. On resume, an adapter may recognize its native positional resume syntax and resolve ownership. Resuming a session known to be external requires explicit interactive confirmation; non-interactive/no-prompt execution blocks it. Confirmation sets an environment marker so downstream session ingestion records the external origin and does not sync it as a CodeMie session.
+
+`BaseAgentAdapter.run()` first generates the session UUID and repository/branch context, merges overrides into a `CODEMIE_*` environment, initializes the logger session, and conditionally starts the local proxy. A proxy is used only when the provider has SSO authentication or the request uses JWT **and** the agent enables proxy support; providers with `authType: 'none'` never use it. On startup the proxy replaces `CODEMIE_BASE_URL` with its local URL and uses a placeholder API key before agent-specific mapping.
+
+The hook order is:
+
+1. `onSessionStart`
+2. map `CODEMIE_*` values into the agent's native environment
+3. `beforeRun`
+4. `enrichArgs`
+5. declarative flag mapping and reasoning-effort injection
+6. built-in handler or spawned native command
+7. `onSessionEnd`, followed by proxy cleanup
+8. `afterRun`, then the optional per-session analytics report
+
+Provider lifecycle resolution preserves agent/provider separation. A provider wildcard hook runs first, then its agent-specific hook; when only a wildcard exists it can feed the agent default. An agent-specific provider hook otherwise replaces the agent default. This lets provider plugins customize an agent without hardcoding providers into the agent integration.
+
+The runtime clears previously mapped native variables before setting mapped values, avoiding inherited-shell contamination. It resolves executables through `PATH` and Unix fallback locations, accounts for Windows quoting and shell behavior, passes inherited stdio, and handles `SIGINT`/`SIGTERM` by cleaning up the proxy and killing the child. Session-end execution is protected so a failing hook cannot strand the proxy; it runs before cleanup, while `afterRun` follows. External processes get a brief proxy grace period for final API calls. Analytics report generation, when opted in by metadata and not disabled by `--no-analytics-report`, is non-fatal.
+
+## Built-in CodeMie Code versus injected runtime plugins
+
+There are two different things called “plugin” here:
+
+- An **agent plugin** is an in-process TypeScript `AgentAdapter` registered by `AgentRegistry`. It represents an agent integration and participates in CLI management and lifecycle dispatch.
+- A **runtime plugin** is source injected into the CodeMie Code/OpenCode-compatible child runtime for one launch. It is not registered as an agent and is not a user-installed extension.
+
+CodeMie Code is itself the built-in agent adapter. Its `beforeRun` builds an OpenCode provider/model configuration, obtains the local proxy endpoint when applicable, sets the whitelabel runtime configuration in `OPENCODE_CONFIG_CONTENT` (or a temporary config file when it is too large), redirects session storage under CodeMie home, and disables OpenCode sharing. It translates a CodeMie `--task` into the native `run` form while leaving recognized native OpenCode subcommands intact.
+
+That same hook builds default `SessionStart` and `SessionEnd` command hooks using an absolute resolved `codemie hook` command, layers profile hooks over those defaults, then merges enabled CodeMie plugin hooks at lower priority than profile hooks. It serializes the result in `OPENCODE_HOOKS`. It additionally appends two runtime `file://` plugins to the generated OpenCode configuration: the shell-hooks plugin and the reasoning-sanitizer plugin.
+
+The injector writes each embedded runtime source once to `<tmpdir>/codemie-hooks/`, returns its `file://` URL, registers best-effort process-exit cleanup, and supports explicit idempotent cleanup. CodeMie Code invokes that cleanup after its session-end pipeline. These short-lived files make the whitelabel runtime load CodeMie behavior without turning that behavior into a persisted external agent plugin.
+
+## Safe extension and maintenance rules
+
+When implementing an agent, add its metadata and adapter under `src/agents/plugins/`, register it centrally, add a shortcut/bin mapping where it is launchable, and route management through aliases and registry queries. Do not bypass `AgentCLI` or create an agent-specific CLI that reimplements profile, auth, proxy, compatibility, or lifecycle behavior. Mark telemetry readers `analyticsOnly: true`; management surfaces must continue using `getManageableAgents()`.
+
+Use the repository ES-module conventions in integration code: `.js` on imports, no `require()` or `__dirname`, and `@/` aliases rather than new deep relative imports. Use the project error classes (for example `AgentInstallationError`, `AgentNotFoundError`, and `ConfigurationError`) at user-facing boundaries instead of generic errors where a domain error exists. Operational diagnostics belong in `logger.debug()`; credential-adjacent values or error contexts must be passed through `sanitizeLogArgs()` rather than logged raw.
+
+## Focused verification
+
+The unit suite covers the built-in adapter's binary detection, install/uninstall behavior (including platform artifact cleanup), lifecycle metadata, session-adapter exposure, injected-plugin file creation/idempotence/cleanup, and absolute default hook commands. Codex lifecycle tests assert that incremental sync starts at session start and stops before processing the session-end event. Registry tests assert that Copilot can be reached by the same session-adapter lookup used by analytics and remains present in management queries.
+
+Agent integration smoke tests exercise shortcut loading and help/health behavior. The real-agent tier is conditionally enabled when SSO credentials are available and runs isolated-home task workflows: Codex verifies proxy authentication, live model resolution, `--task` to `codex exec`, and stdout response; OpenCode verifies binary resolution, proxy/config/hook injection, `run`, and stdout response. Run the appropriate Vitest projects using the package scripts: `npm run test:unit`, `npm run test:integration`, or `npm run test:integration:agent`.

--- a/openwiki/integrations/index.md
+++ b/openwiki/integrations/index.md
@@ -1,0 +1,5 @@
+# Files
+
+- [Agent Adapters, Installation, and Runtime Injection](agent-plugin-system.md) - How CodeMie represents coding agents as registry-backed adapters, manages their installation and launch lifecycle, and injects runtime plugins into the built-in CodeMie Code runtime.
+- [MCP Relay and Desktop/Editor Proxy Clients](mcp-and-desktop-clients.md) - How CodeMie bridges stdio MCP clients to remote streamable HTTP servers with per-session OAuth and cookies, and configures Claude Desktop, VS Code, and Codex Desktop to use its managed local proxy.
+- [Provider Plugins, SSO, and the Streaming Local Proxy](provider-plugins-and-local-proxy.md) - How provider plugins register capabilities and setup behavior, and how SSO or JWT-authenticated agent traffic passes through the ordered, streaming local proxy.

--- a/openwiki/integrations/mcp-and-desktop-clients.md
+++ b/openwiki/integrations/mcp-and-desktop-clients.md
@@ -1,0 +1,174 @@
+---
+type: integration guide
+title: MCP Relay and Desktop/Editor Proxy Clients
+description: How CodeMie bridges stdio MCP clients to remote streamable HTTP servers with per-session OAuth and cookies, and configures Claude Desktop, VS Code, and Codex Desktop to use its managed local proxy.
+tags: [mcp, oauth, proxy, claude-desktop, vscode, codex]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-73aafb9bc993302f60627faa
+    resource: repo://bin/codemie-mcp-proxy.js
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-e0473de04e8bca2ab58c15ba
+    resource: repo://src/cli/commands/mcp/index.ts
+  - id: openwiki-source-b6be2d00bb76713b45bc14e7
+    resource: repo://src/cli/commands/proxy/connect-orchestrator.ts
+  - id: openwiki-source-2c40aa6736391a2d90c58ea0
+    resource: repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop-roundtrip.test.ts
+  - id: openwiki-source-720c45d652a783f720dc208e
+    resource: repo://src/cli/commands/proxy/connectors/__tests__/managed-mcp-remote.test.ts
+  - id: openwiki-source-431846ceb2d744bc3ea2460d
+    resource: repo://src/cli/commands/proxy/connectors/codex-config-toml.ts
+  - id: openwiki-source-628011c68a1102ec766bd0f6
+    resource: repo://src/cli/commands/proxy/connectors/codex-desktop.ts
+  - id: openwiki-source-ea1084a8af1cae3a9fc96515
+    resource: repo://src/cli/commands/proxy/connectors/desktop.ts
+  - id: openwiki-source-1f8f36225466bda936978790
+    resource: repo://src/cli/commands/proxy/connectors/managed-mcp-remote.ts
+  - id: openwiki-source-2f0beade4fae99f513da7c07
+    resource: repo://src/cli/commands/proxy/connectors/vscode-claude-code.ts
+  - id: openwiki-source-683fcb4718c4f2e6f575cb54
+    resource: repo://src/cli/commands/proxy/connectors/vscode.ts
+  - id: openwiki-source-beb5bc61c2dd56a7676e2b44
+    resource: repo://src/cli/commands/proxy/daemon-manager.ts
+  - id: openwiki-source-203af971e5106b89f72f1924
+    resource: repo://src/cli/commands/proxy/index.ts
+  - id: openwiki-source-4009f96dac317b1a3e9f2ab4
+    resource: repo://src/mcp/__tests__/mcp-auth.test.ts
+  - id: openwiki-source-7194e3de52a28f97e55ffc75
+    resource: repo://src/mcp/__tests__/mcp-bridge-logger.test.ts
+  - id: openwiki-source-470ac4096ba0474e24d93208
+    resource: repo://src/mcp/auth/callback-server.ts
+  - id: openwiki-source-85667bef4bba5a6e634cb78e
+    resource: repo://src/mcp/auth/mcp-oauth-provider.ts
+  - id: openwiki-source-68fe9e3f9e3b1f5af7d1b97f
+    resource: repo://src/mcp/stdio-http-bridge.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+CodeMie has two complementary integration paths:
+
+- **MCP relay**: `codemie-mcp-proxy` is a deliberately small stdio process for a client such as Claude Code. It relays JSON-RPC to one remote streamable-HTTP MCP server and performs browser OAuth when that server challenges the connection.
+- **Managed local-proxy clients**: `codemie proxy connect` starts or reuses one local CodeMie gateway daemon, then writes client-specific configuration for Claude Desktop, VS Code, the VS Code Claude Code extension, or Codex Desktop.
+
+These paths solve different problems. The MCP relay carries MCP traffic to a remote MCP endpoint; the managed clients send model traffic to the local CodeMie gateway. Claude Desktop is the overlap: its connector also receives an organization-managed MCP catalog and writes it into Desktop's `managedMcpServers` setting.
+
+## MCP relay
+
+### Entrypoints and installation
+
+The package exposes `codemie-mcp-proxy`, backed by `bin/codemie-mcp-proxy.js`. The launcher validates its required URL, imports only the compiled bridge, starts it, and handles `SIGINT`/`SIGTERM`. It intentionally avoids the normal CLI initialization—migrations, update checks, and plugin loading—because any stdout output would corrupt the JSON-RPC stdio channel. Boot diagnostics go to `~/.codemie/logs/mcp-proxy.log`; user-facing errors use stderr.
+
+Use the convenience command to register a server with Claude Code:
+
+```sh
+codemie mcp add <name> <url> --scope <scope>
+```
+
+It validates the URL and rejects a server name that starts with `-`, verifies that both `codemie-mcp-proxy` and `claude` are installed, then executes the equivalent Claude CLI registration with `codemie-mcp-proxy <url>` after `--`. The scope is forwarded only when supplied. Alternatively, the general CLI command is:
+
+```sh
+codemie mcp-proxy <url>
+```
+
+### Lazy connection, OAuth, cookies, and forwarding
+
+`StdioHttpBridge` starts its `StdioServerTransport` immediately, but does not create the streamable HTTP transport until the first JSON-RPC message. Messages arriving during this one connection attempt are queued. Once connected, subsequent stdio messages are sent directly to HTTP; inbound HTTP messages are sent back over stdio.
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP stdio client
+    participant Bridge as StdioHttpBridge
+    participant OAuth as McpOAuthProvider
+    participant Callback as localhost callback server
+    participant Browser as system browser
+    participant Remote as remote MCP server
+
+    Client->>Bridge: first JSON-RPC message
+    Bridge->>Bridge: queue message and begin lazy connect
+    Bridge->>OAuth: ensureCallbackServer
+    OAuth->>Callback: listen on localhost ephemeral port
+    Bridge->>Remote: start streamable HTTP transport
+    alt authorization required
+        Remote-->>Bridge: UnauthorizedError
+        OAuth->>Browser: open authorization URL
+        Browser->>Callback: GET callback with code
+        Callback-->>OAuth: authorization code
+        OAuth-->>Bridge: code
+        Bridge->>Remote: finishAuth code
+    end
+    Remote-->>Bridge: Set-Cookie response headers
+    Bridge->>Bridge: store cookies by origin
+    Bridge->>Remote: flush queued JSON-RPC with cookies
+    Remote-->>Bridge: JSON-RPC response or notification
+    Bridge-->>Client: JSON-RPC response or notification
+```
+
+This sequence shows the first-message connection, optional OAuth authorization, per-origin cookie capture, and bidirectional JSON-RPC forwarding.
+
+The bridge creates a cookie-aware `fetch` for the HTTP transport because Node fetch does not retain response cookies itself. It captures individual `Set-Cookie` values as `name=value`, keyed by request origin, and supplies the matching origin's combined `Cookie` header on later requests. The jar is in memory, so it lasts only for the bridge process and is not shared across origins.
+
+OAuth state is also session-only. Before HTTP startup, the provider starts a loopback callback server so that its dynamically registered client metadata already has a redirect URI. The provider advertises authorization-code and refresh-token grants with no token-endpoint client authentication, uses `MCP_CLIENT_NAME` when set (otherwise `CodeMie CLI`), and retains client registration, tokens, and PKCE verifier only in memory. On an authorization redirect it opens the platform browser; on Windows it uses PowerShell `Start-Process` so query parameters are not truncated by `cmd` parsing. If opening fails, the authorization URL is written to stderr for manual use.
+
+The callback listener binds `localhost` on an OS-assigned port and accepts only `/callback`. It resolves once with `code` and optional `state`, returns a success page, and closes; an OAuth error, missing code, explicit close, or the default two-minute timeout rejects the pending authorization. Bridge shutdown disposes the callback server, terminates and closes HTTP if it exists, and closes stdio; the shutdown guard makes this idempotent. An HTTP transport close also initiates bridge shutdown. A non-auth connection failure while not shutting down exits the relay process, whereas individual failures while flushing queued messages are logged and do not retry that message unless the failure is `UnauthorizedError`.
+
+### Relay observability and safe changes
+
+Bridge diagnostics use `logger.debug()` and optional file logging enabled at module load by `MCP_PROXY_DEBUG=true`/`1` or `CODEMIE_DEBUG=true`/`1`. Since stdio is protocol data, do not add `console.log` to the relay. In credential-adjacent changes, use the project's error classes (for example, `ConfigurationError` or `ToolExecutionError`) at command boundaries, log through `logger.debug()`/the project logger, and pass structured log arguments through `sanitizeLogArgs()`. Never log OAuth codes, tokens, cookies, or gateway keys; log header presence, counts, names, or sanitized metadata instead.
+
+## Managed proxy connection flow
+
+`codemie proxy connect` accepts one or more target flags:
+
+```sh
+codemie proxy connect --claude-desktop
+codemie proxy connect --vscode
+codemie proxy connect --vscode-claude-code
+codemie proxy connect --codex-desktop --model <slug>
+```
+
+`--profile`, `--force`, and `--verbose` apply to the connection; `--insiders` selects VS Code Insiders for either VS Code target. Calling `connect` with no target prints the target list without configuration changes. The legacy `codemie proxy connect desktop` and `codemie proxy connect vscode` commands still work but print a deprecation notice for `--claude-desktop` and `--vscode` respectively. `codemie proxy disconnect --codex-desktop` removes only the Codex integration.
+
+Before starting a daemon, the orchestrator resolves an SSO-backed profile, verifies stored SSO credentials, and synchronizes registered and plugin skills on a best-effort basis. A Claude Desktop target additionally requires `codeMieUrl`, since that URL is used to fetch organization MCP servers. It derives a daemon identity from the target set: Claude Desktop and the VS Code Claude Code extension use the `claude-desktop` telemetry identity; VS Code BYOK uses `vscode-byok`; Codex uses `codex-desktop`.
+
+Only one daemon serves a connect run. Its persisted state records process identity, local URL and port, profile, gateway key, upstream/provider/project metadata, client identity, and health fields. A running daemon is reused only if profile, port, project, optional provider/upstream URL, and effective client type match, and its deep health check passes. A mismatch, unhealthy daemon, or `--force` causes a stop and restart. Startup polls for readiness for up to five seconds. Stop sends `SIGTERM`, waits up to five seconds, then escalates to `SIGKILL` and clears state so a wedged process cannot block another connection.
+
+Each requested configuration writer runs independently after the daemon is available. The command prints a per-target result summary, sets a nonzero exit code when any target fails, and rolls back a daemon it started only when all requested targets failed. Combining Codex Desktop with a higher-priority target is allowed but warned against: the shared daemon then lacks Codex model-name resolution, so Codex should be connected by itself.
+
+### Claude Desktop: gateway settings and managed MCP catalog
+
+The connector writes CodeMie inference settings into Claude Desktop's active `configLibrary/<UUID>.json`, registers that file through `_meta.json`, preserves unrelated configuration keys, and tells the user to restart the app. It discovers models through the local gateway's `/v1/llm_models?include_all=true`, filters to Claude models, and writes the curated compatible set (with at most one preferred Opus). A 5xx model-catalog failure falls back to the curated list; authorization, malformed response, no models, or no preferred match is a `ConfigurationError` rather than a silently incomplete configuration. On Linux, a present `/etc/claude-desktop/managed-settings.json` is surfaced as a warning because managed settings override the local configuration.
+
+For managed MCPs, the connector fetches `GET /v1/mcp/managed-servers?client=claude-desktop` through the shared authenticated HTTP client. It distinguishes an authoritative empty array from failure: missing SSO credentials, transport or parse failure, non-2xx response, non-array body, or a non-empty response in which every entry is invalid returns `null`; only a successful empty catalog returns `[]`. That distinction prevents a transient server or contract failure from revoking previously written organization entries.
+
+Canonical catalog entries are validated and mapped only when Desktop can represent them: valid names, URL, and `http` or `sse` transport. A structured OAuth object must include `clientId`, `authorizationUrl`, and `tokenUrl`; recognized optional fields are type-checked while unknown fields are retained for forward compatibility. The connector prefers a valid structured OAuth object over boolean and legacy auth shapes. When a structured Desktop OAuth configuration has no usable issuer, it adds the CodeMie default authorization-server list; boolean discovery-based OAuth is left unchanged.
+
+The final Desktop MCP list reconciles bundled defaults, organization entries, and existing user entries. Backend entries win collisions by name or endpoint, and user entries not owned by CodeMie are preserved. Ownership is recorded in `~/.codemie/proxy/desktop-managed-mcp-state.json` (under the CodeMie home) as managed names. On a successful catalog fetch, the marker is atomically written with the union of old and new names *before* the Desktop config, then narrowed to the exact durable set afterward. On a failed fetch it neither revokes previously managed organization entries nor updates the marker; it seeds only non-conflicting defaults when the stored list is readable.
+
+### VS Code targets
+
+`--vscode` writes or reconciles a `CodeMie` `customendpoint` provider in `User/chatLanguageModels.json` (stable or Insiders platform data directory). It replaces duplicate managed providers with one, preserves other providers and existing model-provider settings, and populates the supported model catalog with the local gateway's appropriate `/v1/chat/completions`, `/v1/messages`, or `/v1/responses` endpoint and capabilities. The writer preserves an existing VS Code secret reference for the API key. If none exists, it deliberately omits a literal key and reports that the user must set it in **Chat: Manage Language Models**. Invalid JSON or an unexpected root shape produces a `ConfigurationError` without changing the file; writes are atomic and preserve existing file mode where possible.
+
+`--vscode-claude-code` writes the bundled Claude Code extension's `User/settings.json`. It sets `claudeCode.disableLoginPrompt` and upserts only `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` in `claudeCode.environmentVariables`, preserving unrelated settings and environment variables while deduplicating existing names. It requires the target VS Code user-data directory to exist rather than creating an unused edition directory, and uses the same atomic writer.
+
+### Codex Desktop
+
+`--codex-desktop` integrates with Codex in the ChatGPT desktop app solely by editing the configuration it shares with the Codex CLI: `$CODEX_HOME/config.toml` when `CODEX_HOME` is set, otherwise `~/.codex/config.toml`. The connector checks common macOS/Windows ChatGPT locations unless `--force` is given; other platforms require `--force` to write anyway. Before writing, it discovers and ranks Codex-compatible models through the local proxy with a 15-second bound, so an unreachable or incompatible proxy fails before the user config is touched. `--model` is validated against the same deployment-resolution rule used by the proxy; otherwise the newest ranked model is selected.
+
+The connector validates existing TOML and refuses to replace another active `model_provider` without `--force`. It avoids a TOML serialize/round trip that would lose comments and ordering. Instead, it splices two sentinel-delimited regions: root `model_provider`/`model` settings are prepended before TOML tables, and `[model_providers.codemie]` with `wire_api = "responses"` and the bearer header is appended. It comments out displaced root keys so they can be restored. A pre-managed backup is made once, ownership state is atomically written before the config, and the final generated TOML is parsed before an atomic write.
+
+Disconnect first removes those two marked regions and restores displaced keys, preserving edits made elsewhere while connected. If the result cannot parse or still selects the CodeMie provider—for example, damaged sentinels—it restores the pre-connect backup when available; otherwise it raises `ConfigurationError` and asks for manual removal instead of claiming success while a bearer credential remains.
+
+## Focused verification
+
+The MCP unit tests use mocked MCP transports to verify lazy construction, queued-first-message flushing, stdio-to-HTTP and HTTP-to-stdio routing, idempotent shutdown, and per-origin cookie injection after `Set-Cookie`. OAuth tests exercise a real ephemeral loopback listener for successful, error, missing-code, timeout, and close paths, while mocking browser launch and checking in-memory provider state.
+
+Connector tests cover strict daemon reuse/restart and partial-failure semantics; managed catalog validation and `null` versus `[]` failure behavior; Desktop model and MCP reconciliation; VS Code provider/settings preservation and atomic-write errors; and Codex managed-block connect/disconnect round trips using a temporary `CODEX_HOME`. Run the repository's unit suite with:
+
+```sh
+npm run test:unit
+```
+
+When changing any credential-bearing configuration path, add a test that inspects logged arguments and confirms the raw gateway key, token, cookie, or authorization code is absent.

--- a/openwiki/integrations/provider-plugins-and-local-proxy.md
+++ b/openwiki/integrations/provider-plugins-and-local-proxy.md
@@ -1,0 +1,174 @@
+---
+type: integration architecture
+title: Provider Plugins, SSO, and the Streaming Local Proxy
+description: How provider plugins register capabilities and setup behavior, and how SSO or JWT-authenticated agent traffic passes through the ordered, streaming local proxy.
+tags: [providers, authentication, sso, jwt, proxy, streaming, plugins]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-029d2ecb6970e7ac12c6f34f
+    resource: repo://src/agents/core/BaseAgentAdapter.ts
+  - id: openwiki-source-a7ea460809b23828f691a001
+    resource: repo://src/bin/proxy-daemon.ts
+  - id: openwiki-source-023109980faac7bfe8745e7b
+    resource: repo://src/providers/core/registry.ts
+  - id: openwiki-source-fb49e7ca792739d2d6c63040
+    resource: repo://src/providers/core/types.ts
+  - id: openwiki-source-4e482a9888b381a021765ada
+    resource: repo://src/providers/index.ts
+  - id: openwiki-source-b3a9e8187221976cbdd6d180
+    resource: repo://src/providers/plugins/anthropic-subscription/anthropic-subscription.template.ts
+  - id: openwiki-source-6ebe0b004654cc40702e0fa6
+    resource: repo://src/providers/plugins/bedrock/bedrock.template.ts
+  - id: openwiki-source-9da2aa2eeb2dc46e5f0bdb5c
+    resource: repo://src/providers/plugins/jwt/jwt.template.ts
+  - id: openwiki-source-40549aca45ed2c6b4519cae1
+    resource: repo://src/providers/plugins/litellm/litellm.template.ts
+  - id: openwiki-source-b0b46f95599876ef009e0c58
+    resource: repo://src/providers/plugins/moonshot-subscription/moonshot-subscription.template.ts
+  - id: openwiki-source-46b0777b9d4b5ad6b77e8fc5
+    resource: repo://src/providers/plugins/ollama/ollama.template.ts
+  - id: openwiki-source-82c3d71569d5de21fd86fe86
+    resource: repo://src/providers/plugins/sso/proxy/plugins/gateway-key.plugin.ts
+  - id: openwiki-source-205a13c0a54a06ca9671973b
+    resource: repo://src/providers/plugins/sso/proxy/plugins/index.ts
+  - id: openwiki-source-55bfc6b53095f1f7a12cbe42
+    resource: repo://src/providers/plugins/sso/proxy/plugins/jwt-auth.plugin.ts
+  - id: openwiki-source-97506c0f15d192feed737bf5
+    resource: repo://src/providers/plugins/sso/proxy/plugins/registry.ts
+  - id: openwiki-source-cea6984e613436f4206acbe6
+    resource: repo://src/providers/plugins/sso/proxy/plugins/request-sanitizer.plugin.ts
+  - id: openwiki-source-9df84239e27fa59d57d503ce
+    resource: repo://src/providers/plugins/sso/proxy/plugins/sso-auth.plugin.ts
+  - id: openwiki-source-5513cf740414b88108e6c9dc
+    resource: repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts
+  - id: openwiki-source-1d852df76e77e2eb1c0bffaa
+    resource: repo://src/providers/plugins/sso/proxy/plugins/types.ts
+  - id: openwiki-source-0f0246cf1343fd7be3275baa
+    resource: repo://src/providers/plugins/sso/proxy/proxy-http-client.ts
+  - id: openwiki-source-ed7cdcb667251a8b544c61a9
+    resource: repo://src/providers/plugins/sso/proxy/sso.proxy.ts
+  - id: openwiki-source-221bd209a2f6a9c8ab5f4b91
+    resource: repo://src/providers/plugins/sso/sso.auth.ts
+  - id: openwiki-source-ab7829001d9934d924c351cd
+    resource: repo://src/providers/plugins/sso/sso.template.ts
+  - id: openwiki-source-79c0c43a254e62e4a5696710
+    resource: repo://src/utils/security.ts
+  - id: openwiki-source-f1d023d8ab3ad497e8711389
+    resource: repo://tests/integration/proxy-daemon-lifecycle.test.ts
+  - id: openwiki-source-8099a5b08c0c3705257f3e7c
+    resource: repo://tests/integration/proxy-normalizer-body-contract.test.ts
+  - id: openwiki-source-76eb0f7052908166e0421f62
+    resource: repo://tests/integration/proxy-routing-guard.test.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+## Provider plugins are declarative integration points
+
+The provider subsystem separates provider metadata from the setup, health, model-discovery, environment-export, and agent-lifecycle behavior that may accompany it. A `ProviderTemplate` identifies a provider, its default endpoint and authentication type, recommended models, capabilities, streaming and local-install support, and optional `exportEnvVars` and `agentHooks`. Capabilities are descriptive feature flags such as `streaming`, `tools`, `vision`, `embeddings`, `model-management`, `function-calling`, and `sso-auth`; consumers should use the registered template rather than duplicating provider-specific decisions.
+
+`registerProvider(template)` inserts the template into the process-wide `ProviderRegistry`. Importing `src/providers/index.ts` imports every built-in provider package for this side effect, then exports the registry and provider namespaces. The registry also independently holds health checks, model fetchers, and setup steps. Health-check and model-fetcher lookup uses each implementation's `supports(provider)` predicate, whereas setup steps are keyed by provider name. This makes a provider extension more than a template when it needs interactive setup or discovery, without putting provider-specific branches in the central registry.
+
+| Built-in provider | Authentication and routing implication | Representative declared capabilities |
+| --- | --- | --- |
+| `ai-run-sso` | SSO; requires an integration header when an integration is configured | streaming, tools, function calling, embeddings, SSO |
+| `bearer-auth` | JWT bearer token supplied at runtime; hidden from interactive setup | streaming, tools, function calling |
+| `ollama` | No authentication; local runtime with model installation | streaming, tools, embeddings, model management |
+| `litellm` | API-key gateway | streaming, tools, function calling |
+| `bedrock` | API-key typed configuration backed by AWS credentials | streaming, tools, function calling, vision |
+| `anthropic-subscription` | No proxy authentication; Claude Code uses its native stored subscription login | streaming, tools, function calling, vision |
+| `moonshot-subscription` | No proxy authentication; Kimi Code uses its native stored subscription login | streaming, tools, function calling, vision |
+
+The last two are especially important boundaries: `authType: 'none'` prevents a stale `CODEMIE_AUTH_METHOD=jwt` from causing model traffic to be proxied. Their agent hooks clear explicit provider API/proxy variables so the native CLI login remains authoritative; they can still install/inject local lifecycle hooks for telemetry-related artifacts without routing model traffic through CodeMie.
+
+## SSO, JWT, and default-provider paths
+
+The SSO template is the highest-priority visible provider and exports `CODEMIE_URL`, project, auth method, optional integration ID, and—when configured for JWT—the resolved JWT token. Browser SSO starts an ephemeral local callback server, opens `${ensureApiBase(codeMieUrl)}/v1/auth/login/<port>`, waits with timeout and cancellation support, validates the callback payload, and stores cookies plus the resolved API URL. Credential expiry comes from the access-token JWT `exp` when decodable, otherwise a 24-hour fallback is used. Stored SSO credentials are URL-scoped (with a backward-compatible global fallback only if its normalized origin matches) and expired credentials are cleared.
+
+The proxy chooses authentication at startup:
+
+- **JWT:** `config.jwtToken`, then `CODEMIE_JWT_TOKEN`, then credentials stored for `targetApiUrl`. Absence is an `AuthenticationError`. The JWT interceptor rejects a known-expired credential and injects `Authorization: Bearer ...`.
+- **SSO/default:** `authMethod` defaults to SSO. Only a provider whose registered `authType` is `sso` triggers stored-credential lookup for `targetApiUrl`; lack of matching credentials is an `AuthenticationError`. The SSO interceptor validates cookie names and values for unsafe header characters, drops invalid entries, and injects the remaining cookie header. If none remain, it fails authentication.
+- **No-auth providers:** `BaseAgentAdapter` does not start the proxy for `authType: 'none'`, before it considers the JWT environment setting. For proxy-capable agents, SSO providers or `CODEMIE_AUTH_METHOD=jwt` select the proxy; after startup the adapter changes the child environment to the local URL and uses `proxy-handled` as its API-key placeholder.
+
+Credential storage is owned by `CredentialStore`, not by the proxy. It uses the system keychain where available and an encrypted, machine-specific AES-256-CBC file fallback. Keep this ownership boundary: the proxy loads credentials and injects them into upstream requests, but should neither persist them nor expose them in logs.
+
+## Startup and lifecycle
+
+`CodeMieProxy` is the local HTTP server used by agent adapters and the detached `codemie proxy start` daemon. It builds one `PluginContext`, initializes enabled proxy plugins in ascending priority, then binds to `host` (default `localhost`) and either the configured port or an available port. Once bound it writes the actual port into its configuration and runs `onProxyStart`; this ordering lets lifecycle integrations use the final gateway URL. `/health` and `/healthz` are deliberately pre-auth liveness probes and return the port and start time without invoking plugins or the upstream.
+
+The daemon explicitly binds `127.0.0.1` for desktop gateway compatibility, persists its state after startup, and on restart pins the previous actual port. A pinned port retries `EADDRINUSE` five times rather than silently changing the desktop's configured URL; an unpinned initial bind may fall back to a system-assigned port. Shutdown runs plugin stop hooks, force-closes keep-alive connections, closes the server, and destroys the HTTP agents.
+
+`ProxyHTTPClient` uses keep-alive agents, honours `HTTP_PROXY`/`HTTPS_PROXY`, and bypasses them according to `NO_PROXY`/`no_proxy` plus `noproxy`/`no-proxy` entries in `~/.npmrc` (host, domain, port, IPv4 CIDR, or `*`). Its normal `forward` operation returns the upstream `IncomingMessage` stream; it does not buffer the response. A request body is read as a `Buffer` before interception to preserve byte integrity. Response buffering is an explicit exceptional facility for an `onUpstreamResponse` interceptor that needs to inspect and retry a response.
+
+## Ordered interception and streaming
+
+The proxy core owns only context creation, HTTP forwarding, response streaming, and lifecycle/error orchestration. Cross-cutting policy belongs in interceptors. Plugins register in any order, but the registry initializes enabled plugins sorted by ascending effective priority; initialization failures are logged and do not prevent other plugins from loading. A plugin can supply startup/shutdown, request, upstream-response, response-header, per-chunk, completion, and error hooks. `handleRequest` is an intentional escape hatch for traffic with a fundamentally different destination: if it returns `true`, it owns the response and the normal pipeline is entirely skipped.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Proxy as Local Proxy
+    participant Chain as Ordered Interceptors
+    participant Upstream
+    participant Sync as Session Sync
+    Client->>Proxy: HTTP request
+    alt health path
+        Proxy-->>Client: local health response
+    else custom handler claims request
+        Proxy->>Chain: handleRequest in priority order
+        Chain-->>Client: handler response
+    else standard forwarding
+        Proxy->>Chain: onRequest
+        alt request blocked
+            Proxy-->>Client: local success response
+        else forward
+            Proxy->>Upstream: request with normalized headers and body
+            Upstream-->>Proxy: headers and stream
+            Proxy->>Chain: onUpstreamResponse then onResponseHeaders
+            loop each upstream chunk
+                Proxy->>Chain: onResponseChunk
+                Proxy-->>Client: transformed chunk
+            end
+            Proxy->>Chain: onResponseComplete
+            Chain->>Sync: asynchronous session processing boundary
+        end
+    end
+    alt error before headers
+        Proxy->>Chain: onError
+        Proxy-->>Client: normalized JSON error
+    else error after headers
+        Proxy->>Chain: onError
+        Proxy-->>Client: destroy response
+    end
+```
+
+This sequence shows the normal streaming path and the paths that intentionally bypass it.
+
+The core plugin registration establishes these material ordering constraints:
+
+1. MCP authorization relay (priority 3) is first; it custom-routes MCP OAuth traffic. It validates public origins—including DNS resolution and per-flow root/relay association—and restricts buffering to bounded auth metadata. Because it claims a request, standard LLM interceptors do not protect it; the MCP handler owns its SSRF, authentication, and logging protections.
+2. Endpoint blocking (5) marks known telemetry and managed-settings paths as blocked before auth; the core responds locally with `200` to avoid client retries. Gateway-key authentication (7) checks the incoming local bearer key when configured, emits a `401` on mismatch, and strips a successful gateway authorization header before upstream authentication runs.
+3. SSO and JWT authentication (10) are mutually exclusive no-op/active alternatives. Client-specific normalizers (14), the request sanitizer (15), encrypted-content retry sanitizers (16), and VS Code normalization (17) modify compatibility details before header injection (20). The header plugin adds request/session correlation, CLI/client/model/project/repository/branch metadata, and an integration header only when the provider declares `customProperties.requiresIntegration`.
+4. Logging (50) and SSO session sync (100) run after request policy. Chunk hooks may transform or suppress a chunk; a chunk-hook failure is logged and streaming continues. Other hook failures are also isolated so one optional integration does not terminate forwarding.
+
+Normalization is deliberately scoped by client and endpoint rather than globally rewriting arbitrary API traffic. For `codemie-code` and `codemie-opencode`, JSON chat-completions requests have reasoning fields removed; on a `/responses` path, `reasoning.effort` is retained while unsupported summary variants are removed. When a body changes, the interceptor rebuilds the buffer and updates `content-length`. Other normalizers adapt Claude thinking/sampling, cap Kimi output tokens, resolve Codex desktop model aliases and repair empty tool descriptions, and constrain VS Code identifiers. These are compatibility plugins, not duties for the forwarding core.
+
+## Errors, observability, and safe extension
+
+Errors from custom handling or the standard pipeline reach `onError`. Client aborts are treated as normal disconnects and do not get an error response. Otherwise the proxy normalizes failures with its proxy error classes: it sends a structured JSON error before headers are sent, or destroys an already-started response. `NetworkError` and `TimeoutError` are operational failures logged with `logger.debug()` to avoid production noise; startup credential failures use `AuthenticationError` and missing sync prerequisites use `ConfigurationError`.
+
+When adding a plugin, give it a stable ID and explicit priority, keep its state in the interceptor instance (not global request state), and decide whether it is request-local, stream-aware, or lifecycle-owned. Never add analytics or provider policy to `CodeMieProxy`; use a hook. Avoid buffering a stream unless the feature specifically needs it, and bound any buffered input. For credentials, authorization headers, cookies, gateway keys, tokens, or errors that might embed them, log only safe facts or pass structured arguments through `sanitizeLogArgs()`; the gateway-key plugin demonstrates this. Prefer `logger.debug()` for diagnostic detail and project error classes for expected failures.
+
+## Session synchronization boundary
+
+`SSOSessionSyncPlugin` is an optional, SSO-only lifecycle integration—not part of the request forwarding contract. It is enabled only when a session ID, client type, and SSO credentials exist, and when `CODEMIE_SESSION_SYNC_ENABLED` (highest precedence) or `profileConfig.session.sync.enabled` permits it; it defaults enabled in this eligible SSO case. It may use separately loaded credentials for `syncCodeMieUrl`, allowing sync authentication to be distinct from target API authentication. A missing sync credential logs a diagnostic but does not prevent the proxy from starting.
+
+The plugin constructs a `SessionSyncer` processing context and synchronizes discovered local session data on a timer (default `120000` ms, configurable by `CODEMIE_SESSION_SYNC_INTERVAL`) and once more during proxy shutdown. `CODEMIE_SESSION_DRY_RUN` or profile configuration controls dry-run mode, with environment taking precedence. Concurrent runs are suppressed. The sync API base is explicit `syncApiUrl` when provided; otherwise, after the final port is known, it uses the local proxy URL so the sync call follows the same session-lifecycle path. Thus model-response completion and periodic/final artifact synchronization are related operationally, but sync is not allowed to buffer or delay the model stream.
+
+## Focused verification
+
+- Run `npm run test:integration -- proxy-normalizer-body-contract` to exercise a real in-process proxy against a mock upstream and assert the transformed body that reaches it for request sanitizer, Claude, Kimi, and Codex cases.
+- Run `npm run test:integration -- proxy-daemon-lifecycle` after `npm run build` to verify detached daemon startup, state persistence, pre-auth health, SIGTERM shutdown, and state cleanup using a dummy JWT.
+- Protect routing behavior with the no-auth/stale-JWT regression test in `tests/integration/proxy-routing-guard.test.ts`: native subscription providers must not start the proxy, while SSO and bearer-auth paths remain proxy-capable.

--- a/openwiki/operations/daemon-migrations-and-diagnostics.md
+++ b/openwiki/operations/daemon-migrations-and-diagnostics.md
@@ -1,0 +1,161 @@
+---
+type: "Reference"
+title: "Daemon migrations and diagnostics"
+openwiki_generated: true
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-aa210045b4d9e85b7a7eb1ff
+    resource: repo://bin/codemie.js
+  - id: openwiki-source-a7ea460809b23828f691a001
+    resource: repo://src/bin/proxy-daemon.ts
+  - id: openwiki-source-5970ba54d960eb2eec4d6d41
+    resource: repo://src/cli/commands/doctor/checks/index.ts
+  - id: openwiki-source-2f94a19fb7b02f19ed41bcc7
+    resource: repo://src/cli/commands/doctor/index.ts
+  - id: openwiki-source-14296d817cba1d802b24b959
+    resource: repo://src/cli/commands/proxy/__tests__/health-check.test.ts
+  - id: openwiki-source-b376c4c188c5fc9feceb0a4a
+    resource: repo://src/cli/commands/proxy/__tests__/watcher.test.ts
+  - id: openwiki-source-beb5bc61c2dd56a7676e2b44
+    resource: repo://src/cli/commands/proxy/daemon-manager.ts
+  - id: openwiki-source-0aa3d74b35c8813128e9f682
+    resource: repo://src/cli/commands/proxy/health-check.ts
+  - id: openwiki-source-203af971e5106b89f72f1924
+    resource: repo://src/cli/commands/proxy/index.ts
+  - id: openwiki-source-f7b59c634824953d9d27112a
+    resource: repo://src/cli/commands/proxy/watcher.ts
+  - id: openwiki-source-31253148e08df8198c6db4b6
+    resource: repo://src/cli/commands/self-update.ts
+  - id: openwiki-source-0caa9f4639e6664f82afdb98
+    resource: repo://src/migrations/__tests__/migration-runner-ordering.test.ts
+  - id: openwiki-source-c306fbe28866186a2df852b4
+    resource: repo://src/migrations/index.ts
+  - id: openwiki-source-6b781aaeb9c6906e83565cef
+    resource: repo://src/migrations/registry.ts
+  - id: openwiki-source-f47be9171e929852f6251a39
+    resource: repo://src/migrations/runner.ts
+  - id: openwiki-source-2d04e4cf2b38704351cfbaab
+    resource: repo://src/migrations/tracker.ts
+  - id: openwiki-source-a3460eafeb7568981e78a5ef
+    resource: repo://src/utils/cli-updater.ts
+  - id: openwiki-source-04a561e666605ad95d8062da
+    resource: repo://src/utils/errors.ts
+  - id: openwiki-source-802ad581431769e819a08862
+    resource: repo://src/utils/logger.ts
+  - id: openwiki-source-ed8a2ce3d6071aa1f213f5aa
+    resource: repo://src/utils/paths.ts
+  - id: openwiki-source-79c0c43a254e62e4a5696710
+    resource: repo://src/utils/security.ts
+  - id: openwiki-source-f1d023d8ab3ad497e8711389
+    resource: repo://tests/integration/proxy-daemon-lifecycle.test.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+
+The CLI has deliberately different failure contracts for its startup conveniences and for an explicitly requested operation. Startup migrations and background update checks must not prevent the requested CLI command from loading. In contrast, `codemie self-update` and `codemie proxy start` report failure to the user and exit unsuccessfully when their requested work cannot be completed.
+
+## Startup wrapper: best-effort maintenance before the CLI
+
+`bin/codemie.js` is the executable wrapper. Before dynamically importing the compiled CLI it:
+
+1. imports the migration API, whose module imports all registered migrations;
+2. checks for pending migrations and runs them with user-visible progress;
+3. except in `NODE_ENV=test` or `VITEST=true`, performs the update check; and
+4. dynamically imports `dist/cli/index.js`.
+
+A migration exception becomes a warning and update-check exceptions are suppressed at this wrapper boundary; neither prevents normal CLI initialization. Failure to import the actual CLI is different: it prints an error and exits with code 1.
+
+```mermaid
+flowchart TD
+    Start["codemie executable"] --> Load["load migration registry"]
+    Load --> Pending{"pending migrations"}
+    Pending -->|yes| Run["run migrations in ID order"]
+    Pending -->|no| UpdateGate{"test environment"}
+    Run -->|migration exception| Warn["print migration warning"]
+    Run --> UpdateGate
+    Warn --> UpdateGate
+    UpdateGate -->|no| Check["best-effort update check"]
+    UpdateGate -->|yes| Cli["import compiled CLI"]
+    Check --> Cli
+    Cli -->|import fails| Fatal["print error and exit 1"]
+```
+
+This shows the non-blocking startup migration and update paths.
+
+### Migration tracking is the idempotency boundary
+
+Migrations self-register when imported by `src/migrations/index.ts`; the registry returns them sorted lexically by ID. `MigrationTracker` stores history at `getCodemiePath('migrations.json')`, normally `~/.codemie/migrations.json` but under `CODEMIE_HOME` when that environment variable is set. Missing or invalid history is treated as an empty version-1 history, so migrations are selected solely by whether their ID has a successful record.
+
+`MigrationRunner.runPending()` executes every currently pending migration in that sorted order and continues after an individual failure. A successful migration is recorded whether it changed state (`migrated: true`) or is an applicable no-op (`migrated: false`); a `success: false` result or thrown error is counted as failed but **is not recorded**. It therefore remains pending for retry on a later CLI startup. `dryRun` executes the logic without writing any records.
+
+**Safe migration change rules**
+
+- Give a new migration a unique, ordered ID, implement `up(): Promise<MigrationResult>`, and import it from `src/migrations/index.ts`; do not reorder or silently repurpose an existing ID.
+- Make `up()` safe to retry. A process can make a partial local change and then fail before its success record is written.
+- Return `{ success: true, migrated: false, reason }` only when it is safe to permanently mark the migration complete. Returning failure is the retry mechanism.
+- Do not convert the wrapper’s migration catch into a fatal startup path. This would violate the availability contract for every CLI command.
+- Test orchestration separately from data transformation: the migration ordering tests cover sorted execution, history-backed no-ops, dry runs, and continuation/retry after failures.
+
+## Proxy daemon ownership and state
+
+`codemie proxy start` loads the selected profile, verifies an API URL and SSO credentials, then asks `spawnDaemon()` to start a detached Node subprocess through `bin/proxy-daemon.js`. The JavaScript launcher imports the compiled daemon and treats import failure as fatal. The daemon requires `--target-url` and `--state-file`, validates a positive optional port, and binds the proxy explicitly to `127.0.0.1` rather than `localhost`.
+
+The manager’s default state file is `${CODEMIE_HOME:-~/.codemie}/proxy-daemon.json`. Its state identifies the process and local gateway (`pid`, `port`, `url`, `profile`, `gatewayKey`, `startedAt`) and may carry client/project/telemetry metadata and watcher health fields. Both the manager writer and daemon persistence use write-to-`.tmp` then rename, avoiding a partially written JSON file for readers. A state file alone is not liveness: `checkStatus()` probes its PID and deletes stale state when the process is gone.
+
+`spawnDaemon()` passes endpoint, provider, profile, gateway key, state path, and optional client, project, telemetry and sync context as arguments, then polls state and PID every 100 ms for up to five seconds. If readiness never appears it throws `ToolExecutionError` with the log directory as the remediation location. `proxy start` is idempotent only for a live daemon that matches the requested profile, port, project, client type, provider, and target URL; a live mismatch is a `ConfigurationError` directing the operator to stop it first. The client connection orchestrator can instead stop and replace a mismatch, forced daemon, or deeply unhealthy daemon before configuration is written.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent
+    Absent --> Starting: spawn detached daemon
+    Starting --> Running: proxy starts and state persisted
+    Starting --> Absent: startup fails or readiness times out
+    Running --> Healthy: shallow or deep check passes
+    Healthy --> Recovering: deep check fails
+    Recovering --> Healthy: in-process restart succeeds
+    Recovering --> Unhealthy: unauthorized or attempts exhausted
+    Unhealthy --> Healthy: later deep status check succeeds
+    Healthy --> Stopping: proxy stop
+    Unhealthy --> Stopping: proxy stop
+    Stopping --> Absent: cleanup state
+```
+
+This shows the daemon process, watcher, and operator-visible state lifecycle.
+
+### Shutdown, health, and recovery
+
+`stopDaemon()` sends `SIGTERM`, waits up to five seconds, then escalates to `SIGKILL` for a wedged process and always clears state. The daemon handles both `SIGTERM` and `SIGINT`: it stops the watcher, attempts to stop telemetry and the proxy, unlinks state, and exits. Preserve this cleanup ordering whenever adding a long-lived daemon resource.
+
+Health checks never throw; they return a typed result. A shallow check calls unauthenticated `GET /health` with a 1.5-second deadline, establishing only that the local listener responds. A deep check additionally calls `GET /v1/llm_models?include_all=true` with `Authorization: Bearer <gatewayKey>` and a six-second deadline. A 401, 403, or non-JSON response is classified as `unauthorized` (expired SSO); other non-success or transport failures become `upstream-error`, while a failed shallow check is `dead-socket`.
+
+`codemie proxy status` uses shallow health by default and adds the upstream/auth probe with `--deep`; `--json` emits `stopped`, `healthy`, or `unhealthy` plus connection metadata and a reason when unhealthy. A successful deep human-readable status can clear a stale persisted watcher issue. Do not describe a shallow result as proof that credentials or the upstream are usable.
+
+Inside the daemon, `ProxyWatcher` runs an unref’d deep check every 30 seconds. It detects an unusually large timer gap as a likely sleep/wake event and checks immediately on that tick. A healthy result resets the restart counter and updates `lastHealthyAt`. For a recoverable failure it waits exponential backoff (1 s, 2 s, 4 s, capped by the interval) and reconstructs the proxy **in process** on the actual port selected at initial startup; the port is pinned so configured desktop URLs remain valid. It gives up and persists `health: 'unhealthy'` immediately for expired SSO, or after three failed recovery attempts, rather than looping indefinitely. Reauthentication is an operator action: run `codemie profile login` and restart the proxy.
+
+## Updates and diagnostics
+
+The automatic updater checks npm for `@codemieai/code` with a five-second version lookup, validates both current and received semantic versions, and rate-limits checks using `${CODEMIE_HOME}/.last-update-check` (24 hours by default, configurable with `CODEMIE_UPDATE_CHECK_INTERVAL`). It records a check even when no update is available or lookup returns no result. `${CODEMIE_HOME}/.update-lock` is opened exclusively to ensure only one CLI process installs at a time.
+
+`CODEMIE_AUTO_UPDATE` defaults to enabled (`true`, `1`, or `yes`): an available update is installed silently and takes effect on the next command. Set `CODEMIE_AUTO_UPDATE=false` for an interactive prompt instead. `codemie self-update --check` only reports availability; without `--check`, `codemie self-update` installs visibly. Unlike background checking, this explicit command exits 1 when it cannot check or install.
+
+`codemie doctor` is a diagnostics orchestrator, not a proxy-health command. It runs Node, npm, Python, uv, AWS CLI, active-profile configuration, JWT auth, agents, workflows, and frameworks checks, displaying results as they arrive. After the active-profile check, it asks `ProviderRegistry` for a provider-specific check and bounds that call to 15 seconds. `codemie doctor --verbose` enables `CODEMIE_DEBUG`, prints the debug-log location, and records system and sanitized environment information; diagnostic failures are represented in the summary rather than crashing the command.
+
+## Logging and error-handling requirements for operational changes
+
+Use the project’s error vocabulary at command boundaries: `ConfigurationError` for invalid/missing operator configuration and `ToolExecutionError` for an attempted external operation such as daemon startup. Use `getErrorMessage()` when rendering an unknown caught error. This keeps CLI failure messages actionable without assuming every thrown value is an `Error`.
+
+For diagnostic detail, use `logger.debug()` rather than ordinary terminal output. Debug console output is gated by `CODEMIE_DEBUG`, while the logger’s file output is under `${CODEMIE_HOME}/logs/debug-YYYY-MM-DD.log`, rotates across dates, and retains five days. Never pass raw credential-adjacent objects, headers, tokens, cookies, gateway keys, or URLs with embedded credentials to logging. Call `sanitizeLogArgs()` at the call site for such arguments; it redacts recognized sensitive keys and token-like values before the logger receives them. This matters especially in spawn, health, recovery, and provider-error paths.
+
+## Focused verification
+
+Use isolated `CODEMIE_HOME` before importing modules that compute a module-level state/history path. Relevant coverage includes:
+
+- `src/migrations/__tests__/migration-runner-ordering.test.ts` for ordered registration, persistence, dry run, and failure retry semantics;
+- proxy daemon manager and health-check unit tests for atomic state behavior, stale PID cleanup, readiness arguments, typed shallow/deep outcomes, and authorization classification;
+- `src/cli/commands/proxy/__tests__/watcher.test.ts` for restart limits, immediate unauthorized give-up, recovery counter reset, and stop behavior;
+- `tests/integration/proxy-daemon-lifecycle.test.ts` for the real detached compiled daemon, state readiness, local `/health`, and SIGTERM shutdown cleanup; it uses a temporary home and dummy JWT path so no real credentials are required; and
+- doctor integration tests, including Windows-oriented tool detection, to keep diagnostics non-crashing and cross-platform.
+
+When changing a startup wrapper, test both the best-effort failure path and the fatal CLI-import path. When changing daemon state, preserve backward-compatible optional health metadata and test state cleanup after both graceful and forced termination. When changing health behavior, test timeouts/classification and the distinction between local liveness and authenticated upstream reachability.

--- a/openwiki/operations/index.md
+++ b/openwiki/operations/index.md
@@ -1,0 +1,3 @@
+# Files
+
+- [Daemon migrations and diagnostics](daemon-migrations-and-diagnostics.md)

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,91 @@
+---
+type: navigation guide
+title: CodeMie Code Wiki Quickstart
+description: A task-routing guide from the published CodeMie entry points to the architecture, runtime boundaries, operational lifecycle, integrations, workflows, and focused test suites needed to change the package safely.
+tags: [quickstart, architecture, cli, plugins, testing]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-8037e2358a2c4f9b2c722a11
+    resource: repo://AGENTS.md
+  - id: openwiki-source-371a6d8a4fcb291e3e8d7291
+    resource: repo://bin/agent-executor.js
+  - id: openwiki-source-a1c6f166318281c1a37e8001
+    resource: repo://bin/codemie-claude.js
+  - id: openwiki-source-73aafb9bc993302f60627faa
+    resource: repo://bin/codemie-mcp-proxy.js
+  - id: openwiki-source-aa210045b4d9e85b7a7eb1ff
+    resource: repo://bin/codemie.js
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-23c009faa70a994252df8b77
+    resource: repo://src/agents/core/AgentCLI.ts
+  - id: openwiki-source-cf985357c2ea8c403c53e222
+    resource: repo://src/agents/registry.ts
+  - id: openwiki-source-69f1465f9bd0baca2064728f
+    resource: repo://src/cli/index.ts
+  - id: openwiki-source-7c7fa2026b2641d9e184ea9f
+    resource: repo://src/frameworks/plugins/index.ts
+  - id: openwiki-source-d1fbef09192ffbab6eff0bc2
+    resource: repo://src/index.ts
+  - id: openwiki-source-4e482a9888b381a021765ada
+    resource: repo://src/providers/index.ts
+  - id: openwiki-source-07cf75292ad1458efff13f97
+    resource: repo://src/utils/config.ts
+  - id: openwiki-source-ed8a2ce3d6071aa1f213f5aa
+    resource: repo://src/utils/paths.ts
+  - id: openwiki-source-fbadcd8591b65031efaaedce
+    resource: repo://vitest.config.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+CodeMie Code is an ESM Node.js package (`>=20`) whose public surface is both a library and a set of executable wrappers. Start from the surface the change affects, then follow the owning registry or runtime domain rather than bypassing it with a direct dependency.
+
+## First, classify the change
+
+| If the change concerns… | Start here | Then read |
+|---|---|---|
+| A published command, help text, command factory, shortcut executable, or package export | `package.json`, `bin/`, `src/cli/index.ts`, and `src/index.ts` | [CLI, Binaries, and Command Factories](/openwiki/architecture/cli-surface.md) and [Plugin Architecture and Dependency Boundaries](/openwiki/architecture/system-overview.md) |
+| Profiles, `.env`, credentials, `CODEMIE_HOME`, project settings, or local persistence | `ConfigLoader` and path utilities | [Profiles, Configuration Precedence, and Local State](/openwiki/concepts/configuration-and-local-state.md) |
+| Installing, launching, updating, or adapting a coding agent | `AgentRegistry`, the adapter, and `AgentCLI` | [Agent Adapters, Installation, and Runtime Injection](/openwiki/integrations/agent-plugin-system.md) and [Agent Launch, Sessions, Analytics, and Cleanup](/openwiki/workflows/agent-launch-and-session-telemetry.md) |
+| A model provider, SSO/JWT, request streaming, proxy transformation, or desktop/editor connection | provider registration and SSO proxy code | [Provider Plugins, SSO, and the Streaming Local Proxy](/openwiki/integrations/provider-plugins-and-local-proxy.md) and [MCP Relay and Desktop/Editor Proxy Clients](/openwiki/integrations/mcp-and-desktop-clients.md) |
+| Proxy startup, migrations, self-update, health checks, logs, or a failure that must not block a command | executable wrapper and daemon lifecycle code | [Operational Lifecycle: Daemons, Migrations, Updates, and Diagnostics](/openwiki/operations/daemon-migrations-and-diagnostics.md) |
+| Session/transcript metrics, cleanup, `--task`, resume behavior, or agent process environment | `AgentCLI` and the selected adapter | [Agent Launch, Sessions, Analytics, and Cleanup](/openwiki/workflows/agent-launch-and-session-telemetry.md) |
+| Hooks, assistants, skills, frameworks, or workflow scaffolding | corresponding CLI command and registry | [Hooks, Extensions, Skills, Frameworks, and Workflow Templates](/openwiki/workflows/hooks-skills-frameworks-and-automation.md) |
+| A test failure or coverage for one of these boundaries | Vitest project selection and nearest representative test | [Test Projects, Isolation, and High-Risk Contracts](/openwiki/testing/test-strategy.md) |
+
+## Entry-point map
+
+`package.json` publishes the `codemie` root CLI, built-in and per-agent shortcuts, `codemie-mcp-proxy`, and `proxy-daemon`. The normal root path is deliberately different from the protocol bridge: `bin/codemie.js` runs pending migrations and a best-effort update check before dynamically loading `dist/cli/index.js`; the MCP wrapper validates its URL, logs to a file, and intentionally skips migrations, update checks, and plugin loading so stdout remains a clean JSON-RPC channel.
+
+```text
+published executable
+  ├─ codemie → bin/codemie.js → migrations and update check → src/cli/index.ts
+  │                                              ├─ provider and framework registration
+  │                                              └─ commander command factories
+  ├─ codemie-<agent> → AgentRegistry → AgentCLI → selected agent adapter
+  ├─ codemie-mcp-proxy → StdioHttpBridge over stdio and HTTP
+  └─ proxy-daemon → compiled proxy daemon
+```
+
+The root CLI imports provider and framework entry modules for registration before it adds command factories. Its `--task <task>` fast path resolves the `codemie-code` adapter through `AgentRegistry` and runs it through `AgentCLI`; otherwise it presents first-time/returning-user guidance for an argument-free invocation or lets Commander parse the requested command. Add a command through its factory and owning domain, not by reaching around those registries.
+
+Agent shortcuts are intentionally thin wrappers: they resolve a named adapter from the registry and construct `AgentCLI`. The registry lazily registers built-in adapters once. Management callers must use its manageable-agent view, because analytics-only adapters remain registry-visible for telemetry but are excluded from install, update, uninstall, list, and doctor behavior.
+
+## Safe change boundaries
+
+- **Respect configuration and authentication gates.** `AgentCLI` checks installation, resolves configuration using CLI overrides, handles explicit JWT precedence, normalizes CodeMie API URLs for SSO/JWT providers, validates required configuration and provider authentication, then checks provider/model compatibility before launch. A change to flags, credentials, or adapter launch must preserve that order and its exit behavior. See [configuration](/openwiki/concepts/configuration-and-local-state.md), [agent integration](/openwiki/integrations/agent-plugin-system.md), and the [launch workflow](/openwiki/workflows/agent-launch-and-session-telemetry.md).
+- **Keep local state relocatable.** `getCodemieHome()` honors `CODEMIE_HOME` and otherwise uses `~/.codemie`; callers should derive child paths through `getCodemiePath()`. `ConfigLoader` overlays defaults, global and local configuration, environment variables, and CLI overrides in that precedence order. Do not hard-code a home path or let tests write user state.
+- **Preserve wrapper-specific failure semantics.** A failed normal-CLI migration only warns and a failed update check is ignored; failure to import the root CLI exits nonzero. Conversely, invalid MCP input or bridge startup failure is fatal, while shutdown tries to close the bridge. Route changes in these paths through the operational and MCP pages above.
+- **Keep public API intentional.** `src/index.ts` is the package library barrel: it exposes the agent registry/adapter type, logger and process/error utilities, environment manager, SSO and proxy types, proxy-plugin registry, hook processing, and `ConfigLoader`. Changing it is a compatibility change, not merely an internal refactor.
+
+## Focused validation route
+
+Use the narrowest Vitest project that owns the contract. `unit` runs source tests in an isolated Node environment; `cli` runs non-agent integration tests; and `agent` runs the networked SSO/JWT integration tests after a build setup with longer timeouts and bounded workers. All receive a process-specific temporary `CODEMIE_HOME`, which protects developer state and prevents concurrent invocations sharing test logs. Package scripts expose these projects as `test:unit`, `test:integration`, and `test:integration:agent` (with `test:all` running all three).
+
+For high-risk changes, begin with the owning page's test guidance and a nearby contract test—for example, agent shortcuts, proxy-daemon lifecycle, proxy header/normalizer behavior, session synchronization, or SSO desktop integration—rather than treating a broad suite as the specification. Repository guidance also requires tests to be written or run only when explicitly requested.
+
+## Repository working constraints
+
+Before modifying code, use the repository task classifier to select the relevant curated guide, then confirm behavior in source and focused tests. The project expects ESM imports with `.js` extensions, async/await, project-specific errors and logging, and the dependency direction **CLI → registry → plugin**. Avoid raw secret logging and raw `~/.codemie` paths. The generated wiki routes to the right owner; it does not replace source, tests, or the repository instructions.

--- a/openwiki/testing/index.md
+++ b/openwiki/testing/index.md
@@ -1,0 +1,3 @@
+# Files
+
+- [Test Projects, Isolation, and High-Risk Contracts](test-strategy.md) - How CodeMie separates unit, CLI integration, and networked agent tests, isolates local state, and protects proxy, session, and desktop integration contracts.

--- a/openwiki/testing/test-strategy.md
+++ b/openwiki/testing/test-strategy.md
@@ -1,0 +1,159 @@
+---
+type: testing strategy
+title: Test Projects, Isolation, and High-Risk Contracts
+description: How CodeMie separates unit, CLI integration, and networked agent tests, isolates local state, and protects proxy, session, and desktop integration contracts.
+tags: [testing, vitest, integration, isolation, proxy, agents]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-5b54a58d1b51cd490b0e7162
+    resource: repo://package.json
+  - id: openwiki-source-025b38a028884ce4ac5ee989
+    resource: repo://src/agents/__tests__/registry.test.ts
+  - id: openwiki-source-248306aee0eb09853d82469f
+    resource: repo://src/agents/core/__tests__/BaseAgentAdapter.test.ts
+  - id: openwiki-source-00b770f4244605106eb62208
+    resource: repo://src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts
+  - id: openwiki-source-f4cc7984950b5f65ea0cf38e
+    resource: repo://src/providers/plugins/sso/proxy/plugins/__tests__/gateway-key.plugin.test.ts
+  - id: openwiki-source-e5ff76ecfebe642cc78dec38
+    resource: repo://src/providers/plugins/sso/proxy/plugins/__tests__/vscode-request-normalizer.plugin.test.ts
+  - id: openwiki-source-205a13c0a54a06ca9671973b
+    resource: repo://src/providers/plugins/sso/proxy/plugins/index.ts
+  - id: openwiki-source-97506c0f15d192feed737bf5
+    resource: repo://src/providers/plugins/sso/proxy/plugins/registry.ts
+  - id: openwiki-source-ed7cdcb667251a8b544c61a9
+    resource: repo://src/providers/plugins/sso/proxy/sso.proxy.ts
+  - id: openwiki-source-352a660cc969cbf1385450f2
+    resource: repo://tests/helpers/agent-smoke.ts
+  - id: openwiki-source-92d1b2d5c6debf0b4ec77602
+    resource: repo://tests/helpers/jwt-auth.ts
+  - id: openwiki-source-3dbc825cdae925c7ec5969b8
+    resource: repo://tests/helpers/sso-auth.ts
+  - id: openwiki-source-8aeaeaa0ce1eab7009a3887c
+    resource: repo://tests/helpers/temp-workspace.ts
+  - id: openwiki-source-278a3c6244f20c8d3320f49b
+    resource: repo://tests/helpers/test-isolation.ts
+  - id: openwiki-source-8cb5b18295203a0b7f424c9a
+    resource: repo://tests/integration/agent-task-session.test.ts
+  - id: openwiki-source-f1d023d8ab3ad497e8711389
+    resource: repo://tests/integration/proxy-daemon-lifecycle.test.ts
+  - id: openwiki-source-bf26f1f43b252ad2816b3966
+    resource: repo://tests/integration/proxy-header-contract.test.ts
+  - id: openwiki-source-c27f9ca04004586d91dad705
+    resource: repo://tests/integration/session-syncer.test.ts
+  - id: openwiki-source-2499787505d9cb75d20434d6
+    resource: repo://tests/integration/vscode-byok.test.ts
+  - id: openwiki-source-81c62787d2029eaa4b22b0aa
+    resource: repo://tests/setup/agent-build-setup.ts
+  - id: openwiki-source-fbadcd8591b65031efaaedce
+    resource: repo://vitest.config.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+# Test Projects, Isolation, and High-Risk Contracts
+
+CodeMie uses Vitest projects to make the cost and dependencies of a test explicit. Co-located unit tests exercise source-level behavior with mocks where an external boundary would distract from the contract. The CLI project executes command and local-server integration paths without network authentication. The agent project is deliberately the networked tier: it builds the distribution, establishes the required authentication mode, and launches real supported agent binaries.
+
+This is not an instruction to run the suites as part of documentation work. Repository policy is to write or run tests only when the user explicitly requests it. When tests are requested, use the configured Vitest projects and preserve `CODEMIE_HOME` isolation rather than substituting an ad hoc command or a developer's real home.
+
+## Project boundaries and entrypoints
+
+| Project | Selection | Intended boundary | Key execution constraints |
+| --- | --- | --- | --- |
+| `unit` | `src/**/*.test.ts` and `src/**/*.spec.ts` | Source logic, registries, adapter decisions, parsers, and plugin behavior | Node environment, isolated files, 30-second test and hook timeouts, V8 coverage configuration. |
+| `cli` | `tests/integration/**/*.test.ts`, excluding `agent-*.test.ts` | Built CLI commands, local filesystem/process behavior, and deterministic local HTTP integration | Node environment, isolated files, group order 1, no network authentication requirement. |
+| `agent` | `tests/integration/agent-*.test.ts` | A real built distribution, supported agent CLI, authentication, proxy, hooks, and session artifacts | Global build/setup, isolated files, group order 2, 180-second test timeout, 300-second hook timeout, and up to two workers by default or `CI_AGENT_MAX_WORKERS`. |
+
+The package scripts expose these projects as `npm run test:unit`, `npm run test:integration` (the `cli` project), and `npm run test:integration:agent`; `test:run` selects unit plus CLI, while `test:all` runs all three serially by project. The ordinary CI script builds before its unit and CLI tests. Agent setup itself also builds once per Vitest session because its tests execute `bin/...` entry points against `dist/`.
+
+All three projects set `NODE_ENV=test`, `FORCE_COLOR=1`, and `CODEMIE_HOME` to a temp directory named with the config evaluation process ID. The PID component prevents simultaneous `vitest run` invocations from sharing logs or configuration state. Vitest's `isolate: true` protects test-file module environments, but it does not make filesystem paths, spawned processes, fixed ports, or a mutated `process.env` safe by itself; suites that own those resources must allocate and clean them explicitly.
+
+```mermaid
+flowchart TD
+  V["Vitest configuration"] --> U["unit project"]
+  V --> C["cli project"]
+  V --> A["agent project"]
+  U --> H["Temporary CODEMIE_HOME"]
+  C --> H
+  A --> H
+  A --> G["Global setup"]
+  G --> B["Build dist and install supported Claude"]
+  B --> R["Real agent and authenticated service"]
+  C --> L["CLI and local process contracts"]
+  U --> M["Mocked source contracts"]
+```
+
+This shows dependency escalation: a test should stay in the lowest tier that can prove its contract, with agent tests reserved for behavior that requires an actual distribution, agent executable, credentials, or remote service.
+
+## Isolation is a correctness requirement
+
+`CODEMIE_HOME` relocates the configuration, credentials, sessions, logs, and daemon state described in [Profiles, Configuration Precedence, and Local State](../concepts/configuration-and-local-state.md). Tests must never accidentally read or modify `~/.codemie`. The config-level environment value is a baseline, but a suite needing a distinct profile, daemon state file, or session directory should create a unique temporary home, pass it to spawned children, and remove it in teardown.
+
+`TempWorkspace` supplies throwaway working directories with file, JSON, config, and minimal Git-repository helpers. It is appropriate when the test needs a repository-shaped current directory, but it is separate from the CodeMie home: use both when a child reads its profile from `CODEMIE_HOME` and operates in a workspace. `resolveLongPath()` and `getTempDir()` handle Windows short-path behavior so paths passed as a child `cwd` compare consistently.
+
+The reusable `setupTestIsolation()` helper captures the incoming `CODEMIE_HOME`, assigns a temporary home before a suite, restores the prior value afterward, and deletes the temporary tree unless debugging opts out. Cleanup should use `afterEach`, `afterAll`, or `finally` according to resource lifetime. It must also close local servers, stop proxies, reap spawned PIDs, and restore every changed environment variable; removing a directory alone cannot clean a detached listener.
+
+Agent subprocesses use a stronger boundary. `jwtCleanEnv()` is an allowlist environment that removes ambient credentials and `CODEMIE_*` state; `ssoCleanEnv()` removes `CODEMIE_*` and CI CodeMie variables while retaining the platform/keychain/network environment needed by SSO. Both remove `node_modules/.bin` from `PATH` so a local dependency shim cannot shadow the globally linked `codemie` hook command. The agent smoke harness writes a per-test SSO profile, copies locally decryptable SSO credential files, initializes a Git workspace for agents that require trust, and invokes the local `bin` entry point with that home.
+
+## Import timing and global registries
+
+Module initialization is observable behavior when a module derives a default path from the environment or registers a singleton. Set environment variables and install mocks **before** importing such a module. If a test needs a fresh module-level registry or cached configuration, use `vi.resetModules()` and then dynamically `await import(...)`; reset/restore mocks and environment state afterward.
+
+The detached-daemon lifecycle test is the canonical example: it creates and exports its temporary `CODEMIE_HOME` before dynamically importing `daemon-manager`, because that module computes `DEFAULT_STATE_FILE` during module evaluation. Importing first would bind the manager to the developer/default home and invalidate both the test's isolation and its cleanup assumptions. The desktop connector tests likewise reset modules around `CODEX_HOME` changes. Proxy plugin registration is also singleton state: tests which manually assemble a pipeline reset the plugin registry before and after each case, while the ordinary proxy import auto-registers the core plugins.
+
+## What the focused tests protect
+
+### Configuration, registry, and launch decisions
+
+Unit tests protect the extension boundary rather than merely checking a class exists. The agent-registry suite asserts the complete expected built-in/agent-plugin membership, unique names, retrievability, and the adapter operations consumers rely on. This catches a missing registration or an accidental analytics-only agent behavior change at the CLI discovery boundary.
+
+`BaseAgentAdapter` tests cover the decisions that can silently route traffic incorrectly: an analytics-sync URL alone must not enable the model proxy; an `authType: 'none'` provider must remain direct even if a stale `CODEMIE_AUTH_METHOD=jwt` is inherited; and proxy-capable SSO/JWT configurations do enable the proxy. They also pin valid `sso`/`jwt` proxy auth-method mapping, safe handling of unknown/manual values, reasoning-effort injection, Windows command quoting, and dry-run behavior—including stopping an already-created proxy before returning so the command cannot hang. See [Agent Plugin System](../integrations/agent-plugin-system.md) for the runtime extension model.
+
+### Proxy security, ordering, and lifecycle
+
+The local proxy is an ordered interceptor pipeline, not an unordered set of extensions. Registration order is intentionally immaterial; the registry initializes enabled plugins in ascending priority. The production core positions endpoint blocking before gateway-key validation, validates and strips the local gateway credential before SSO/JWT upstream authentication, performs request normalization/sanitization before header injection, and places session synchronization late in the lifecycle. The header contract integration test makes this ordering observable against a mock upstream: a valid local gateway key never leaves the machine, the upstream receives the real JWT authorization and CodeMie context headers, and an invalid gateway key produces `401` without an upstream request.
+
+The daemon lifecycle test complements mocks by starting the real detached `bin/proxy-daemon.js` process with a dummy JWT and a local `/health` probe. It verifies state-file persistence and readiness, running status, pre-auth shallow health, SIGTERM shutdown, state deletion, process reaping, and loss of service after stop. The dummy token is sufficient because `/health` is local and does not call an upstream gateway; it keeps the test credential-free while proving the release-critical detached-process path. See [Provider Plugins, SSO, and the Streaming Local Proxy](../integrations/provider-plugins-and-local-proxy.md) and [Daemon Migrations and Diagnostics](../operations/daemon-migrations-and-diagnostics.md) for the corresponding runtime and operations behavior.
+
+```mermaid
+sequenceDiagram
+  participant Test
+  participant Manager as Daemon Manager
+  participant Daemon as Proxy Daemon
+  participant Health as Local Health
+  Test->>Manager: set isolated home then dynamic import
+  Test->>Daemon: spawn detached with temp state path
+  Daemon-->>Manager: write state after bind
+  Test->>Manager: poll state and process liveness
+  Test->>Health: shallow health request
+  Health-->>Test: healthy local response
+  Test->>Manager: stop daemon
+  Manager->>Daemon: SIGTERM then fallback if needed
+  Daemon-->>Test: state removed and port unavailable
+```
+
+This is the detached daemon contract exercised without a real upstream credential.
+
+### Session artifacts and synchronization
+
+The networked task/session test executes the branch's `codemie-claude` entry point with a UUID-bearing file-generation task. In JWT mode it creates a temporary home and bearer profile; in local SSO mode it uses the SSO autotest profile and restores the user's previously active profile afterward. It asserts process success, actual generated work, and eventual hook-produced session files rather than assuming they exist at process exit. A poll waits for the post-exit rename/synchronization boundary, then validates the completed session JSON and its conversation and metrics JSONL records against schemas, their IDs, and the UUID-correlated user and assistant content. In SSO mode it additionally requires a conversation sync attempt, conversation ID, timestamps, and synced metrics.
+
+`SessionSyncer` integration tests use a mocked metrics sender to test persistence and failure semantics deterministically: pending JSONL deltas become aggregated metrics sent to `/v1/metrics`; successful records become `synced` with an attempt count and timestamp; already-synced input is not resent; and processor failures leave work pending for a later attempt without necessarily failing the overall multi-processor sync result. This preserves the distinction between artifact durability and best-effort remote synchronization.
+
+### Desktop and editor compatibility
+
+Desktop integrations combine generated configuration with a gateway that must correctly interpret client-specific traffic. The Codex desktop connector tests use temporary workspaces and dynamic imports to verify `CODEX_HOME` path resolution, unmanaged-config backup behavior, preservation of unrelated TOML, model discovery/filtering, requested-model rejection, and the ordering that writes ownership marker state before modifying user configuration.
+
+The VS Code BYOK integration suite starts real in-process proxy and upstream HTTP servers, writes `chatLanguageModels.json` into a temporary VS Code-style `User` directory, and tests every supported model and reasoning-effort combination. It verifies that model selection comes from the supported matrix rather than the active profile model, each request reaches the correct endpoint with CodeMie client/project context but without its local authorization key, and Responses traffic receives the required `user` normalization. The normalizer's unit tests additionally guarantee it applies only to `vscode-byok`, preserves valid short identifiers, deterministically hashes overlength identifiers without logging them, and updates `content-length` after body changes. A recovery test preserves encrypted reasoning state while upstream affinity is healthy, then confirms that a rejected replay is surfaced for that request and subsequent requests remove the invalid state and succeed. See [MCP and Desktop Clients](../integrations/mcp-and-desktop-clients.md) for the user-facing integration contract.
+
+## Selecting and maintaining tests
+
+Choose the smallest configured project that can demonstrate the risk:
+
+- use a unit test for deterministic mapping, validation, error handling, registry membership, plugin scoping, and module-local policy;
+- use the CLI project for real command entry points, local proxy/server behavior, process lifecycle, persisted files, or generated desktop configuration without a live authenticated service; and
+- use the agent project only for real agent execution, SSO/JWT behavior, extension hooks, or externally synchronized session artifacts.
+
+For changes involving config paths, module initialization, credentials, a registry, a daemon, or a desktop client, state the isolation and teardown plan in the test. For proxy changes, test both the allowed upstream view and the rejection/no-forwarding path; header names, stripping, body rewriting, and plugin priority are compatibility/security contracts. For asynchronous session work, poll a bounded time for durable artifacts and validate their schema and correlation rather than making timing-sensitive fixed sleeps. These focused checks provide stronger release protection than broad implementation-coupled assertions.

--- a/openwiki/workflows/agent-launch-and-session-telemetry.md
+++ b/openwiki/workflows/agent-launch-and-session-telemetry.md
@@ -1,0 +1,147 @@
+---
+type: workflow
+title: Agent Launch, Sessions, Analytics, and Cleanup
+description: End-to-end lifecycle for launching a managed agent, correlating its session and transcript, processing telemetry, synchronizing analytics, and releasing proxy resources on every exit path.
+tags: [agent-launch, sessions, telemetry, analytics, proxy, lifecycle]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-23c009faa70a994252df8b77
+    resource: repo://src/agents/core/AgentCLI.ts
+  - id: openwiki-source-029d2ecb6970e7ac12c6f34f
+    resource: repo://src/agents/core/BaseAgentAdapter.ts
+  - id: openwiki-source-820e3288d1d3678265fa6397
+    resource: repo://src/agents/core/lifecycle-helpers.ts
+  - id: openwiki-source-7c0a0677480d0d1efa59c312
+    resource: repo://src/agents/core/session/session-origin-audit.ts
+  - id: openwiki-source-7b89aee89395463bb77ddf67
+    resource: repo://src/agents/core/session/SessionStore.ts
+  - id: openwiki-source-b66b4ea7b01fdc112698d663
+    resource: repo://src/agents/core/session/types.ts
+  - id: openwiki-source-0a8f99256c2ede8a33194372
+    resource: repo://src/cli/commands/__tests__/hook.session-origin.test.ts
+  - id: openwiki-source-577de9d6ad0287e4b17219cd
+    resource: repo://src/cli/commands/analytics/index.ts
+  - id: openwiki-source-630ae58bd3751593ef25dd12
+    resource: repo://src/cli/commands/analytics/native-loader.ts
+  - id: openwiki-source-33fc2e4824864bd50ca5107d
+    resource: repo://src/cli/commands/hook.ts
+  - id: openwiki-source-5513cf740414b88108e6c9dc
+    resource: repo://src/providers/plugins/sso/proxy/plugins/sso.session-sync.plugin.ts
+  - id: openwiki-source-3e331c197fbcb85e2c34a742
+    resource: repo://src/providers/plugins/sso/session/SessionSyncer.ts
+  - id: openwiki-source-580860a2e755afda5c2fd61f
+    resource: repo://src/telemetry/runtime/DesktopTelemetryRuntime.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+# Agent Launch, Sessions, Analytics, and Cleanup
+
+A managed `codemie-<agent>` invocation has one CodeMie session identity for its lifetime. `BaseAgentAdapter.run()` generates that UUID before proxy setup, puts it in `CODEMIE_SESSION_ID`, initializes logger context, and carries it into proxy configuration, child environment, hook invocations, local session files, and later synchronization. Repository and branch are detected once at launch and propagated in `CODEMIE_REPOSITORY` and `CODEMIE_GIT_BRANCH`, avoiding divergent repository buckets between proxy and metrics.
+
+This workflow concerns managed launches and desktop-discovered sessions. For profile precedence and on-disk configuration, see [Configuration and local state](/openwiki/concepts/configuration-and-local-state.md); for provider/proxy mechanics, see [Provider plugins and local proxy](/openwiki/integrations/provider-plugins-and-local-proxy.md); and for hook installation and automation, see [Hooks, skills, frameworks, and automation](/openwiki/workflows/hooks-skills-frameworks-and-automation.md).
+
+## Launch and identity
+
+`AgentCLI` is the CLI-facing gate. It checks installation, loads configuration with profile and command-line overrides, applies the explicit JWT override where supplied, validates required configuration, provider authentication, and model compatibility, then exports provider settings as `CODEMIE_*` overrides. `--task` and `--print-config` imply silent operation; `--no-analytics-report` becomes `CODEMIE_SESSION_ANALYTICS_REPORT=0`.
+
+Before launching, the CLI recognizes both its `--resume` option and an adapter's native resume syntax. If an adapter says the target is not CodeMie-owned, interactive confirmation is required; non-interactive use is refused with guidance to use the native agent. A confirmed external resume propagates `CODEMIE_SESSION_ORIGIN=external-resume` only to the child environment and writes an audit event. The hook persists that origin on the session record before an upload can occur. This separation matters: the CodeMie UUID identifies this launch, while the native agent session ID and transcript path are recorded as its correlation.
+
+```mermaid
+sequenceDiagram
+    participant CLI as AgentCLI
+    participant Adapter as BaseAgentAdapter
+    participant Proxy as CodeMieProxy
+    participant Child as Agent process
+    participant Hook as codemie hook
+    participant Store as SessionStore
+    participant Sync as SessionSyncer
+    participant API as Analytics API
+
+    CLI->>CLI: resolve config and resume ownership
+    CLI->>Adapter: run args and provider environment
+    Adapter->>Adapter: create CodeMie session UUID and git context
+    Adapter->>Proxy: start with session ID and proxy config
+    Proxy-->>Adapter: local proxy URL
+    Adapter->>Adapter: map environment and run lifecycle hooks
+    Adapter->>Child: spawn with correlated environment
+    Child->>Hook: SessionStart or Stop or SessionEnd event
+    Hook->>Store: persist correlation and local JSONL state
+    Hook->>Sync: process transcript and sync pending data
+    Sync->>API: metrics and conversations
+    Child-->>Adapter: exit error or signal
+    Adapter->>Adapter: run session-end hook and cleanup in finally
+    Adapter->>Proxy: stop and final sync
+    Proxy->>Sync: final synchronization
+    Adapter->>Adapter: optionally write session analytics report
+```
+
+The sequence shows the managed-agent path. The session ID is constant across adapter, proxy, hook, store, and synchronizer; the agent-native ID is the correlated remote lifecycle identity.
+
+## Proxy, environment, and lifecycle extensions
+
+The adapter starts a `CodeMieProxy` only when the selected provider needs SSO or JWT proxying *and* the agent metadata enables SSO support. Providers with `authType: 'none'` never use it, even if stale JWT environment state exists. The proxy configuration includes the target API, auth mode/token, client type, profile, integration, session ID, resolved repository/branch, project, and optional dedicated sync URLs. On success the child receives the local proxy URL as `CODEMIE_BASE_URL` and the placeholder `CODEMIE_API_KEY=proxy-handled`; it does not receive the upstream credential as its API key.
+
+After proxy setup, lifecycle resolution is deliberately provider-agnostic from the agent's perspective. Resolution composes provider wildcard hooks first, then provider agent-specific hooks; if only a wildcard is present it is chained with the agent default. If no provider hook applies, the agent default is used. The practical order is:
+
+1. `onSessionStart` after proxy setup and before environment transformation.
+2. Declarative `CODEMIE_*` to agent-specific environment mapping, which first clears mapped variables to avoid contamination from a previous run.
+3. `beforeRun`, then `enrichArgs`, declarative flag transformation, and optional reasoning-effort injection.
+4. External binary execution with inherited stdio, or a built-in `customRunHandler`.
+5. `onSessionEnd`, then proxy cleanup, then `afterRun`.
+
+Provider and agent authors should use those hooks rather than embedding provider names in adapters. `beforeRun` is the extension point for generated config and environment adjustment; `enrichArgs` receives the finalized configuration context for agent-specific CLI defaults. The dry-run print-config path still tears down a real proxy in `finally` after it prints secret-redacted generated configuration.
+
+## Session state, transcript processing, and ownership
+
+`SessionStore` owns one JSON record per CodeMie session at `~/.codemie/sessions/{sessionId}.json` and transparently reads the `completed_` version after finalization. A record holds launch metadata, native correlation, status (`active`, `completed`, `recovered`, or `failed`), optional origin, active-time accumulator, per-processor sync state, and polling runtime checkpoint. A SessionStart hook creates the record and captures the native session ID/transcript path; a re-entrant start for an active record updates correlation without resetting start time or active duration. A completed record must not be resurrected.
+
+Hooks read JSON from stdin, require `CODEMIE_AGENT` and `CODEMIE_SESSION_ID`, set logger agent/session/profile context, normalize agent-specific event names, and route `SessionStart`, `UserPromptSubmit`, `Stop`, `SubagentStop`, and `SessionEnd`. User prompt submission starts activity timing; Stop and SessionEnd accumulate it, with guards against double-start and Stop without a start. Stop incrementally parses every supplied transcript path through the registered agent `SessionAdapter`; parsing is agent-specific but the adapter reads once into `ParsedSession` for all processors. This produces local metrics and conversation JSONL, with per-file deduplication handling forked/copied history.
+
+SessionEnd has an intentional ordering: accumulate activity, transform remaining transcript messages, sync pending JSONL, send the end lifecycle metric, mark the record completed, then rename the metadata, metrics, and conversation files with `completed_`. Renaming last preserves files required by sync and metrics; `SessionStore`'s completed-file fallback covers the final-sync race.
+
+### External resumes are never silently adopted
+
+`external-resume` is an ingestion boundary, not merely a UI warning. The persisted `Session.origin` is authoritative when present; the environment flag is only a fail-closed fallback if writing the record did not happen. For such a session, hooks skip lifecycle start/end metrics and do not write ownership markers. `SessionSyncer` is the central backstop: regardless of whether a hook, proxy timer, or desktop runtime calls it, it skips both metric and conversation processors for external origin.
+
+CodeMie-owned transcripts receive an idempotent sidecar marker keyed by native transcript basename in `~/.codemie/sessions`; compatible agents also receive an in-transcript compatibility marker. Tree-structured Pi transcripts intentionally get only the sidecar because appending a line would break their resume tree. The local analytics native loader uses correlation paths and sidecars to avoid double-counting managed native logs; its `--include-external` option makes unmanaged native session output explicit.
+
+## Synchronization and analytics
+
+`SessionSyncer` is shared by SessionEnd and SSO proxy sync. It requires a stored, matched correlation, constructs an empty parsed session to put processors into JSONL sync mode, runs metrics then conversation processors by priority, aggregates failures instead of abandoning later processors, and persists all resulting sync-state updates once. Missing metadata or an unmatched correlation produces a failed result rather than uploading ambiguous data.
+
+In SSO mode, `SSOSessionSyncPlugin` validates session ID, SSO cookies, client type, and the enablement switch before creating its interceptor; failed prerequisites raise `ConfigurationError`, disabling that plugin rather than pretending synchronization is active. Enablement precedence is `CODEMIE_SESSION_SYNC_ENABLED`, then profile `session.sync.enabled`, then enabled by default. Dry-run precedence is analogous with `CODEMIE_SESSION_DRY_RUN`, defaulting false. The interceptor prevents concurrent syncs, runs periodically using `CODEMIE_SESSION_SYNC_INTERVAL` (default 120000 ms), and clears its timer plus performs a final sync in `onProxyStop`.
+
+For desktop clients that are observed rather than launched, `DesktopTelemetryRuntime` polls a `LocalTelemetryAdapter`, ignores sessions predating runtime startup, and maps each external session ID to a generated or previously correlated CodeMie session. It stores a runtime checkpoint with external ID, transcript path, and activity timestamps, processes and syncs records when present, and finalizes on inactivity or daemon stop. Finalization re-discovers and processes a transcript when possible, then syncs, sends end metrics, and records completion. It reloads SSO credentials to form its processing context; lack of cookies suppresses lifecycle metric sending.
+
+The `codemie analytics` command loads CodeMie-tracked sessions and, by default, discovers native logs as well. It supports filters for session, project, agent, branch, and time, detailed output, JSON/CSV export, and HTML/JSON reports. Native scanning can be disabled; unmanaged sessions require `--include-external`.
+
+Agents opting into `metadata.sessionAnalyticsReport` create a per-session report on child exit unless `CODEMIE_SESSION_ANALYTICS_REPORT=0`. Report generation retrieves the email from serialized profile configuration or falls back to multi-provider config, and all report errors are non-fatal.
+
+## Shutdown and failure invariants
+
+Cleanup is a lifecycle guarantee, not a happy-path epilogue:
+
+- Child `error`, ordinary nonzero exit, synchronous spawn/setup failure, and built-in-handler errors all invoke `onSessionEnd` followed by proxy cleanup. A throwing `onSessionEnd` is logged and cannot skip proxy stop.
+- `SIGINT` and `SIGTERM` stop the proxy and signal the child. On child exit, handlers are removed, a two-second grace period permits final agent API calls while the proxy is still available, and the signal is placed in `CODEMIE_EXIT_SIGNAL` before session-end processing.
+- Stopping the proxy triggers the SSO plugin's timer cleanup and final session sync. Avoid moving cleanup before session-end hooks or removing the grace period without understanding agent shutdown traffic.
+- Telemetry, marker, metrics, and session-record failures are generally logged and non-blocking so they do not break an interactive agent session. In contrast, an analytics-auth gate can block a prompt when analytics is configured but authentication is known invalid, preventing silent loss of configured metrics.
+
+When changing failure paths, use the project's typed error classes at configuration/integration boundaries (for example `ConfigurationError`) and `logger.debug()` for diagnostic-only paths. Never log cookies, bearer values, JWTs, API keys, serialized profile configuration, or raw credential-adjacent errors. Pass structured credential-adjacent diagnostic arguments through `sanitizeLogArgs()` (and retain the existing explicit configuration masking) before logging.
+
+## Focused verification
+
+Run the focused Vitest suites when modifying this flow:
+
+```text
+src/agents/core/__tests__/AgentCLI-resume.test.ts
+src/agents/core/__tests__/BaseAgentAdapter.test.ts
+src/agents/core/__tests__/BaseAgentAdapter-session-report.test.ts
+src/cli/commands/__tests__/hook-routing-contract.test.ts
+src/cli/commands/__tests__/hook.session-origin.test.ts
+src/providers/plugins/sso/session/__tests__/SessionSyncer.test.ts
+src/telemetry/runtime/__tests__/DesktopTelemetryRuntime.test.ts
+```
+
+The high-value regressions are confirmed external-resume propagation and exclusion from markers/metrics/sync, completed-session lookup, report kill-switch and non-fatal behavior, proxy selection for SSO/JWT only, lifecycle ordering and cleanup on spawn/exit/signal paths, sync processor ordering/error aggregation, and desktop repository forwarding. See [Test strategy](/openwiki/testing/test-strategy.md) for broader test conventions and [Daemon migrations and diagnostics](/openwiki/operations/daemon-migrations-and-diagnostics.md) for daemon operational context.

--- a/openwiki/workflows/hooks-skills-frameworks-and-automation.md
+++ b/openwiki/workflows/hooks-skills-frameworks-and-automation.md
@@ -1,0 +1,198 @@
+---
+type: workflow systems
+title: Hooks, Extensions, Skills, Frameworks, and Workflow Templates
+description: How CodeMie executes configurable hooks and agent lifecycle hooks, installs agent extensions, discovers and synchronizes skills, registers development frameworks, and installs repository CI workflow templates.
+tags: [hooks, extensions, skills, assistants, frameworks, automation, workflows]
+verified:
+  - by: openwiki/0.4.3
+    at: 2026-08-29T08:09:18.077Z
+sources:
+  - id: openwiki-source-23c009faa70a994252df8b77
+    resource: repo://src/agents/core/AgentCLI.ts
+  - id: openwiki-source-6fa6326b0aec78a524ed76ec
+    resource: repo://src/agents/core/extension/BaseExtensionInstaller.ts
+  - id: openwiki-source-0281d261fe50fcf2ae50a87c
+    resource: repo://src/cli/commands/assistants/setup/generators/claude-agent-generator.ts
+  - id: openwiki-source-48d6edfbe7960e5227beeb60
+    resource: repo://src/cli/commands/assistants/setup/generators/claude-skill-generator.ts
+  - id: openwiki-source-3ab121b39d4b194a8ef10e2b
+    resource: repo://src/cli/commands/assistants/setup/helpers.ts
+  - id: openwiki-source-2685240536e66d49fc4654e3
+    resource: repo://src/cli/commands/assistants/setup/index.ts
+  - id: openwiki-source-33fc2e4824864bd50ca5107d
+    resource: repo://src/cli/commands/hook.ts
+  - id: openwiki-source-9146f27c2510b5e8afb4aad6
+    resource: repo://src/cli/commands/skill.ts
+  - id: openwiki-source-e48292565bbdf63d1ce89a50
+    resource: repo://src/cli/commands/skills/add.ts
+  - id: openwiki-source-fc6f7ba2acdd1ce3c3156299
+    resource: repo://src/cli/commands/skills/index.ts
+  - id: openwiki-source-f08eb9092b00a83bf8fafdb2
+    resource: repo://src/cli/commands/workflow.ts
+  - id: openwiki-source-ae701ba4fd4af400e6cf208b
+    resource: repo://src/frameworks/core/registry.ts
+  - id: openwiki-source-f3c7f637f71ecf7332d8bbd1
+    resource: repo://src/frameworks/index.ts
+  - id: openwiki-source-7c7fa2026b2641d9e184ea9f
+    resource: repo://src/frameworks/plugins/index.ts
+  - id: openwiki-source-a11b9a7f8004ccb4a6dad120
+    resource: repo://src/hooks/decision.ts
+  - id: openwiki-source-cfdf6af3efc35c2e8c23da1d
+    resource: repo://src/hooks/executor.ts
+  - id: openwiki-source-ea1e7e32280795efc2b08284
+    resource: repo://src/hooks/matcher.ts
+  - id: openwiki-source-d0adec1201abf3456bfeffd3
+    resource: repo://src/hooks/prompt-executor.ts
+  - id: openwiki-source-82f756bcef81278bbbbd0f92
+    resource: repo://src/hooks/types.ts
+  - id: openwiki-source-1ea9e2a5718bed7d79e8b2d7
+    resource: repo://src/skills/core/SkillDiscovery.ts
+  - id: openwiki-source-e659018683ea5696caf2b901
+    resource: repo://src/skills/core/SkillManager.ts
+  - id: openwiki-source-4cf14f111091af383fe98e11
+    resource: repo://src/skills/core/types.ts
+  - id: openwiki-source-1151bbe36e76f7a7f3a43a1f
+    resource: repo://src/skills/sync/SkillSync.ts
+  - id: openwiki-source-f6252ef77d7dfe84d64135cf
+    resource: repo://src/workflows/detector.ts
+  - id: openwiki-source-a34ad10effdf70046bdca15e
+    resource: repo://src/workflows/installer.ts
+  - id: openwiki-source-6ceeb46e59ef4699b5454247
+    resource: repo://src/workflows/registry.ts
+  - id: openwiki-source-c3700592c8cecfccf48e125f
+    resource: repo://src/workflows/templates/github/metadata.ts
+  - id: openwiki-source-fec897d985ccf1238ae9722f
+    resource: repo://src/workflows/templates/gitlab/metadata.ts
+generated: { by: "openwiki/0.4.3", at: "2026-08-29T08:09:18.077Z" }
+---
+
+# Hooks, Extensions, Skills, Frameworks, and Workflow Templates
+
+CodeMie has several similarly named mechanisms with deliberately different owners and effects:
+
+- **The configurable hook engine** (`src/hooks/`) evaluates locally configured command or LLM hooks around tool, prompt, stop, and session lifecycle points. It can return a decision or conversation context.
+- **The `codemie hook` command** is a separate integration boundary for installed agent plugins/extensions. It reads an agent event from standard input, normalizes it through the selected agent adapter, and performs session correlation, activity accounting, transcript processing, and best-effort analytics work. It is not the configurable `HookExecutor` dispatcher.
+- **Extensions** package the integration files—including an agent-native `hooks/hooks.json`—that cause an external agent to invoke that command.
+- **Skills** are Markdown instruction bundles discovered by CodeMie or installed for a target agent. Assistant setup can generate target-agent skill/subagent wrappers; `SkillSync` copies CodeMie-managed skill directories into Claude Code’s discovery location.
+- **Frameworks** are registered adapters for external development methodologies and CLIs. They are installed/initialized through the agent CLI rather than being skill content.
+- **Workflow templates** are versioned CI definitions copied into the current VCS repository. They are not agent hook definitions.
+
+## Configurable hook execution
+
+`HooksConfiguration` maps lifecycle event names to matchers, whose `hooks` are either `command` or `prompt` configurations. A command needs `command`; a prompt hook needs `prompt`; both may set a timeout (60 seconds is the command default). Inputs include correlation and execution context—session ID, transcript path, working directory, permission mode, agent/profile names—and event-specific tool, output, prompt, or execution-history fields. Results can decide `allow`, `deny`, `block`, or `approve`, optionally supply a reason, additional context, modified tool input, output suppression, or a permission decision.
+
+Tool events use their matcher; an omitted matcher means `*`. `*` matches every tool. Patterns containing `|`, character-class brackets, braces, or parentheses are compiled as an anchored regular expression; other patterns are literals. Invalid regular expressions fall back to a literal comparison. `UserPromptSubmit`, `Stop`, and `SessionStart` flatten all configured matchers and therefore run all their hooks rather than filtering by tool name.
+
+```mermaid
+flowchart TD
+    Event["Lifecycle event"] --> Select["Select event configuration"]
+    Select --> Tool{"Tool event"}
+    Tool -->|"yes"| Match["Match literal wildcard or anchored regex"]
+    Tool -->|"no"| All["Flatten all configured hooks"]
+    Match --> Unique["Hash and deduplicate configurations"]
+    All --> Unique
+    Unique --> Run["Run unique hooks concurrently"]
+    Run --> Kind{"Hook type"}
+    Kind -->|"command"| Command["Sanitize tool data and run shell command"]
+    Kind -->|"prompt"| Prompt["Resolve template and invoke LLM"]
+    Command --> Parse["Parse exit status and JSON output"]
+    Prompt --> Parse
+    Parse --> Merge["Merge decisions and context"]
+    Merge --> Result["Aggregated hook result"]
+```
+
+This shows the standalone configurable hook engine’s match, execution, and decision path.
+
+### Execution, decisions, and safety properties
+
+`HookExecutor` hashes type, command/prompt, and effective timeout to remove duplicates both within a dispatch and until `clearCache()` starts a new event cycle. It runs the remaining hooks with `Promise.allSettled`, so one rejected task does not stop the others. Command hooks run in the configured working directory with shell parsing, receive context in `CODEMIE_*` environment variables, and currently receive serialized JSON through `CODEMIE_HOOK_INPUT`. Before serialization, `tool_input` and `tool_output` are passed through `sanitizeValue`.
+
+Hook stdout is expected to be JSON, but empty output means allow and non-JSON output becomes `additionalContext`. Exit code `2` produces a blocking result with stderr/stdout feedback; other nonzero exits fail open as `allow` while retaining feedback. Execution errors, an unknown hook type, a missing required command/prompt, missing LLM configuration, and prompt invocation failures also fail open. When several hooks return successfully, decision precedence is **block > deny > approve > allow**; all additional contexts are joined and later `updatedInput` values override earlier keys. The executor’s `PostToolUse` result is documented as informational, while its pre-tool, prompt, stop, and session calls expose the aggregated decision to their caller.
+
+Prompt hooks use `ChatOpenAI` at temperature zero, default model `gpt-3.5-turbo`, and a 30-second default request timeout. Templates may substitute `$ARGUMENTS`, `$TOOL_NAME`, `$TOOL_INPUT`, `$PROMPT`, `$SESSION_ID`, and `$CWD`. JSON replies are validated; a plain-text reply is treated as a denial only if it contains blocking language such as “block”, “deny”, “reject”, or “prevent”.
+
+> **Operational caution:** hook commands execute with the invoking user’s environment and shell. Treat configurations as trusted code. Do not write raw hook payloads, cookie headers, API keys, or unredacted tool output to diagnostics. Use `logger.debug()` for diagnostics and sanitize credential-adjacent values before logging or forwarding them.
+
+## Agent hook-event routing and extension installation
+
+Agent-native plugin hooks invoke `codemie hook`. In CLI mode, the command reads JSON from stdin and requires an event session ID and event name. It establishes logger context from `CODEMIE_AGENT` and `CODEMIE_SESSION_ID`; after agent transformation it requires a transcript path except for `SessionStart` and `SessionEnd`. Programmatic callers use `processEvent(event, config)` and receive errors instead of process termination for validation/handler failures.
+
+An adapter may supply `getHookTransformer()` and an event-name mapping. Transformation precedes the internal transcript validation, which lets an adapter derive a path that its native payload did not provide. Unknown events are ignored. The supported route set is `SessionStart`, `SessionEnd`, `PermissionRequest`, `Stop`, `UserPromptSubmit`, `SubagentStop`, and `PreCompact`.
+
+```mermaid
+sequenceDiagram
+    participant Native as Agent extension
+    participant Command as codemie hook
+    participant Adapter as Agent registry adapter
+    participant Router as Event router
+    participant Store as Session store
+    participant Syncer as Session adapter and sync
+    Native->>Command: JSON event on stdin
+    Command->>Adapter: transform event and map name
+    Adapter-->>Command: normalized event
+    Command->>Router: validate and route
+    alt SessionStart
+        Router->>Store: create or refresh correlation record
+    else UserPromptSubmit
+        Router->>Store: start activity tracking
+    else Stop or SubagentStop
+        Router->>Store: accumulate active duration when Stop
+        Router->>Syncer: process transcript path or paths
+    else SessionEnd
+        Router->>Syncer: final processing and pending API sync
+        Router->>Store: mark completed and rename local files
+    end
+```
+
+This is the agent hook-event boundary; it is distinct from the configurable hook-engine diagram above.
+
+On `SessionStart`, the router creates or refreshes the CodeMie session correlation record, starts best-effort start metrics work, and non-blockingly runs `SkillSync.syncToClaude()` for the event working directory. Re-entry into a still-active record preserves its start and accumulated-active-time values. A `UserPromptSubmit` can enforce the analytics-auth gate when analytics is configured: invalid/missing credentials or a saved invalid-auth marker block the native CLI prompt with exit code 2, while programmatic mode throws for the host to surface. It then starts active-time tracking. `Stop` accumulates active duration and incrementally processes every supplied transcript path; `SessionEnd` does final processing/API synchronization, sends end metrics when configured, marks the session complete, then renames session, metrics, and conversation files with `completed_` prefixes. Most telemetry, session-processing, and skill-sync failures are caught so they do not otherwise block agent execution.
+
+`BaseExtensionInstaller` is the reusable installer for these agent-specific integration bundles. Subclasses provide source/target paths, manifest path, and critical files. `install()` reads source and installed manifest versions; an absent or version-different valid install triggers a clean replacement copy, while equal/unknown versions are retained. It verifies critical files and parses critical JSON before reporting success, then best-effort rewrites copied hook commands to an absolute CodeMie binary path. Installation failure returns `action: 'failed'` rather than throwing from the base workflow, meaning agent use can continue without extension hooks.
+
+Manifests may also enable a selective project-local copy. `local-install.json` is preferred, with legacy manifest configuration accepted as fallback. Whitelist, blacklist, and hybrid include/exclude strategies use normalized forward-slash paths so Windows glob matching remains correct; overwrite policy is `always`, `never`, or `newer`. A per-agent version record under the CodeMie home controls whether the local copy is refreshed.
+
+## Skills and assistant setup
+
+A CodeMie skill is a `SKILL.md` with validated YAML frontmatter: non-empty `name` and `description`, optional version/author/license/modes/compatibility, and numeric priority. Discovery searches up to three levels under these roots:
+
+| Source | Root | Base priority |
+| --- | --- | ---: |
+| Project | `<cwd>/.codemie/skills/` | 1000 |
+| Mode-specific | `~/.codemie/skills-<mode>/` | 500 |
+| Enabled plugin | resolved plugin skills and commands | 200 |
+| Global | `~/.codemie/skills/` | 100 |
+
+The effective priority is source base plus frontmatter priority. Same-name skills are deduplicated so the higher value wins, then results are filtered by compatible agent and requested mode and sorted descending. A malformed/unreadable file is excluded rather than failing all discovery. Discovery caches by working directory, mode, and agent; `SkillManager.reload()` clears it. Pattern-based invocation can load named skills with an inventory of their companion files.
+
+There are two CLI surfaces. `codemie skill` manages the internal discovery model: `list`, `validate`, `reload`, and `sync` (currently target `claude` only). In contrast, plural `codemie skills` is an authenticated wrapper around the upstream `skills` CLI for catalog/distribution operations such as add, update, remove, list, and find. Its add command accepts a repository, URL, local path, or well-known endpoint, can select target agents, forces copy mode on Windows, disables interactive Git credential prompts, sanitizes the source used in metrics, and applies a two-minute Git operation limit.
+
+`SkillSync` refreshes discovery, then copies each discovered skill’s *entire containing directory* to `<cwd>/.claude/skills/<skill-name>`, skipping hidden directories and `node_modules`. `.claude/skills/.codemie-sync.json` records source path and `SKILL.md` mtime, enabling unchanged skills to be skipped. `--dry-run` reports without writes. `--clean` removes only manifest-tracked skill directories no longer discovered—but the implementation returns early when discovery finds zero skills, so that invocation does not clean all prior output. Individual copy/cleanup errors are accumulated in the result rather than aborting the whole sync.
+
+`codemie setup assistants` authenticates, loads existing registrations, lets the user select server assistants and choose subagent versus skill representation, selects global or local storage, and targets Claude, Codex, and/or Gemini. It unregisters removed or reconfigured artifacts before generating replacements, then persists the selected registration set to the chosen CodeMie configuration scope. For Claude, agent mode writes `<scope>/.claude/agents/<slug>.md`; skill mode writes `<scope>/.claude/skills/<slug>/SKILL.md`. Generated wrappers invoke `codemie assistants chat <id>` and instruct callers to mint and reuse a task-specific `--conversation-id`, preventing unrelated assistant calls in one agent session from sharing implicit context. Codex and Gemini use their respective assistant-skill generators for either selected mode.
+
+## Framework adapters
+
+Importing `src/frameworks/index.ts` imports the plugins module, whose side effect registers `SpeckitPlugin`, `BmadPlugin`, and `CodebaseMemoryPlugin` in the static `FrameworkRegistry`. The registry returns only available adapters and can filter by `metadata.supportedAgents`; an absent/empty supported-agent list means all agents.
+
+A framework adapter encapsulates installing/uninstalling an external CLI, detecting initialization in the project, mapping a CodeMie agent name to the framework’s name, reporting a version, and initializing. `BaseFrameworkAdapter` provides ordinary CLI detection with `--version` then `which`, five-second/ two-second limits, and init-directory existence checks; concrete adapters own their commands and dependency/error behavior. The agent CLI exposes `codemie-<agent> init --list` and `codemie-<agent> init <framework>`: it rejects unknown or unsupported framework/agent pairs and passes force, current directory, and framework-specific options to `init`. `codemie install <framework>` consults the same registry for installation.
+
+For example, SpecKit supports Claude and Gemini, detects `.specify`, installs `specify-cli` through `uv` from the upstream Git repository after verifying `uv` and Git, and initializes in place with the mapped agent plus an OS-specific shell/PowerShell script option. It refuses an already initialized project unless forced.
+
+## Repository workflow templates
+
+`codemie workflow list`, `install <workflow-id>`, and `uninstall <workflow-id>` manage CI templates. Provider autodetection first confirms a Git work tree and then derives GitHub or GitLab from the `origin` URL; callers can override it with `--github` or `--gitlab`. GitHub files belong in `.github/workflows`; GitLab files belong in `.gitlab` according to this installer. The registry has GitHub template metadata for `pr-review`, `inline-fix`, and `code-ci`; the GitLab metadata list is currently empty.
+
+Install resolves a template by ID and provider, creates the provider directory, and writes `codemie-<id>.yml`. An existing install is skipped unless `--force`; `--dry-run` prints the destination and rendered content without writing. It can replace recognized timeout, max-turns fallback, and environment fields in the template. Dependency validation reports required/optional repository secrets and tools as warnings; it cannot verify secret values. Therefore installing a file is not operational readiness: configure the required secrets, commit and push the generated definition, and review its declared triggers and permissions before enabling it. Uninstall only removes the installed file; it does not remove prior CI runs or history.
+
+## Focused verification
+
+The focused hook tests exercise matching, decision parsing, command input/environment propagation, blocking exit code 2, fail-open errors, deduplication, and cache reset. Skill-sync tests isolate `CODEMIE_HOME` and a temporary project, then verify whole-directory copy and manifest creation, mtime-based skipping/re-sync, dry runs, and guarded orphan cleanup. Extension installer tests cover hook-command localization and Windows path behavior; framework plugin tests cover their concrete adapters. Workflow integration tests cover the CLI/install flow. For changes that can write or delete user files, retain temporary-directory isolation and explicitly test `--dry-run`, no-op/up-to-date, force, and cleanup paths.
+
+## Related pages
+
+- [CLI surface](/openwiki/architecture/cli-surface.md)
+- [Configuration and local state](/openwiki/concepts/configuration-and-local-state.md)
+- [Agent plugin system](/openwiki/integrations/agent-plugin-system.md)
+- [Agent launch and session telemetry](/openwiki/workflows/agent-launch-and-session-telemetry.md)
+- [Test strategy](/openwiki/testing/test-strategy.md)

--- a/openwiki/workflows/index.md
+++ b/openwiki/workflows/index.md
@@ -1,0 +1,4 @@
+# Files
+
+- [Agent Launch, Sessions, Analytics, and Cleanup](agent-launch-and-session-telemetry.md) - End-to-end lifecycle for launching a managed agent, correlating its session and transcript, processing telemetry, synchronizing analytics, and releasing proxy resources on every exit path.
+- [Hooks, Extensions, Skills, Frameworks, and Workflow Templates](hooks-skills-frameworks-and-automation.md) - How CodeMie executes configurable hooks and agent lifecycle hooks, installs agent extensions, discovers and synchronizes skills, registers development frameworks, and installs repository CI workflow templates.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "codemie-codex": "./bin/codemie-codex.js",
     "codemie-kimi": "./bin/codemie-kimi.js",
     "codemie-kimi-acp": "./bin/codemie-kimi-acp.js",
+    "codemie-openwiki": "./bin/codemie-openwiki.js",
     "codemie-mcp-proxy": "./bin/codemie-mcp-proxy.js",
     "proxy-daemon": "./bin/proxy-daemon.js",
     "codemie-copilot": "./bin/codemie-copilot.js"

--- a/src/agents/__tests__/registry.test.ts
+++ b/src/agents/__tests__/registry.test.ts
@@ -25,6 +25,7 @@ describe('AgentRegistry', () => {
           'pi',
           'kimi',
           'kimi-acp',
+          'openwiki',
           'copilot-cli', // analytics-only: read for the report, never managed by CodeMie
         ].sort()
       );

--- a/src/agents/core/AgentCLI.ts
+++ b/src/agents/core/AgentCLI.ts
@@ -20,6 +20,7 @@ import { CodexPluginMetadata } from '../plugins/codex/codex.plugin.js';
 import { KimiPluginMetadata } from '../plugins/kimi/kimi.plugin.js';
 import { KimiAcpPluginMetadata } from '../plugins/kimi/kimi-acp.plugin.js';
 import { PiPluginMetadata } from '../plugins/pi/pi.plugin.js';
+import { OpenWikiPluginMetadata } from '../plugins/openwiki/openwiki.plugin.js';
 import { CopilotCliPluginMetadata } from '../plugins/copilot-cli/index.js';
 import { getAgentInstallCommand, getAgentLauncherCommand } from './agent-aliases.js';
 import { createAssistantsSetupCommand } from '../../cli/commands/assistants/setup/index.js';
@@ -630,6 +631,7 @@ export class AgentCLI {
       'kimi': KimiPluginMetadata,
       'kimi-acp': KimiAcpPluginMetadata,
       'pi': PiPluginMetadata,
+      'openwiki': OpenWikiPluginMetadata,
       'copilot-cli': CopilotCliPluginMetadata,
     };
     return metadataMap[this.adapter.name];

--- a/src/agents/plugins/openwiki/openwiki.plugin.ts
+++ b/src/agents/plugins/openwiki/openwiki.plugin.ts
@@ -1,0 +1,57 @@
+import type { AgentConfig, AgentMetadata } from '../../core/types.js';
+import { BaseAgentAdapter } from '../../core/BaseAgentAdapter.js';
+
+/**
+ * OpenWiki agent plugin
+ *
+ * Thin wrapper around the OpenWiki CLI (https://github.com/langchain-ai/openwiki),
+ * an agent that writes and maintains a Markdown wiki for the current repository.
+ *
+ * OpenWiki reads its model access from OPENWIKI_PROVIDER / OPENAI_COMPATIBLE_*
+ * / OPENWIKI_MODEL_ID env vars, so the declarative envMapping below wires the
+ * active CodeMie profile straight into it: for SSO/JWT profiles the base class
+ * starts the local proxy (auth + attribution headers injected there) and
+ * CODEMIE_BASE_URL/CODEMIE_API_KEY become the proxy URL / 'proxy-handled';
+ * for api-key providers the real values are forwarded instead.
+ */
+export const OpenWikiPluginMetadata: AgentMetadata = {
+  name: 'openwiki',
+  displayName: 'OpenWiki',
+  description: 'OpenWiki - agent-written, self-updating wiki for your codebase',
+  npmPackage: 'openwiki',
+  cliCommand: 'openwiki',
+  envMapping: {
+    baseUrl: ['OPENAI_COMPATIBLE_BASE_URL'],
+    apiKey: ['OPENAI_COMPATIBLE_API_KEY'],
+    model: ['OPENWIKI_MODEL_ID'],
+  },
+  supportedProviders: ['ai-run-sso', 'bearer-auth', 'litellm', 'ollama', 'moonshot-subscription'],
+  blockedModelPatterns: [],
+  ssoConfig: { enabled: true, clientType: 'codemie-openwiki' },
+  ownedSubcommands: ['init'],
+  flagMappings: {
+    '--task': { type: 'flag', target: '-p' },
+  },
+  lifecycle: {
+    async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig): Promise<NodeJS.ProcessEnv> {
+      env.OPENWIKI_PROVIDER = 'openai-compatible';
+
+      // OpenWiki (LangChain) appends /chat/completions to the base URL. The SSO
+      // proxy and LiteLLM accept the bare base URL (same contract the opencode
+      // plugin relies on); Ollama only serves the OpenAI-compatible API
+      // under /v1.
+      const baseUrl = env.OPENAI_COMPATIBLE_BASE_URL;
+      if (config.provider === 'ollama' && baseUrl && !baseUrl.endsWith('/v1')) {
+        env.OPENAI_COMPATIBLE_BASE_URL = `${baseUrl.replace(/\/$/, '')}/v1`;
+      }
+
+      return env;
+    },
+  },
+};
+
+export class OpenWikiPlugin extends BaseAgentAdapter {
+  constructor(metadata: AgentMetadata = OpenWikiPluginMetadata) {
+    super(metadata);
+  }
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -7,6 +7,7 @@ import { CodexPlugin } from './plugins/codex/index.js';
 import { PiPlugin } from './plugins/pi/index.js';
 import { KimiPlugin } from './plugins/kimi/kimi.plugin.js';
 import { KimiAcpPlugin } from './plugins/kimi/kimi-acp.plugin.js';
+import { OpenWikiPlugin } from './plugins/openwiki/openwiki.plugin.js';
 import { CopilotCliPlugin } from './plugins/copilot-cli/index.js';
 import { AgentAdapter, AgentAnalyticsAdapter } from './core/types.js';
 
@@ -40,6 +41,7 @@ export class AgentRegistry {
     AgentRegistry.registerPlugin(new PiPlugin());
     AgentRegistry.registerPlugin(new KimiPlugin());
     AgentRegistry.registerPlugin(new KimiAcpPlugin());
+    AgentRegistry.registerPlugin(new OpenWikiPlugin());
     AgentRegistry.registerPlugin(new CopilotCliPlugin());
 
     AgentRegistry.initialized = true;

--- a/src/cli/commands/docs.ts
+++ b/src/cli/commands/docs.ts
@@ -1,0 +1,159 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { FrameworkRegistry } from '../../frameworks/core/registry.js';
+import type { FrameworkAdapter } from '../../frameworks/core/types.js';
+import { AgentRegistry } from '../../agents/registry.js';
+import { getErrorMessage } from '../../utils/errors.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Documentation & knowledge tools command group.
+ *
+ * Docs tools (codegraph, graphify, codebase-memory) are framework adapters
+ * tagged group: 'documentation' — they are deterministic local tooling, not
+ * agent harnesses. OpenWiki is the exception: it is model-backed and managed
+ * as an agent (`codemie install openwiki`, `codemie-openwiki`), so here it is
+ * listed as a pointer only.
+ */
+export function createDocsCommand(): Command {
+  const docs = new Command('docs');
+  docs.description('Manage documentation & knowledge tools (install and initialize per project)');
+
+  const listAction = async (): Promise<void> => {
+    const tools = FrameworkRegistry.getFrameworksByGroup('documentation');
+
+    console.log();
+    console.log(chalk.bold('📚 Documentation & Knowledge Tools:\n'));
+
+    for (const tool of tools) {
+      await printToolStatus(tool);
+    }
+
+    await printOpenwikiStatus();
+  };
+
+  docs
+    .command('list')
+    .description('List available documentation tools and their status')
+    .action(listAction);
+
+  docs
+    .command('install <name>')
+    .description('Install a documentation tool (see: codemie docs list)')
+    .action(async (name: string) => {
+      const tool = resolveDocsTool(name);
+      if (!tool) {
+        process.exitCode = 1;
+        return;
+      }
+
+      try {
+        await tool.install();
+      } catch (error) {
+        logger.error(getErrorMessage(error));
+        process.exitCode = 1;
+      }
+    });
+
+  docs
+    .command('uninstall <name>')
+    .description('Uninstall a documentation tool')
+    .action(async (name: string) => {
+      const tool = resolveDocsTool(name);
+      if (!tool) {
+        process.exitCode = 1;
+        return;
+      }
+
+      try {
+        await tool.uninstall();
+      } catch (error) {
+        logger.error(getErrorMessage(error));
+        process.exitCode = 1;
+      }
+    });
+
+  docs
+    .command('init <name>')
+    .description('Initialize a documentation tool in the current project')
+    .option('--cwd <path>', 'Project directory (default: current directory)')
+    .action(async (name: string, options: { cwd?: string }) => {
+      const tool = resolveDocsTool(name);
+      if (!tool) {
+        process.exitCode = 1;
+        return;
+      }
+
+      try {
+        // FrameworkAdapter.init is agent-centric; docs tools are agent-agnostic
+        // except agent-specific ones (e.g. graphify ships a Claude Code skill),
+        // which declare their target in supportedAgents.
+        const agentName = tool.metadata.supportedAgents?.[0] ?? 'docs';
+        await tool.init(agentName, { cwd: options.cwd });
+      } catch (error) {
+        logger.error(getErrorMessage(error));
+        process.exitCode = 1;
+      }
+    });
+
+  // Bare `codemie docs` behaves like `codemie docs list`
+  docs.action(listAction);
+
+  return docs;
+}
+
+async function printToolStatus(tool: FrameworkAdapter): Promise<void> {
+  const installed = await tool.isInstalled();
+  const status = installed ? chalk.green('✓ installed') : chalk.yellow('○ not installed');
+  const version = installed ? await tool.getVersion() : null;
+  const versionStr = version ? chalk.white(` (${version})`) : '';
+  const initialized = await tool.isInitialized();
+  const initStr = initialized ? chalk.green('✓ initialized in this project') : chalk.gray('○ not initialized here');
+
+  console.log(chalk.bold(`  ${tool.metadata.displayName}`) + versionStr);
+  console.log(`    Install: ${chalk.cyan(`codemie docs install ${tool.metadata.name}`)} — ${status}`);
+  console.log(`    Init:    ${chalk.cyan(`codemie docs init ${tool.metadata.name}`)} — ${initStr}`);
+  console.log(`    ${chalk.white(tool.metadata.description)}`);
+  if (tool.metadata.docsUrl) {
+    console.log(chalk.gray(`    Docs: ${tool.metadata.docsUrl}`));
+  }
+  console.log();
+}
+
+async function printOpenwikiStatus(): Promise<void> {
+  const agent = AgentRegistry.getAgent('openwiki');
+  const installed = agent ? await agent.isInstalled() : false;
+  const status = installed ? chalk.green('✓ installed') : chalk.yellow('○ not installed');
+  const version = installed && agent ? await agent.getVersion() : null;
+  const versionStr = version ? chalk.white(` (${version})`) : '';
+  const initialized = existsSync(join(process.cwd(), 'openwiki'));
+  const initStr = initialized ? chalk.green('✓ initialized in this project') : chalk.gray('○ not initialized here');
+
+  console.log(chalk.bold('  OpenWiki') + versionStr + chalk.gray(' (agent-managed, uses your CodeMie profile)'));
+  console.log(`    Install: ${chalk.cyan('codemie install openwiki')} — ${status}`);
+  console.log(`    Init:    ${chalk.cyan('codemie-openwiki --init')} — ${initStr}`);
+  console.log(`    ${chalk.white('Agent-written, self-updating wiki for your codebase')}`);
+  console.log();
+}
+
+function resolveDocsTool(name: string): FrameworkAdapter | undefined {
+  if (name === 'openwiki') {
+    console.log(chalk.yellow('OpenWiki is managed as an agent, not a docs tool:'));
+    console.log(`  Install: ${chalk.cyan('codemie install openwiki')}`);
+    console.log(`  Init:    ${chalk.cyan('codemie-openwiki --init')}`);
+    return undefined;
+  }
+
+  const tool = FrameworkRegistry.getFramework(name);
+  if (!tool || (tool.metadata.group ?? 'framework') !== 'documentation') {
+    const available = FrameworkRegistry.getFrameworksByGroup('documentation')
+      .map((t) => t.metadata.name)
+      .join(', ');
+    console.error(chalk.red(`✗ Unknown documentation tool '${name}'. Available: ${available}, openwiki`));
+    return undefined;
+  }
+
+  return tool;
+}

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -53,27 +53,34 @@ export function createInstallCommand(): Command {
             console.log();
           }
 
-          // Show frameworks
+          // Show frameworks, split into dev frameworks and documentation tools
           const { FrameworkRegistry } = await import('../../frameworks/index.js');
-          const frameworks = FrameworkRegistry.getAllFrameworks();
+          const frameworkGroups: Array<{ group: 'framework' | 'documentation'; heading: string }> = [
+            { group: 'framework', heading: '🛠️  Available Frameworks:\n' },
+            { group: 'documentation', heading: '📚 Documentation & Knowledge Tools:\n' },
+          ];
 
-          if (frameworks.length > 0) {
-            console.log(chalk.bold('🛠️  Available Frameworks:\n'));
+          for (const { group, heading } of frameworkGroups) {
+            const frameworks = FrameworkRegistry.getFrameworksByGroup(group);
 
-            for (const framework of frameworks) {
-              const installed = await framework.isInstalled();
-              const status = installed ? chalk.green('✓ installed') : chalk.yellow('○ not installed');
-              const version = installed ? await framework.getVersion() : null;
-              const versionStr = version ? chalk.white(` (${version})`) : '';
+            if (frameworks.length > 0) {
+              console.log(chalk.bold(heading));
 
-              console.log(chalk.bold(`  ${framework.metadata.displayName}`) + versionStr);
-              console.log(`    Command: ${chalk.cyan(`codemie install ${framework.metadata.name}`)}`);
-              console.log(`    Status: ${status}`);
-              console.log(`    ${chalk.white(framework.metadata.description)}`);
-              if (framework.metadata.docsUrl) {
-                console.log(chalk.gray(`    Docs: ${framework.metadata.docsUrl}`));
+              for (const framework of frameworks) {
+                const installed = await framework.isInstalled();
+                const status = installed ? chalk.green('✓ installed') : chalk.yellow('○ not installed');
+                const version = installed ? await framework.getVersion() : null;
+                const versionStr = version ? chalk.white(` (${version})`) : '';
+
+                console.log(chalk.bold(`  ${framework.metadata.displayName}`) + versionStr);
+                console.log(`    Command: ${chalk.cyan(`codemie install ${framework.metadata.name}`)}`);
+                console.log(`    Status: ${status}`);
+                console.log(`    ${chalk.white(framework.metadata.description)}`);
+                if (framework.metadata.docsUrl) {
+                  console.log(chalk.gray(`    Docs: ${framework.metadata.docsUrl}`));
+                }
+                console.log();
               }
-              console.log();
             }
           }
 
@@ -273,8 +280,13 @@ export function createInstallCommand(): Command {
             // Show how to initialize the framework
             console.log();
             console.log(chalk.cyan('💡 Next steps:'));
-            console.log(chalk.white(`   Initialize in project:`), chalk.blueBright(`codemie-<agent> init ${framework.metadata.name}`));
-            console.log(chalk.white(`   List frameworks:`), chalk.blueBright(`codemie-<agent> init --list`));
+            if ((framework.metadata.group ?? 'framework') === 'documentation') {
+              console.log(chalk.white(`   Initialize in project:`), chalk.blueBright(`codemie docs init ${framework.metadata.name}`));
+              console.log(chalk.white(`   List documentation tools:`), chalk.blueBright('codemie docs list'));
+            } else {
+              console.log(chalk.white(`   Initialize in project:`), chalk.blueBright(`codemie-<agent> init ${framework.metadata.name}`));
+              console.log(chalk.white(`   List frameworks:`), chalk.blueBright(`codemie-<agent> init --list`));
+            }
             console.log();
           } catch (error: unknown) {
             spinner.fail(`Failed to install ${framework.metadata.displayName}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,7 @@ import { createMcpCommand } from './commands/mcp/index.js';
 import { createMcpProxyCommand } from './commands/mcp-proxy.js';
 import { createProxyCommand } from './commands/proxy/index.js';
 import { createCodebaseCommand } from './commands/codebase/index.js';
+import { createDocsCommand } from './commands/docs.js';
 import { FirstTimeExperience } from './first-time.js';
 import { getDirname } from '../utils/paths.js';
 
@@ -102,6 +103,7 @@ program.addCommand(createMcpCommand());
 program.addCommand(createMcpProxyCommand());
 program.addCommand(createProxyCommand());
 program.addCommand(createCodebaseCommand());
+program.addCommand(createDocsCommand());
 
 // Check for --task option before parsing commands
 const taskIndex = process.argv.indexOf('--task');

--- a/src/frameworks/core/registry.ts
+++ b/src/frameworks/core/registry.ts
@@ -68,6 +68,17 @@ export class FrameworkRegistry {
   }
 
   /**
+   * Get frameworks in a listing group (default group: 'framework')
+   * @param group - Listing group to filter by
+   * @returns Array of framework adapters in the group
+   */
+  static getFrameworksByGroup(group: 'framework' | 'documentation' = 'framework'): FrameworkAdapter[] {
+    return this.getAllFrameworks().filter(
+      (adapter) => (adapter.metadata.group ?? 'framework') === group
+    );
+  }
+
+  /**
    * Get framework names
    * @returns Array of registered framework names
    */

--- a/src/frameworks/core/types.ts
+++ b/src/frameworks/core/types.ts
@@ -44,6 +44,14 @@ export interface FrameworkMetadata {
 
   /** Directory created by framework initialization (for detection) */
   initDirectory?: string;
+
+  /**
+   * Listing group: 'framework' (default) for dev frameworks like SpecKit/BMAD,
+   * 'documentation' for documentation & knowledge tools (codegraph, graphify,
+   * codebase-memory). Documentation tools surface under `codemie docs` and are
+   * grouped separately in `codemie install` listings.
+   */
+  group?: 'framework' | 'documentation';
 }
 
 /**

--- a/src/frameworks/plugins/codebase-memory.plugin.ts
+++ b/src/frameworks/plugins/codebase-memory.plugin.ts
@@ -27,6 +27,7 @@ export const CodebaseMemoryMetadata: FrameworkMetadata = {
   isAgentSpecific: false,
   supportedAgents: [],
   initDirectory: '.codebase-memory',
+  group: 'documentation',
 };
 
 export class CodebaseMemoryPlugin extends BaseFrameworkAdapter {

--- a/src/frameworks/plugins/codegraph.plugin.ts
+++ b/src/frameworks/plugins/codegraph.plugin.ts
@@ -1,0 +1,84 @@
+/**
+ * CodeGraph Documentation Tool Plugin
+ *
+ * Integration for @colbymchenry/codegraph — local-first code intelligence
+ * (knowledge graph + MCP server) for AI agents. Deterministic local tooling;
+ * no model access required, so it is a documentation tool, not an agent.
+ */
+
+import { exec, installGlobal } from '../../utils/processes.js';
+import { logger } from '../../utils/logger.js';
+import { BaseFrameworkAdapter } from '../core/BaseFrameworkAdapter.js';
+import type { FrameworkInitOptions, FrameworkMetadata } from '../core/types.js';
+
+const NPM_PACKAGE = '@colbymchenry/codegraph';
+
+export const CodegraphMetadata: FrameworkMetadata = {
+  name: 'codegraph',
+  displayName: 'CodeGraph',
+  description: 'Local-first code intelligence graph and MCP server for AI agents',
+  docsUrl: 'https://www.npmjs.com/package/@colbymchenry/codegraph',
+  requiresInstallation: true,
+  installMethod: 'npm',
+  packageName: NPM_PACKAGE,
+  cliCommand: 'codegraph',
+  isAgentSpecific: false,
+  supportedAgents: [],
+  initDirectory: '.codegraph',
+  group: 'documentation',
+};
+
+export class CodegraphPlugin extends BaseFrameworkAdapter {
+  constructor() {
+    super(CodegraphMetadata);
+  }
+
+  async install(): Promise<void> {
+    this.logInstallStart();
+
+    try {
+      await installGlobal(NPM_PACKAGE);
+      const version = await this.getVersion();
+      this.logInstallSuccess(version || undefined);
+    } catch (error) {
+      this.logInstallError(error);
+      throw error;
+    }
+  }
+
+  async uninstall(): Promise<void> {
+    this.logUninstallStart();
+
+    try {
+      await exec('npm', ['uninstall', '-g', NPM_PACKAGE], { timeout: 120000 });
+      this.logUninstallSuccess();
+    } catch (error) {
+      this.logUninstallError(error);
+      throw error;
+    }
+  }
+
+  async init(_agentName: string, options?: FrameworkInitOptions): Promise<void> {
+    const cwd = options?.cwd || process.cwd();
+
+    this.logInitStart();
+
+    if (!(await this.isInstalled())) {
+      logger.warn('CodeGraph not found. Installing...');
+      await this.install();
+    }
+
+    try {
+      // Builds the initial index and creates .codegraph/ in the project
+      await exec('codegraph', ['init', cwd], { cwd, timeout: 600000 });
+
+      this.logInitSuccess(cwd);
+      logger.info('Next steps:');
+      logger.info('  - Wire the MCP server into your agents: codegraph install');
+      logger.info('  - Refresh the index after changes: codegraph sync');
+    } catch (error) {
+      this.logInitError(error);
+      throw error;
+    }
+  }
+}

--- a/src/frameworks/plugins/graphify.plugin.ts
+++ b/src/frameworks/plugins/graphify.plugin.ts
@@ -1,0 +1,100 @@
+/**
+ * Graphify Documentation Tool Plugin
+ *
+ * Integration for Graphify (https://github.com/safishamsi/graphify) — builds a
+ * queryable knowledge graph from a codebase (tree-sitter AST + Claude for docs
+ * and images) and ships it as a Claude Code skill (`/graphify`).
+ *
+ * Note: the PyPI package is temporarily named `graphifyy` while the `graphify`
+ * name is being reclaimed; the CLI command is `graphify`.
+ */
+
+import { commandExists, exec } from '../../utils/processes.js';
+import { logger } from '../../utils/logger.js';
+import { BaseFrameworkAdapter } from '../core/BaseFrameworkAdapter.js';
+import type { FrameworkInitOptions, FrameworkMetadata } from '../core/types.js';
+
+const PIP_PACKAGE = 'graphifyy';
+
+export const GraphifyMetadata: FrameworkMetadata = {
+  name: 'graphify',
+  displayName: 'Graphify',
+  description: 'Queryable knowledge graph for your codebase, docs and images (Claude Code skill)',
+  docsUrl: 'https://github.com/safishamsi/graphify',
+  repoUrl: 'https://github.com/safishamsi/graphify',
+  requiresInstallation: true,
+  installMethod: 'pip',
+  packageName: PIP_PACKAGE,
+  cliCommand: 'graphify',
+  isAgentSpecific: true,
+  supportedAgents: ['claude'],
+  initDirectory: 'graphify-out',
+  group: 'documentation',
+};
+
+export class GraphifyPlugin extends BaseFrameworkAdapter {
+  constructor() {
+    super(GraphifyMetadata);
+  }
+
+  async install(): Promise<void> {
+    this.logInstallStart();
+
+    try {
+      // pipx keeps the CLI isolated and handles PATH on macOS/Windows;
+      // fall back to a user-level pip install when pipx is unavailable.
+      if (await commandExists('pipx')) {
+        await exec('pipx', ['install', PIP_PACKAGE], { timeout: 300000 });
+      } else if (await commandExists('pip3')) {
+        await exec('pip3', ['install', '--user', PIP_PACKAGE], { timeout: 300000 });
+      } else {
+        throw new Error('Neither pipx nor pip3 found. Install Python 3.10+ first.');
+      }
+
+      const version = await this.getVersion();
+      this.logInstallSuccess(version || undefined);
+    } catch (error) {
+      this.logInstallError(error);
+      throw error;
+    }
+  }
+
+  async uninstall(): Promise<void> {
+    this.logUninstallStart();
+
+    try {
+      if (await commandExists('pipx')) {
+        await exec('pipx', ['uninstall', PIP_PACKAGE], { timeout: 120000 });
+      } else {
+        await exec('pip3', ['uninstall', '-y', PIP_PACKAGE], { timeout: 120000 });
+      }
+      this.logUninstallSuccess();
+    } catch (error) {
+      this.logUninstallError(error);
+      throw error;
+    }
+  }
+
+  async init(agentName: string, options?: FrameworkInitOptions): Promise<void> {
+    const cwd = options?.cwd || process.cwd();
+
+    this.assertAgentSupported(agentName);
+    this.logInitStart(agentName);
+
+    if (!(await this.isInstalled())) {
+      logger.warn('Graphify not found. Installing...');
+      await this.install();
+    }
+
+    try {
+      // Installs the /graphify skill into Claude Code (global, idempotent)
+      await exec('graphify', ['install'], { cwd, timeout: 60000 });
+
+      this.logInitSuccess(cwd);
+      logger.info('Next step: open Claude Code in this directory and run: /graphify .');
+    } catch (error) {
+      this.logInitError(error);
+      throw error;
+    }
+  }
+}

--- a/src/frameworks/plugins/index.ts
+++ b/src/frameworks/plugins/index.ts
@@ -8,13 +8,19 @@ import { FrameworkRegistry } from '../core/registry.js';
 import { SpeckitPlugin } from './speckit.plugin.js';
 import { BmadPlugin } from './bmad.plugin.js';
 import { CodebaseMemoryPlugin } from './codebase-memory.plugin.js';
+import { CodegraphPlugin } from './codegraph.plugin.js';
+import { GraphifyPlugin } from './graphify.plugin.js';
 
 // Export plugins
 export { SpeckitPlugin } from './speckit.plugin.js';
 export { BmadPlugin } from './bmad.plugin.js';
 export { CodebaseMemoryPlugin } from './codebase-memory.plugin.js';
+export { CodegraphPlugin } from './codegraph.plugin.js';
+export { GraphifyPlugin } from './graphify.plugin.js';
 
 // Auto-register plugins
 FrameworkRegistry.registerFramework(new SpeckitPlugin());
 FrameworkRegistry.registerFramework(new BmadPlugin());
 FrameworkRegistry.registerFramework(new CodebaseMemoryPlugin());
+FrameworkRegistry.registerFramework(new CodegraphPlugin());
+FrameworkRegistry.registerFramework(new GraphifyPlugin());


### PR DESCRIPTION
## Summary

Adds a documentation & knowledge tooling layer: a `codemie docs` command group managing three knowledge tools (codebase-memory, codegraph, graphify) via a new frameworks plugin system, plus a new `openwiki` agent that generates and maintains a linked Markdown wiki for the repository, running on the active CodeMie profile (SSO/LiteLLM/Ollama).

## Changes

- **cli/frameworks**: `codemie docs list|install|uninstall|init` command group; frameworks plugin layer with codebase-memory (persistent code intelligence graph + 3D UI), codegraph (local-first symbol index + MCP server), and graphify (multimodal knowledge graph as a Claude Code skill) plugins
- **agents**: new `openwiki` agent (`codemie-openwiki` bin) generating a source-cited wiki with validated Mermaid diagrams; registry and AgentCLI wiring
- **docs**: README and docs/COMMANDS.md sections for the new tooling, agent guidance updates, `.openwikiignore`, initial generated `openwiki/` content

## Testing

- [ ] Tests added/updated
- [x] Manual testing done

## Checklist

- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`