### PR TITLE
feat(agents): forward CODEMIE_DEBUG and stream idle timeout to openwiki runs

### DIFF
--- a/src/agents/plugins/openwiki/openwiki.plugin.ts
+++ b/src/agents/plugins/openwiki/openwiki.plugin.ts
@@ -13,6 +13,16 @@ import { BaseAgentAdapter } from '../../core/BaseAgentAdapter.js';
  * starts the local proxy (auth + attribution headers injected there) and
  * CODEMIE_BASE_URL/CODEMIE_API_KEY become the proxy URL / 'proxy-handled';
  * for api-key providers the real values are forwarded instead.
+ *
+ * Usage notes:
+ * - Unmapped flags pass through to the OpenWiki CLI unchanged, so the
+ *   non-interactive print mode works as-is: `codemie-openwiki --update -p`
+ *   (or `--task <message>`, mapped to `-p`) streams output to stdout and
+ *   exits, instead of the interactive TUI.
+ * - The interactive TUI shows only a spinner during long planning/generation
+ *   phases. Setting CODEMIE_DEBUG=true/1 is forwarded as OPENWIKI_DEBUG=1,
+ *   which makes the run view render an activity feed (stream open, model
+ *   build, tool calls).
  */
 export const OpenWikiPluginMetadata: AgentMetadata = {
   name: 'openwiki',
@@ -35,6 +45,18 @@ export const OpenWikiPluginMetadata: AgentMetadata = {
   lifecycle: {
     async beforeRun(env: NodeJS.ProcessEnv, config: AgentConfig): Promise<NodeJS.ProcessEnv> {
       env.OPENWIKI_PROVIDER = 'openai-compatible';
+
+      // Follow CodeMie's own debug flag: OpenWiki's run view renders a live
+      // activity feed instead of a bare spinner when OPENWIKI_DEBUG=1.
+      if (env.OPENWIKI_DEBUG === undefined && (env.CODEMIE_DEBUG === 'true' || env.CODEMIE_DEBUG === '1')) {
+        env.OPENWIKI_DEBUG = '1';
+      }
+
+      // Idle-stream watchdog for long generations through the local proxy.
+      // OpenWiki 0.4.x only enforces this for Bedrock; forward it anyway so
+      // the protection activates automatically once OpenWiki honors it for
+      // openai-compatible streams.
+      env.OPENWIKI_STREAM_IDLE_TIMEOUT ??= '300000';
 
       // OpenWiki (LangChain) appends /chat/completions to the base URL. The SSO
       // proxy and LiteLLM accept the bare base URL (same contract the opencode


### PR DESCRIPTION
## Summary
OpenWiki's interactive TUI shows only a spinner during long planning/generation phases, which reads as a hang (observed while running codemie-openwiki against this repo — 30+ minutes of invisible LLM calls through the SSO proxy). This wires two beforeRun defaults into the openwiki plugin to improve progress visibility and prepare stall protection.

## Changes
- CODEMIE_DEBUG=true/1 is forwarded as OPENWIKI_DEBUG=1, so OpenWiki's run view renders a live activity feed (stream open, model build, tool calls) instead of a bare spinner; an explicitly set OPENWIKI_DEBUG takes precedence
- OPENWIKI_STREAM_IDLE_TIMEOUT defaults to 300000ms (5 min). OpenWiki 0.4.x only enforces it for Bedrock; forwarding it activates the stream stall watchdog automatically once openai-compatible streams honor it (upstream langchain-ai/openwiki)
- Plugin header comment now documents the non-interactive print mode (--update -p / --task) that already works via flag passthrough

## Testing
- [ ] Tests added/updated (not added — repo policy: tests only on explicit request)
- [x] Manual verification done (typecheck, eslint via lint-staged, gitleaks, flag-passthrough checks)

## Checklist
- [x] Code follows project standards
- [ ] CI is green (pending — pre-commit hooks passed locally: lint, typecheck, secrets scan)
- [x] No merge conflicts with main