### PR TITLE
fix(proxy): honor active profile model for codex desktop

### DIFF
--- a/src/bin/proxy-daemon.ts
+++ b/src/bin/proxy-daemon.ts
@@ -32,6 +32,7 @@ const { values } = parseArgs({
     'target-url':   { type: 'string' },
     'provider':     { type: 'string' },
     'profile':      { type: 'string' },
+    'model':        { type: 'string' },
     'project':      { type: 'string' },
     'client-type':  { type: 'string' },
     'port':         { type: 'string' },
@@ -63,6 +64,7 @@ const port = parsedPort;
 const gatewayKey = (values['gateway-key'] as string | undefined) ?? 'codemie-proxy';
 const profile    = (values['profile'] as string | undefined) ?? 'default';
 const provider   = (values['provider'] as string | undefined) ?? 'ai-run-sso';
+const model = values['model'] as string | undefined;
 const project = values['project'] as string | undefined;
 const clientType = values['client-type'] as string | undefined;
 const authMethod = ((values['auth-method'] as string | undefined) ?? 'sso') as 'sso' | 'jwt';
@@ -79,6 +81,7 @@ const config: ProxyConfig = {
   host: '127.0.0.1',
   provider,
   profile,
+  model,
   project,
   gatewayKey,
   authMethod,

--- a/src/cli/commands/proxy/__tests__/connect-orchestrator.test.ts
+++ b/src/cli/commands/proxy/__tests__/connect-orchestrator.test.ts
@@ -3,7 +3,12 @@
  * @group unit
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { deriveDaemonIdentity, type ConnectTargets } from '../connect-orchestrator.js';
+import {
+  daemonMatchesRequest,
+  deriveDaemonIdentity,
+  type ConnectTargets,
+  type RequestedDaemonConfig,
+} from '../connect-orchestrator.js';
 
 vi.mock('../../../../utils/config.js', () => ({
   ConfigLoader: {
@@ -92,13 +97,14 @@ function daemonState(extra: Record<string, unknown> = {}): Record<string, unknow
 }
 
 // A running daemon whose fields match the happy-path config for a claude-desktop request.
-function matchingDesktopState(): Record<string, unknown> {
+function matchingDesktopState(extra: Record<string, unknown> = {}): Record<string, unknown> {
   return daemonState({
     provider: 'ai-run-sso',
     targetUrl: 'https://x.example.com/api',
     project: 'proj',
     telemetryMode: 'claude-desktop',
     syncCodeMieUrl: 'https://x.example.com',
+    ...extra,
   });
 }
 
@@ -157,6 +163,54 @@ describe('deriveDaemonIdentity', () => {
         expect(spawnOptions).not.toHaveProperty('telemetryMode');
       }
     }
+  });
+});
+
+describe('daemonMatchesRequest — model comparison', () => {
+  function baseRequest(extra: Partial<RequestedDaemonConfig> = {}): RequestedDaemonConfig {
+    return {
+      profile: 'p',
+      port: 4001,
+      project: 'proj',
+      clientType: 'codex-desktop',
+      provider: 'ai-run-sso',
+      targetUrl: 'https://x.example.com/api',
+      ...extra,
+    };
+  }
+
+  function codexState(extra: Record<string, unknown> = {}): Parameters<typeof daemonMatchesRequest>[0] {
+    return daemonState({
+      provider: 'ai-run-sso',
+      targetUrl: 'https://x.example.com/api',
+      project: 'proj',
+      clientType: 'codex-desktop',
+      ...extra,
+    }) as Parameters<typeof daemonMatchesRequest>[0];
+  }
+
+  it('matches when the requested model equals the recorded model', () => {
+    expect(
+      daemonMatchesRequest(codexState({ model: 'gpt-5-codex' }), baseRequest({ model: 'gpt-5-codex' }))
+    ).toBe(true);
+  });
+
+  it('fails to match when the profile model changed against the running daemon', () => {
+    expect(
+      daemonMatchesRequest(codexState({ model: 'gpt-5-codex' }), baseRequest({ model: 'gpt-5' }))
+    ).toBe(false);
+  });
+
+  it('compares the trimmed form on both sides', () => {
+    expect(
+      daemonMatchesRequest(codexState({ model: 'gpt-5-codex' }), baseRequest({ model: '  gpt-5-codex  ' }))
+    ).toBe(true);
+  });
+
+  it('reuses the daemon when no model is requested (backward compatible)', () => {
+    expect(
+      daemonMatchesRequest(codexState({ model: 'gpt-5-codex' }), baseRequest({ model: undefined }))
+    ).toBe(true);
   });
 });
 
@@ -228,6 +282,27 @@ describe('connectTargets — no-write paths and daemon lifecycle', () => {
     });
     vi.mocked(spawnDaemon).mockResolvedValue(
       daemonState({ telemetryMode: 'claude-desktop', syncCodeMieUrl: 'https://x.example.com' }) as Awaited<ReturnType<typeof spawnDaemon>>
+    );
+    const { connectTargets } = await import('../connect-orchestrator.js');
+
+    await connectTargets({ targets: { claudeDesktop: true } });
+
+    expect(stopDaemon).toHaveBeenCalled();
+    expect(spawnDaemon).toHaveBeenCalled();
+  });
+
+  it('restarts when the profile model changed against an otherwise-matching daemon', async () => {
+    await setupHappyMocks({ model: 'gpt-5' });
+    const { checkStatus, spawnDaemon, stopDaemon } = await import('../daemon-manager.js');
+    const { checkProxyHealth } = await import('../health-check.js');
+    // A healthy daemon that matches on every field EXCEPT the (now-changed) model.
+    vi.mocked(checkStatus).mockResolvedValue({
+      running: true,
+      state: matchingDesktopState({ model: 'gpt-4' }) as Awaited<ReturnType<typeof checkStatus>>['state'],
+    });
+    vi.mocked(checkProxyHealth).mockResolvedValue({ healthy: true, level: 'deep', code: 'ok' });
+    vi.mocked(spawnDaemon).mockResolvedValue(
+      daemonState({ telemetryMode: 'claude-desktop', syncCodeMieUrl: 'https://x.example.com', model: 'gpt-5' }) as Awaited<ReturnType<typeof spawnDaemon>>
     );
     const { connectTargets } = await import('../connect-orchestrator.js');
 

--- a/src/cli/commands/proxy/__tests__/daemon-manager.test.ts
+++ b/src/cli/commands/proxy/__tests__/daemon-manager.test.ts
@@ -168,6 +168,21 @@ describe('spawnDaemon', () => {
     expect(args).not.toContain('--model');
   });
 
+  it('forwards the profile model as a --model argument when set', async () => {
+    arrangeReadyDaemon();
+
+    await spawnDaemon({
+      targetUrl: 'https://upstream.example.com',
+      provider: 'ai-run-sso',
+      profile: 'work',
+      port: 4001,
+      model: 'gpt-5.6-luna-2026-07-09',
+    });
+
+    const args = vi.mocked(spawnDetached).mock.calls[0][1];
+    expect(args).toEqual(expect.arrayContaining(['--model', 'gpt-5.6-luna-2026-07-09']));
+  });
+
   it('omits optional client context when it is not configured', async () => {
     arrangeReadyDaemon();
 

--- a/src/cli/commands/proxy/__tests__/index.test.ts
+++ b/src/cli/commands/proxy/__tests__/index.test.ts
@@ -454,11 +454,52 @@ describe('proxy connect vscode', () => {
     );
   });
 
-  it('reuses a matching daemon independently of the profile model', async () => {
+  it('reuses a matching daemon when the profile model is unchanged', async () => {
     const { ConfigLoader } = await import('../../../../utils/config.js');
     const { checkStatus, spawnDaemon, stopDaemon } = await import('../daemon-manager.js');
     const { checkProxyHealth } = await import('../health-check.js');
     const { writeVsCodeLanguageModelsConfig } = await import('../connectors/vscode.js');
+    const { createProxyCommand } = await import('../index.js');
+    vi.mocked(ConfigLoader.load).mockResolvedValue({
+      name: 'custom',
+      provider: 'ai-run-sso',
+      baseUrl: 'https://custom.example.com/api',
+      model: 'shared-profile-model',
+      codeMieProject: 'team-project',
+      codeMieUrl: 'https://custom.example.com',
+    } as Awaited<ReturnType<typeof ConfigLoader.load>>);
+    vi.mocked(checkStatus).mockResolvedValue({
+      running: true,
+      state: {
+        pid: process.pid,
+        port: 4001,
+        url: 'http://127.0.0.1:4001',
+        profile: 'custom',
+        gatewayKey: 'local-key',
+        provider: 'ai-run-sso',
+        targetUrl: 'https://custom.example.com/api',
+        project: 'team-project',
+        model: 'shared-profile-model',
+        clientType: 'vscode-byok',
+        startedAt: new Date().toISOString(),
+      },
+    });
+    vi.mocked(checkProxyHealth).mockResolvedValue({ healthy: true, level: 'deep', code: 'ok' });
+
+    await createProxyCommand().parseAsync(['connect', 'vscode', '--profile', 'custom'], { from: 'user' });
+
+    expect(stopDaemon).not.toHaveBeenCalled();
+    expect(spawnDaemon).not.toHaveBeenCalled();
+    expect(writeVsCodeLanguageModelsConfig).toHaveBeenCalledWith(
+      'http://127.0.0.1:4001',
+      false
+    );
+  });
+
+  it('restarts a matching daemon when the profile model changed', async () => {
+    const { ConfigLoader } = await import('../../../../utils/config.js');
+    const { checkStatus, spawnDaemon, stopDaemon } = await import('../daemon-manager.js');
+    const { checkProxyHealth } = await import('../health-check.js');
     const { createProxyCommand } = await import('../index.js');
     vi.mocked(ConfigLoader.load).mockResolvedValue({
       name: 'custom',
@@ -479,20 +520,27 @@ describe('proxy connect vscode', () => {
         provider: 'ai-run-sso',
         targetUrl: 'https://custom.example.com/api',
         project: 'team-project',
+        model: 'old-profile-model',
         clientType: 'vscode-byok',
         startedAt: new Date().toISOString(),
       },
     });
     vi.mocked(checkProxyHealth).mockResolvedValue({ healthy: true, level: 'deep', code: 'ok' });
+    vi.mocked(spawnDaemon).mockResolvedValue({
+      pid: process.pid,
+      port: 4001,
+      url: 'http://127.0.0.1:4001',
+      profile: 'custom',
+      gatewayKey: 'local-key',
+      clientType: 'vscode-byok',
+      model: 'new-profile-model',
+      startedAt: new Date().toISOString(),
+    } as Awaited<ReturnType<typeof spawnDaemon>>);
 
     await createProxyCommand().parseAsync(['connect', 'vscode', '--profile', 'custom'], { from: 'user' });
 
-    expect(stopDaemon).not.toHaveBeenCalled();
-    expect(spawnDaemon).not.toHaveBeenCalled();
-    expect(writeVsCodeLanguageModelsConfig).toHaveBeenCalledWith(
-      'http://127.0.0.1:4001',
-      false
-    );
+    expect(stopDaemon).toHaveBeenCalled();
+    expect(spawnDaemon).toHaveBeenCalled();
   });
 
 });

--- a/src/cli/commands/proxy/connect-orchestrator.ts
+++ b/src/cli/commands/proxy/connect-orchestrator.ts
@@ -517,6 +517,7 @@ async function runVscodeClaudeCode(state: DaemonState, insiders: boolean): Promi
 interface CodexDesktopRunOptions {
   force?: boolean;
   model?: string;
+  profileModel?: string;
   verbose?: boolean;
 }
 
@@ -544,7 +545,7 @@ async function runCodexDesktop(
     console.log(chalk.cyan(`Codex config: ${configPath}`));
 
     const discovered = await discoverCodexModels(state.url, state.gatewayKey);
-    const model = selectCodexModel(discovered, options.model);
+    const model = selectCodexModel(discovered, options.model, options.profileModel);
 
     await writeCodexDesktopConfig({
       configPath,
@@ -669,6 +670,7 @@ export async function connectTargets(opts: ConnectOptions): Promise<void> {
     results.push(await runCodexDesktop(state, {
       force: Boolean(opts.force),
       model: opts.model,
+      profileModel: config.model,
       verbose,
     }));
   }

--- a/src/cli/commands/proxy/connect-orchestrator.ts
+++ b/src/cli/commands/proxy/connect-orchestrator.ts
@@ -114,6 +114,18 @@ export interface RequestedDaemonConfig {
   clientType: string;
   provider?: string;
   targetUrl?: string;
+  /** Normalized profile model that drives the daemon lifecycle (see `normalizeDaemonModel`). */
+  model?: string;
+}
+
+/**
+ * Canonical form of a profile model for daemon lifecycle comparison. Trims
+ * surrounding whitespace and treats an empty/blank value as "unset" so the
+ * recorded `state.model` and the requested `config.model` compare apples-to-apples.
+ */
+export function normalizeDaemonModel(model: string | undefined): string | undefined {
+  const trimmed = model?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 export function getEffectiveClientType(
@@ -138,6 +150,8 @@ export function daemonMatchesRequest(
     state.project === requested.project &&
     (!requested.provider || state.provider === requested.provider) &&
     (!requested.targetUrl || state.targetUrl === requested.targetUrl) &&
+    (!normalizeDaemonModel(requested.model) ||
+      normalizeDaemonModel(state.model) === normalizeDaemonModel(requested.model)) &&
     getEffectiveClientType(state) === requested.clientType;
 }
 
@@ -342,7 +356,7 @@ async function ensureDaemon(
       targetUrl: config.baseUrl as string,
       provider: config.provider ?? 'ai-run-sso',
       profile: config.name ?? 'default',
-      ...(config.model ? { model: config.model } : {}),
+      ...(normalizeDaemonModel(config.model) ? { model: normalizeDaemonModel(config.model) } : {}),
       port: DEFAULT_DAEMON_PORT,
       project: config.codeMieProject,
       ...identity.spawnOptions,
@@ -646,6 +660,7 @@ export async function connectTargets(opts: ConnectOptions): Promise<void> {
       clientType: identity.clientType,
       provider: config.provider ?? 'ai-run-sso',
       targetUrl: config.baseUrl,
+      model: normalizeDaemonModel(config.model),
     };
 
     const ensured = await ensureDaemon(requested, identity, config, Boolean(opts.force), verbose);

--- a/src/cli/commands/proxy/connect-orchestrator.ts
+++ b/src/cli/commands/proxy/connect-orchestrator.ts
@@ -342,6 +342,7 @@ async function ensureDaemon(
       targetUrl: config.baseUrl as string,
       provider: config.provider ?? 'ai-run-sso',
       profile: config.name ?? 'default',
+      ...(config.model ? { model: config.model } : {}),
       port: DEFAULT_DAEMON_PORT,
       project: config.codeMieProject,
       ...identity.spawnOptions,

--- a/src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts
@@ -436,6 +436,38 @@ describe('selectCodexModel accepts the names the app picker shows', () => {
   });
 });
 
+describe('selectCodexModel honours the active profile model', () => {
+  afterEach(() => { vi.resetModules(); });
+
+  it('pins the resolved profile model when no --model flag is given', async () => {
+    const { selectCodexModel } = await import('../codex-desktop.js');
+    const list = ['gpt-5-2025-08-07', 'gpt-5.6-luna-2026-07-09'];
+
+    // The profile's config.model is the undated picker name; it must resolve to
+    // its dated deployment rather than dropping to the recency default.
+    expect(selectCodexModel(list, undefined, 'gpt-5.6-luna')).toBe('gpt-5.6-luna-2026-07-09');
+  });
+
+  it('falls back to the recency default when the profile model is unresolvable', async () => {
+    const { selectCodexModel } = await import('../codex-desktop.js');
+    const list = ['gpt-5.6-luna-2026-07-09', 'gpt-5-2025-08-07'];
+
+    expect(selectCodexModel(list, undefined, 'gpt-4o')).toBe('gpt-5.6-luna-2026-07-09');
+    expect(selectCodexModel(list, undefined, undefined)).toBe('gpt-5.6-luna-2026-07-09');
+    expect(selectCodexModel(list, undefined, '   ')).toBe('gpt-5.6-luna-2026-07-09');
+  });
+
+  it('lets an explicit --model flag win over the profile model', async () => {
+    const { selectCodexModel } = await import('../codex-desktop.js');
+    const { ConfigurationError } = await import('@/utils/errors.js');
+    const list = ['gpt-5-2025-08-07', 'gpt-5.6-luna-2026-07-09'];
+
+    // Explicit request still resolves-or-throws, unaffected by the profile model.
+    expect(selectCodexModel(list, 'gpt-5', 'gpt-5.6-luna')).toBe('gpt-5-2025-08-07');
+    expect(() => selectCodexModel(list, 'gpt-4o', 'gpt-5.6-luna')).toThrow(ConfigurationError);
+  });
+});
+
 describe('disconnect verifies CodeMie keys actually went away', () => {
   let workspace: TempWorkspace;
 

--- a/src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts
+++ b/src/cli/commands/proxy/connectors/__tests__/codex-desktop.test.ts
@@ -457,6 +457,20 @@ describe('selectCodexModel honours the active profile model', () => {
     expect(selectCodexModel(list, undefined, '   ')).toBe('gpt-5.6-luna-2026-07-09');
   });
 
+  it('ignores an Anthropic profile model and pins the codex default without throwing', async () => {
+    const { selectCodexModel } = await import('../codex-desktop.js');
+    const list = ['gpt-5.6-luna-2026-07-09', 'gpt-5-2025-08-07'];
+
+    // The active profile is frequently an Anthropic/Sonnet profile (e.g.
+    // config.model = 'claude-sonnet-5'). A Claude name is never a Codex
+    // deployment, so it must resolve to the recency-ranked Codex default — and,
+    // unlike an explicit unresolvable --model, must NOT throw: the user did not
+    // ask for a Codex model, it is merely their default profile.
+    expect(() => selectCodexModel(list, undefined, 'claude-sonnet-5')).not.toThrow();
+    expect(selectCodexModel(list, undefined, 'claude-sonnet-5')).toBe('gpt-5.6-luna-2026-07-09');
+    expect(selectCodexModel(list, undefined, 'claude-opus-4-8')).toBe('gpt-5.6-luna-2026-07-09');
+  });
+
   it('lets an explicit --model flag win over the profile model', async () => {
     const { selectCodexModel } = await import('../codex-desktop.js');
     const { ConfigurationError } = await import('@/utils/errors.js');

--- a/src/cli/commands/proxy/connectors/codex-desktop.ts
+++ b/src/cli/commands/proxy/connectors/codex-desktop.ts
@@ -179,18 +179,34 @@ export async function discoverCodexModels(
  * time the user is present and can be told, so silently substituting would mean
  * they run something other than what they asked for.
  */
-export function selectCodexModel(discovered: string[], requested?: string): string {
-  if (requested === undefined) return discovered[0];
-  if (requested.trim() === '') {
-    throw new ConfigurationError('--model was given an empty value.');
+export function selectCodexModel(
+  discovered: string[],
+  requested?: string,
+  profileModel?: string
+): string {
+  if (requested !== undefined) {
+    if (requested.trim() === '') {
+      throw new ConfigurationError('--model was given an empty value.');
+    }
+
+    const resolution = resolveCodexDeployment(requested.trim(), discovered, undefined);
+    if (resolution.kind === 'exact' || resolution.kind === 'resolved') return resolution.model;
+
+    throw new ConfigurationError(
+      `Model "${requested}" is not available through the proxy. Available: ${discovered.join(', ')}`
+    );
   }
 
-  const resolution = resolveCodexDeployment(requested.trim(), discovered, undefined);
-  if (resolution.kind === 'exact' || resolution.kind === 'resolved') return resolution.model;
+  // No explicit --model: prefer the active profile's configured model, resolved
+  // to its dated deployment the same way an in-flight request is. Only when it
+  // has no CodeMie equivalent do we drop to the recency-ranked default.
+  const profile = profileModel?.trim();
+  if (profile) {
+    const resolution = resolveCodexDeployment(profile, discovered, undefined);
+    if (resolution.kind === 'exact' || resolution.kind === 'resolved') return resolution.model;
+  }
 
-  throw new ConfigurationError(
-    `Model "${requested}" is not available through the proxy. Available: ${discovered.join(', ')}`
-  );
+  return discovered[0];
 }
 
 export interface CodexDesktopState {

--- a/src/cli/commands/proxy/daemon-manager.ts
+++ b/src/cli/commands/proxy/daemon-manager.ts
@@ -86,6 +86,7 @@ export interface SpawnOptions {
   profile: string;
   port?: number;
   gatewayKey?: string;
+  model?: string;
   project?: string;
   clientType?: string;
   telemetryMode?: 'none' | 'claude-desktop';
@@ -107,6 +108,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<DaemonState> {
     '--provider', opts.provider,
     '--profile', opts.profile,
     '--gateway-key', gatewayKey,
+    ...(opts.model ? ['--model', opts.model] : []),
     ...(opts.project ? ['--project', opts.project] : []),
     ...(opts.clientType ? ['--client-type', opts.clientType] : []),
     '--state-file', stateFile,
@@ -125,6 +127,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<DaemonState> {
       profile: opts.profile,
       port: opts.port,
       gatewayKey,
+      model: opts.model,
       project: opts.project,
       clientType: opts.clientType,
       telemetryMode: opts.telemetryMode,

--- a/src/cli/commands/proxy/daemon-manager.ts
+++ b/src/cli/commands/proxy/daemon-manager.ts
@@ -16,6 +16,7 @@ export interface DaemonState {
   targetUrl?: string;
   provider?: string;
   project?: string;
+  model?: string;
   clientType?: string;
   syncApiUrl?: string;
   syncCodeMieUrl?: string;

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/codex-request-normalizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/codex-request-normalizer.plugin.test.ts
@@ -181,6 +181,25 @@ describe('CodexRequestNormalizerPlugin fallback without a pinned model', () => {
     expect(bodyOf(context).model).toBe('gpt-5.6-sol-2026-07-09');
   });
 
+  it('ignores an Anthropic pinned profile model and falls back to the codex default', async () => {
+    // The active profile is frequently an Anthropic/Sonnet profile
+    // (config.model = 'claude-sonnet-5'). A Claude name is never a Codex
+    // deployment, so the fallback must drop to the recency default rather than
+    // substitute a Claude slug into a Codex Responses request.
+    const { CodexRequestNormalizerPlugin } = await import('../codex-request-normalizer.plugin.js');
+    const plugin = new CodexRequestNormalizerPlugin();
+    const interceptor = await plugin.createInterceptor(
+      makePluginContext({ config: { clientType: 'codex-desktop', model: 'claude-sonnet-5' } })
+    );
+    (interceptor as unknown as { setAvailableModelsForTest(m: string[]): void })
+      .setAvailableModelsForTest(AVAILABLE);
+
+    const context = makeProxyContext({ model: 'gpt-4o-does-not-exist', input: 'hi' });
+    await interceptor.onRequest!(context);
+
+    expect(bodyOf(context).model).toBe('gpt-5.6-luna-2026-07-09');
+  });
+
   it('prefers an explicitly pinned model over the newest when one is configured', async () => {
     const { CodexRequestNormalizerPlugin } = await import('../codex-request-normalizer.plugin.js');
     const plugin = new CodexRequestNormalizerPlugin();

--- a/src/providers/plugins/sso/proxy/plugins/__tests__/codex-request-normalizer.plugin.test.ts
+++ b/src/providers/plugins/sso/proxy/plugins/__tests__/codex-request-normalizer.plugin.test.ts
@@ -163,6 +163,24 @@ describe('CodexRequestNormalizerPlugin fallback without a pinned model', () => {
     expect(bodyOf(context).model).toBe('gpt-5.6-luna-2026-07-09');
   });
 
+  it('resolves an undated pinned profile model to its dated deployment', async () => {
+    // config.model carries the profile's undated picker name (e.g. from
+    // `codemie proxy connect --codex-desktop`); the fallback must resolve it to
+    // the dated deployment rather than dropping to the recency default.
+    const { CodexRequestNormalizerPlugin } = await import('../codex-request-normalizer.plugin.js');
+    const plugin = new CodexRequestNormalizerPlugin();
+    const interceptor = await plugin.createInterceptor(
+      makePluginContext({ config: { clientType: 'codex-desktop', model: 'gpt-5.6-sol' } })
+    );
+    (interceptor as unknown as { setAvailableModelsForTest(m: string[]): void })
+      .setAvailableModelsForTest(AVAILABLE);
+
+    const context = makeProxyContext({ model: 'gpt-4o-does-not-exist', input: 'hi' });
+    await interceptor.onRequest!(context);
+
+    expect(bodyOf(context).model).toBe('gpt-5.6-sol-2026-07-09');
+  });
+
   it('prefers an explicitly pinned model over the newest when one is configured', async () => {
     const { CodexRequestNormalizerPlugin } = await import('../codex-request-normalizer.plugin.js');
     const plugin = new CodexRequestNormalizerPlugin();

--- a/src/providers/plugins/sso/proxy/plugins/codex-request-normalizer.plugin.ts
+++ b/src/providers/plugins/sso/proxy/plugins/codex-request-normalizer.plugin.ts
@@ -216,7 +216,12 @@ class CodexRequestNormalizerInterceptor implements ProxyInterceptor {
    */
   private resolveFallbackModel(): string | undefined {
     const pinned = this.context.config.model;
-    if (pinned && this.availableModels.includes(pinned)) return pinned;
+    if (pinned) {
+      // The pinned value may be the profile's undated picker name; resolve it to
+      // its dated deployment the same way an in-flight request is resolved.
+      const resolution = resolveCodexDeployment(pinned, this.availableModels, undefined);
+      if (resolution.kind === 'exact' || resolution.kind === 'resolved') return resolution.model;
+    }
     return rankDeploymentsByRecency(this.availableModels)[0];
   }
 


### PR DESCRIPTION
## Summary

Codex desktop (via `codemie proxy connect --codex-desktop`) ignored the active profile's configured model and always pinned the newest recency-ranked deployment. It now honors the profile's `config.model`, with precedence: explicit `--model` flag → profile model → recency fallback. Applied at both connect-time (what gets written to `~/.codex/config.toml`) and runtime (the proxy request normalizer's fallback).

## Changes

- **Connect-time** (`codex-desktop.ts`, `connect-orchestrator.ts`): thread the already-loaded profile `config.model` into `selectCodexModel` as the resolved preference when no `--model` is given.
- **Daemon** (`daemon-manager.ts`, `proxy-daemon.ts`): forward the profile model to the daemon so the runtime normalizer sees `context.config.model`.
- **Runtime** (`codex-request-normalizer.plugin.ts`): resolve the pinned profile model to its dated deployment in the fallback path instead of always taking recency `[0]`.
- **Daemon lifecycle** (`connect-orchestrator.ts`): compare the normalized model in `daemonMatchesRequest`, so a profile model change against a live daemon forces a restart rather than silently reusing the stale one.
- **Anthropic safety**: a non-Codex profile model (e.g. the default `epm-cdme` profile's `claude-sonnet-5`) resolves to the Codex recency default and never throws — a Claude slug is never pinned into a Codex request. Guarded by dedicated tests.

Precedence, recency ranking, resolver semantics, and the proxy→agent decoupling boundary are unchanged. The pure `resolveCodexDeployment` resolver was reused, not modified.

## Testing

- [x] Unit tests added/updated (connect-time selection, daemon `--model` forwarding, runtime fallback, daemon match/restart, Anthropic profile guards) — full proxy + normalizer suite green (339 tests) on top of `main`.
- [ ] Manual `proxy connect --codex-desktop` end-to-end verification (config.toml `model` value) — pending reviewer/author.

## Checklist

- [ ] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [ ] No merge conflicts with `main`
- [x] No attribution-header / Responses `user` / JWT claim changes (not a CRITICAL change)

Developed with the SDLC Factory sdlc-light flow; planning artifacts on the source branch.
