### PR TITLE
fix(agents): honour profile model for Claude and harden agent test harness

### DIFF
--- a/src/providers/core/__tests__/providers-core.test.ts
+++ b/src/providers/core/__tests__/providers-core.test.ts
@@ -376,10 +376,20 @@ describe('defaultAgentHooks', () => {
 
   describe('claude.enrichArgs', () => {
     const original = process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
+    const originalModel = process.env.CODEMIE_MODEL;
+
+    // CODEMIE_MODEL now drives --model injection, and CodeMie exports its whole
+    // CODEMIE_* block into the shell of any session it launches. Clearing it per
+    // test keeps these assertions independent of the developer's environment.
+    beforeEach(() => {
+      delete process.env.CODEMIE_MODEL;
+    });
 
     afterEach(() => {
       if (original === undefined) delete process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
       else process.env.CODEMIE_CLAUDE_EXTENSION_DIR = original;
+      if (originalModel === undefined) delete process.env.CODEMIE_MODEL;
+      else process.env.CODEMIE_MODEL = originalModel;
     });
 
     it('returns args unchanged when the extension dir env var is unset', () => {
@@ -400,6 +410,45 @@ describe('defaultAgentHooks', () => {
       const args = ['--plugin-dir', '/other', 'chat'];
       const result = claudeHooks.enrichArgs!(args, {} as AgentConfig);
       expect(result).toBe(args);
+    });
+
+    // Claude Code ignores ANTHROPIC_MODEL; --model is the only way the profile's
+    // model reaches the wire ahead of ~/.claude/settings.json and the default tier.
+    it('prepends --model from CODEMIE_MODEL', () => {
+      delete process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
+      process.env.CODEMIE_MODEL = 'claude-sonnet-5';
+      const result = claudeHooks.enrichArgs!(['-p', 'hi'], {} as AgentConfig);
+      expect(result).toEqual(['--model', 'claude-sonnet-5', '-p', 'hi']);
+    });
+
+    it('injects both --model and --plugin-dir together', () => {
+      process.env.CODEMIE_CLAUDE_EXTENSION_DIR = '/plugins/here';
+      process.env.CODEMIE_MODEL = 'claude-sonnet-5';
+      const result = claudeHooks.enrichArgs!(['-p', 'hi'], {} as AgentConfig);
+      expect(result).toEqual(['--model', 'claude-sonnet-5', '--plugin-dir', '/plugins/here', '-p', 'hi']);
+    });
+
+    it('does not override an explicit --model already in args', () => {
+      delete process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
+      process.env.CODEMIE_MODEL = 'claude-sonnet-5';
+      const args = ['--model', 'claude-opus-5', '-p', 'hi'];
+      expect(claudeHooks.enrichArgs!(args, {} as AgentConfig)).toBe(args);
+    });
+
+    it('does not override an explicit --model= form already in args', () => {
+      delete process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
+      process.env.CODEMIE_MODEL = 'claude-sonnet-5';
+      const args = ['--model=claude-opus-5', '-p', 'hi'];
+      expect(claudeHooks.enrichArgs!(args, {} as AgentConfig)).toBe(args);
+    });
+
+    // anthropic-subscription deliberately blanks CODEMIE_MODEL so the Claude CLI
+    // applies its own defaults — an empty value must never become `--model ''`.
+    it('ignores a blank CODEMIE_MODEL', () => {
+      delete process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
+      process.env.CODEMIE_MODEL = '   ';
+      const args = ['-p', 'hi'];
+      expect(claudeHooks.enrichArgs!(args, {} as AgentConfig)).toBe(args);
     });
   });
 });

--- a/src/providers/core/default-agent-hooks.ts
+++ b/src/providers/core/default-agent-hooks.ts
@@ -52,10 +52,31 @@ export const defaultAgentHooks: ProviderTemplate['agentHooks'] = {
 
   'claude': {
     enrichArgs(args: string[], _config: AgentConfig): string[] {
+      let enriched = args;
+
       const pluginDir = process.env.CODEMIE_CLAUDE_EXTENSION_DIR;
-      if (!pluginDir) return args;
-      if (args.some(arg => arg === '--plugin-dir')) return args;
-      return ['--plugin-dir', pluginDir, ...args];
+      if (pluginDir && !enriched.some(arg => arg === '--plugin-dir')) {
+        enriched = ['--plugin-dir', pluginDir, ...enriched];
+      }
+
+      // Claude Code ignores ANTHROPIC_MODEL. Its precedence is
+      // `--model` > settings.json `model` > its own default tier, so mapping the
+      // profile's model onto ANTHROPIC_MODEL alone (claude.plugin.ts envMapping)
+      // never reaches the wire: a developer with `"model"` pinned in
+      // ~/.claude/settings.json silently ran every session on that model, and one
+      // without it silently ran on the default (opus) tier — in both cases
+      // ignoring the model chosen in `codemie setup`.
+      //
+      // Empty is meaningful and must not be forwarded: anthropic-subscription
+      // deliberately blanks CODEMIE_MODEL so the Claude CLI applies its own
+      // defaults (anthropic-subscription.template.ts).
+      const model = process.env.CODEMIE_MODEL?.trim();
+      const hasModelFlag = enriched.some(arg => arg === '--model' || arg.startsWith('--model='));
+      if (model && !hasModelFlag) {
+        enriched = ['--model', model, ...enriched];
+      }
+
+      return enriched;
     }
   }
 };

--- a/src/utils/__tests__/logger-write-error.test.ts
+++ b/src/utils/__tests__/logger-write-error.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for the unhandled write-stream error that failed CI on
+ * PR #522: every unit test passed, then the run died with
+ *
+ *   Error: ENOENT: no such file or directory,
+ *   open '/tmp/metrics-upload-XXXX/logs/debug-YYYY-MM-DD.log'
+ *
+ * fs.createWriteStream opens the file asynchronously, so a logs directory that
+ * disappears between the mkdir and the open surfaces as an 'error' event rather
+ * than a throw the initializeLogFile try/catch could catch. With no listener
+ * Node treats it as an unhandled error and takes the process down.
+ *
+ * Reproducing the ENOENT timing directly would be a race. Occupying the log
+ * path with a DIRECTORY produces the identical failure mode deterministically:
+ * createWriteStream fails asynchronously (EISDIR), exercising the same listener.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { logger } from '../logger.js';
+
+const ORIGINAL_CODEMIE_HOME = process.env.CODEMIE_HOME;
+let home: string;
+
+describe('Logger write-stream error handling', () => {
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'codemie-logger-writeerr-'));
+    process.env.CODEMIE_HOME = home;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CODEMIE_HOME === undefined) delete process.env.CODEMIE_HOME;
+    else process.env.CODEMIE_HOME = ORIGINAL_CODEMIE_HOME;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('does not crash the process when the log file cannot be opened', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    // Occupy the exact log-file path with a directory so the async open fails.
+    mkdirSync(join(home, 'logs', `debug-${today}.log`), { recursive: true });
+
+    expect(() => logger.notice('write stream should fail to open')).not.toThrow();
+
+    // Let the stream's async 'error' event fire. Before the fix this surfaced as
+    // an unhandled error and failed the whole vitest run despite passing tests.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // The handler disables file logging rather than letting the error escape.
+    expect(logger.getLogFilePath()).toBeNull();
+
+    // Logging still works afterwards (console-only) and stays non-fatal.
+    expect(() => logger.notice('still alive')).not.toThrow();
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -85,6 +85,18 @@ class Logger {
       // Create write stream with append mode
       this.writeStream = fs.createWriteStream(this.logFilePath, { flags: 'a' });
 
+      // createWriteStream opens the file ASYNCHRONOUSLY, so a logs directory that
+      // disappears between this call and the open surfaces as an 'error' event —
+      // never as a throw the try/catch above can see. With no listener attached
+      // Node treats it as an unhandled error and takes the whole process down, so
+      // an ephemeral CODEMIE_HOME (a temp dir in tests, a sandbox that cleans up
+      // under us) could kill the CLI purely because logging failed. Logging must
+      // never be fatal: degrade to console-only instead.
+      this.writeStream.on('error', () => {
+        this.writeStream = null;
+        this.logFilePath = null;
+      });
+
       this.logFileInitialized = true;
     } catch {
       // If we can't create log directory, disable file logging

--- a/tests/helpers/agent-smoke.ts
+++ b/tests/helpers/agent-smoke.ts
@@ -18,6 +18,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { copySsoCredentials, ssoCleanEnv } from './sso-auth.js';
 import { getTempDir } from './temp-workspace.js';
+import { getCodemieTestUrl } from './test-env.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -46,7 +47,7 @@ export interface AgentSmokeRun {
 }
 
 function writeSmokeProfile(home: string, model: string): void {
-  const url = (process.env.CI_CODEMIE_URL ?? 'https://codemie.lab.epam.com').replace(/\/$/, '');
+  const url = getCodemieTestUrl();
   const config = {
     version: 2,
     activeProfile: 'sso-autotest',

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -9,6 +9,6 @@ export { writeSsoProfile, ssoCleanEnv, copySsoCredentials, setupSsoAutotestProfi
 export { waitForOutput, cleanKill } from './interactive-helpers.js';
 export { spawnPty, type PtySession } from './pty-session.js';
 export { getLatestMetricsRecord } from './metrics.js';
-export { getTestEnvFlag, getTestEnvFlagOrDefault, stripNodeModulesBin } from './test-env.js';
+export { getTestEnvFlag, getTestEnvFlagOrDefault, stripNodeModulesBin, getTestEnvValue, getCodemieTestUrl, getCodemieTestModel, DEFAULT_CODEMIE_TEST_URL, DEFAULT_CODEMIE_TEST_MODEL } from './test-env.js';
 export { pollForSession, type SessionPollOptions, type SessionPollResult } from './session-poll.js';
 export { runAgentTaskSmoke, type AgentSmokeOptions, type AgentSmokeRun } from './agent-smoke.js';

--- a/tests/helpers/jwt-auth.ts
+++ b/tests/helpers/jwt-auth.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { stripNodeModulesBin } from './test-env.js';
+import { stripNodeModulesBin, getCodemieTestUrl, getCodemieTestModel } from './test-env.js';
 
 // Slug used for the test assistant agent file
 const CI_ASSISTANT_SLUG = 'ci-assistant';
@@ -95,14 +95,14 @@ export function writeJwtProfile(codemieHome: string, overrides: JwtProfileOverri
   const authUrlRaw = process.env.CI_CODEMIE_AUTH_URL?.trim();
   if (!authUrlRaw) throw new Error('CI_CODEMIE_AUTH_URL must be set in .env.test.local or env variables');
   const authBase = authUrlRaw.replace(/\/$/, '');
-  const codeMieUrl = (overrides.codeMieUrl ?? process.env.CI_CODEMIE_URL ?? '').replace(/\/$/, '');
+  const codeMieUrl = (overrides.codeMieUrl ?? getCodemieTestUrl()).replace(/\/$/, '');
   const profile: Record<string, string> = {
     name: profileName,
     provider: 'bearer-auth',
     authMethod: 'jwt',
-    codeMieUrl: overrides.codeMieUrl ?? process.env.CI_CODEMIE_URL ?? '',
+    codeMieUrl,
     baseUrl: `${codeMieUrl}/code-assistant-api`,
-    model: overrides.model ?? process.env.CI_CODEMIE_MODEL ?? 'claude-sonnet-4-6',
+    model: overrides.model ?? getCodemieTestModel(),
     authServerUrl: overrides.authServerUrl ?? authBase,
     authRealm: overrides.authRealm ?? 'codemie-prod',
   };

--- a/tests/helpers/sso-auth.ts
+++ b/tests/helpers/sso-auth.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { stripNodeModulesBin } from './test-env.js';
+import { stripNodeModulesBin, getCodemieTestUrl, getCodemieTestModel } from './test-env.js';
 
 const SSO_PROFILE_NAME = 'sso-autotest';
 
@@ -10,15 +10,15 @@ function getCodemieConfigDir(): string {
 }
 
 function buildSsoProfile(): Record<string, unknown> {
-  const ciCodemieUrl = (process.env.CI_CODEMIE_URL ?? '').replace(/\/$/, '');
+  const ciCodemieUrl = getCodemieTestUrl();
   return {
     name: SSO_PROFILE_NAME,
     provider: 'ai-run-sso',
     authMethod: 'sso',
-    codeMieUrl: process.env.CI_CODEMIE_URL ?? '',
+    codeMieUrl: ciCodemieUrl,
     baseUrl: `${ciCodemieUrl}/code-assistant-api`,
     apiKey: 'sso-authenticated',
-    model: process.env.CODEMIE_MODEL ?? 'claude-sonnet-4-6',
+    model: getCodemieTestModel(),
     timeout: 300,
     debug: false,
   };

--- a/tests/helpers/test-env.ts
+++ b/tests/helpers/test-env.ts
@@ -73,3 +73,69 @@ export function stripNodeModulesBin(envPath: string): string {
     .filter(dir => !dir.replace(/\\/g, '/').includes('node_modules/.bin'))
     .join(delimiter);
 }
+
+/**
+ * Default CodeMie instance used by agent tests when nothing else supplies one.
+ */
+export const DEFAULT_CODEMIE_TEST_URL = 'https://codemie.lab.epam.com';
+
+/**
+ * Default model used by generated test profiles when nothing else supplies one.
+ */
+export const DEFAULT_CODEMIE_TEST_MODEL = 'claude-sonnet-4-6';
+
+/**
+ * Read a string test value with file-first priority, empty-safe coalescing and
+ * optional alias fallbacks.
+ *
+ * Empty or whitespace-only values are treated as ABSENT — this is the whole
+ * point of the helper. CodeMie exports its full CODEMIE_* block into the shell
+ * of every agent session it launches, and some providers deliberately blank
+ * individual vars (anthropic-subscription.template.ts sets CODEMIE_MODEL = ''
+ * so the Claude CLI falls back to its own defaults). Running the suite from
+ * inside such a session inherits CODEMIE_MODEL='', and plain `??` coalescing
+ * lets that empty string beat the intended default — the generated profile is
+ * then written with no model and every agent test fails with
+ * "Configuration incomplete / Missing: model".
+ *
+ * Priority: .env.test.local value > process.env (name, then each alias) > defaultValue.
+ */
+export function getTestEnvValue(name: string, defaultValue = '', aliases: string[] = []): string {
+  const clean = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+  const keys = [name, ...aliases];
+  if (_dotEnvExists) {
+    for (const key of keys) {
+      const fromFile = clean(_fileEnv[key]);
+      if (fromFile !== undefined) return fromFile;
+    }
+  }
+  for (const key of keys) {
+    const fromEnv = clean(process.env[key]);
+    if (fromEnv !== undefined) return fromEnv;
+  }
+  return defaultValue;
+}
+
+/**
+ * Resolve the CodeMie instance URL for agent tests, without a trailing slash.
+ *
+ * Falls back to CODEMIE_URL — which is always present when the suite is run
+ * from a shell that CodeMie itself launched — before the hardcoded default, so
+ * a developer needs no .env.test.local to point the tests at their instance.
+ */
+export function getCodemieTestUrl(): string {
+  return getTestEnvValue('CI_CODEMIE_URL', DEFAULT_CODEMIE_TEST_URL, ['CODEMIE_URL']).replace(/\/$/, '');
+}
+
+/**
+ * Resolve the model written into generated test profiles.
+ *
+ * CODEMIE_MODEL stays honoured as an explicit override, but only when it holds
+ * a real value — an inherited empty string falls through to the default.
+ */
+export function getCodemieTestModel(): string {
+  return getTestEnvValue('CI_CODEMIE_MODEL', DEFAULT_CODEMIE_TEST_MODEL, ['CODEMIE_MODEL']);
+}

--- a/tests/integration/agent-assistant.test.ts
+++ b/tests/integration/agent-assistant.test.ts
@@ -39,6 +39,7 @@ import {
   setupSsoAutotestProfile,
   teardownSsoAutotestProfile,
   getTestEnvFlagOrDefault,
+  getCodemieTestUrl,
 } from '../helpers/index.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -75,7 +76,7 @@ describe.runIf(process.env.SSO_AVAILABLE !== 'false')('Assistant management test
   let originalActiveProfile: string | undefined;
 
   beforeAll(async () => {
-    const ciCodemieUrl = (process.env.CI_CODEMIE_URL ?? '').replace(/\/$/, '');
+    const ciCodemieUrl = getCodemieTestUrl();
 
     if (!CI_IS_LOCAL_RUN) {
       // JWT mode: isolated temp home
@@ -90,6 +91,13 @@ describe.runIf(process.env.SSO_AVAILABLE !== 'false')('Assistant management test
     } else {
       // SSO mode: upsert sso-autotest profile into ~/.codemie
       originalActiveProfile = setupSsoAutotestProfile();
+      // CREDENTIALS_DIR in src/utils/security.ts is a module-level constant
+      // resolved from CODEMIE_HOME at import time, and the agent vitest project
+      // points CODEMIE_HOME at a throwaway temp home. The real credentials must
+      // therefore be copied into that same temp home before the in-process SDK
+      // client looks them up, or the lookup fails with "SSO authentication
+      // required" despite the global setup having validated them.
+      if (process.env.CODEMIE_HOME) copySsoCredentials(process.env.CODEMIE_HOME);
       sdkClient = await getCodemieClient(true);
     }
 

--- a/tests/integration/agent-codex.test.ts
+++ b/tests/integration/agent-codex.test.ts
@@ -48,6 +48,7 @@ import {
   setupSsoAutotestProfile,
   teardownSsoAutotestProfile,
   getTempDir,
+  getCodemieTestUrl,
 } from '../helpers/index.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -60,7 +61,7 @@ const CODEX_MODEL = process.env.CODEMIE_CODEX_MODEL ?? 'gpt-5.4';
 
 /** Write an sso-autotest profile carrying a Codex-appropriate model. */
 function writeCodexProfile(home: string): void {
-  const url = (process.env.CI_CODEMIE_URL ?? 'https://codemie.lab.epam.com').replace(/\/$/, '');
+  const url = getCodemieTestUrl();
   const config = {
     version: 2,
     activeProfile: 'sso-autotest',

--- a/tests/integration/agent-jwt-token.test.ts
+++ b/tests/integration/agent-jwt-token.test.ts
@@ -28,6 +28,7 @@ import {
   getTempDir,
   jwtCleanEnv,
   getTestEnvFlagOrDefault,
+  getCodemieTestUrl,
 } from '../helpers/index.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -44,7 +45,7 @@ const CI_IS_LOCAL_RUN = getTestEnvFlagOrDefault('CI_IS_LOCAL_RUN', true);
  * active profile selection and the auth method at runtime.
  */
 function writeTwoProfileConfig(testHome: string): void {
-  const ciCodemieUrl = (process.env.CI_CODEMIE_URL ?? '').replace(/\/$/, '');
+  const ciCodemieUrl = getCodemieTestUrl();
   const authBase = (process.env.CI_CODEMIE_AUTH_URL ?? '').replace(/\/$/, '');
   const config = {
     version: 2,
@@ -54,7 +55,7 @@ function writeTwoProfileConfig(testHome: string): void {
         name: 'profile-sso-active',
         provider: 'ai-run-sso',
         authMethod: 'sso',
-        codeMieUrl: process.env.CI_CODEMIE_URL ?? '',
+        codeMieUrl: ciCodemieUrl,
         baseUrl: `${ciCodemieUrl}/code-assistant-api`,
         apiKey: 'sso-authenticated',
         model: process.env.CI_CODEMIE_MODEL ?? 'claude-sonnet-4-6',
@@ -65,7 +66,7 @@ function writeTwoProfileConfig(testHome: string): void {
         name: 'profile-jwt-override',
         provider: 'bearer-auth',
         authMethod: 'jwt',
-        codeMieUrl: process.env.CI_CODEMIE_URL ?? '',
+        codeMieUrl: ciCodemieUrl,
         baseUrl: `${ciCodemieUrl}/code-assistant-api`,
         model: process.env.CI_CODEMIE_MODEL ?? 'claude-sonnet-4-6',
         authServerUrl: authBase,

--- a/tests/integration/agent-skills.test.ts
+++ b/tests/integration/agent-skills.test.ts
@@ -36,6 +36,7 @@ import {
   setupSsoAutotestProfile,
   teardownSsoAutotestProfile,
   getTestEnvFlagOrDefault,
+  getCodemieTestUrl,
 } from '../helpers/index.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -63,7 +64,7 @@ describe.runIf(process.env.SSO_AVAILABLE !== 'false')('Skill tests', () => {
   let originalActiveProfile: string | undefined;
 
   beforeAll(async () => {
-    const ciCodemieUrl = (process.env.CI_CODEMIE_URL ?? '').replace(/\/$/, '');
+    const ciCodemieUrl = getCodemieTestUrl();
 
     if (!CI_IS_LOCAL_RUN) {
       jwtToken = await fetchJwtToken();
@@ -76,6 +77,13 @@ describe.runIf(process.env.SSO_AVAILABLE !== 'false')('Skill tests', () => {
       });
     } else {
       originalActiveProfile = setupSsoAutotestProfile();
+      // CREDENTIALS_DIR in src/utils/security.ts is a module-level constant
+      // resolved from CODEMIE_HOME at import time, and the agent vitest project
+      // points CODEMIE_HOME at a throwaway temp home. The real credentials must
+      // therefore be copied into that same temp home before the in-process SDK
+      // client looks them up, or the lookup fails with "SSO authentication
+      // required" despite the global setup having validated them.
+      if (process.env.CODEMIE_HOME) copySsoCredentials(process.env.CODEMIE_HOME);
       sdkClient = await getCodemieClient(true);
     }
 

--- a/tests/integration/test-env-helpers.test.ts
+++ b/tests/integration/test-env-helpers.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for the empty-safe test-env resolvers.
+ *
+ * Guards the failure mode that broke the whole agent suite before the 0.15.0
+ * release: CodeMie exports its full CODEMIE_* block into the shell of every
+ * agent session it launches, and the anthropic-subscription provider
+ * deliberately blanks CODEMIE_MODEL (see
+ * src/providers/plugins/anthropic-subscription/anthropic-subscription.template.ts).
+ * Running `npm run test:all` from inside such a session inherited
+ * CODEMIE_MODEL='', and the old `process.env.CODEMIE_MODEL ?? 'claude-sonnet-4-6'`
+ * coalescing let that empty string beat the default — every generated profile
+ * was written with no model and the agent tests died with
+ * "Configuration incomplete / Missing: model".
+ *
+ * Synthetic variable names are used throughout so the assertions hold whether
+ * or not the developer has a .env.test.local (which takes priority for real keys).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { getTestEnvValue } from '../helpers/test-env.js';
+
+const PRIMARY = 'CI_PROBE_TEST_ENV_VALUE_PRIMARY';
+const ALIAS = 'CI_PROBE_TEST_ENV_VALUE_ALIAS';
+const TOUCHED = [PRIMARY, ALIAS];
+
+afterEach(() => {
+  for (const key of TOUCHED) delete process.env[key];
+});
+
+describe('getTestEnvValue', () => {
+  it('returns the default when the variable is unset', () => {
+    expect(getTestEnvValue(PRIMARY, 'fallback-value')).toBe('fallback-value');
+  });
+
+  it('returns the value when the variable holds a real value', () => {
+    process.env[PRIMARY] = 'real-value';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value')).toBe('real-value');
+  });
+
+  // The exact regression: set-but-empty must behave as absent, not as "".
+  it('treats an inherited empty string as absent and uses the default', () => {
+    process.env[PRIMARY] = '';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value')).toBe('fallback-value');
+  });
+
+  it('treats a whitespace-only value as absent and uses the default', () => {
+    process.env[PRIMARY] = '   ';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value')).toBe('fallback-value');
+  });
+
+  it('falls back to an alias when the primary name is unset', () => {
+    process.env[ALIAS] = 'alias-value';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value', [ALIAS])).toBe('alias-value');
+  });
+
+  it('falls back to an alias when the primary name is set but empty', () => {
+    process.env[PRIMARY] = '';
+    process.env[ALIAS] = 'alias-value';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value', [ALIAS])).toBe('alias-value');
+  });
+
+  it('prefers the primary name over an alias when both hold real values', () => {
+    process.env[PRIMARY] = 'primary-value';
+    process.env[ALIAS] = 'alias-value';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value', [ALIAS])).toBe('primary-value');
+  });
+
+  it('falls through to the default when both the primary and alias are empty', () => {
+    process.env[PRIMARY] = '';
+    process.env[ALIAS] = '  ';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value', [ALIAS])).toBe('fallback-value');
+  });
+
+  it('trims surrounding whitespace from a real value', () => {
+    process.env[PRIMARY] = '  padded-value  ';
+    expect(getTestEnvValue(PRIMARY, 'fallback-value')).toBe('padded-value');
+  });
+});

--- a/tests/setup/agent-build-setup.ts
+++ b/tests/setup/agent-build-setup.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { config as loadEnv } from 'dotenv';
 import { setupSsoAutotestProfile, teardownSsoAutotestProfile } from '../helpers/sso-auth.js';
+import { getCodemieTestUrl } from '../helpers/test-env.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '../..');
@@ -44,7 +45,7 @@ export async function setup(): Promise<void> {
   loadEnv({ path: resolve(root, '.env.test.local'), override: true });
 
   // Default to the public prod instance when no .env.test.local is present.
-  process.env.CI_CODEMIE_URL ??= 'https://codemie.lab.epam.com';
+  process.env.CI_CODEMIE_URL = getCodemieTestUrl();
 
   console.log('\n[agent-integration] Building dist/ (runs once per session)...');
   execSync('npm run build', { cwd: root, stdio: 'inherit' });
@@ -133,7 +134,7 @@ export async function setup(): Promise<void> {
       // Credentials missing or expired — launch browser SSO login directly.
       // Using stdio: 'inherit' so the user sees and can complete the flow.
       console.log('[agent-integration] SSO credentials missing or expired — launching login...\n');
-      const codemieUrl = process.env.CI_CODEMIE_URL ?? '';
+      const codemieUrl = getCodemieTestUrl();
       try {
         execSync(
           `node ${resolve(root, 'bin/codemie.js')} profile login --url ${codemieUrl}`,


### PR DESCRIPTION
## Summary

The model chosen in `codemie setup` never reached the wire for Claude. `claude.plugin.ts` maps the profile's model onto `ANTHROPIC_MODEL` only, but Claude Code ignores that variable — its precedence is `--model` > `~/.claude/settings.json` `"model"` > its own default tier. So a developer with `model` pinned in `~/.claude/settings.json` silently ran every session on that model, and one without it silently ran on the default (opus) tier.

This PR fixes that, and separately hardens two agent test-harness defects that made the suite fail locally regardless of product state.

## Changes

**`fix(agents)` — model selection**
- Inject `--model $CODEMIE_MODEL` in the `claude` `enrichArgs` hook, beside the existing `--plugin-dir` injection, with the same "already present" guard.
- An explicit `--model` / `--model=` in argv still wins — CodeMie never overrides a user's own choice.
- A blank `CODEMIE_MODEL` is treated as absent rather than forwarded as `--model ''`: `anthropic-subscription` deliberately blanks it so the Claude CLI applies its own defaults.

**`test(tests)` — harness hardening**
- `getTestEnvValue` / `getCodemieTestUrl` / `getCodemieTestModel` treat empty and whitespace-only env values as absent. CodeMie exports its whole `CODEMIE_*` block into any session it launches, so running the suite from such a shell inherited `CODEMIE_MODEL=''`, and `??` let that empty string beat the intended default — every generated profile was written with no model.
- `CI_CODEMIE_URL` now falls back to `CODEMIE_URL`, so no `.env.test.local` is needed inside a CodeMie-launched shell.
- `agent-assistant` / `agent-skills` copy SSO credentials into the worker's temp `CODEMIE_HOME`. `CREDENTIALS_DIR`/`FALLBACK_FILE` in `src/utils/security.ts` are module-level constants resolved at import time, so the real credentials were never in scope for the in-process SDK client.

## Impact

Evidence for the precedence claim, from the outgoing request body (claude 2.1.218, `ai-run-sso`):

| settings `model` | `ANTHROPIC_MODEL` | request body |
|---|---|---|
| `claude-haiku-4-5` | `claude-sonnet-4-6` | `claude-haiku-4-5` |
| `claude-haiku-4-5` | `claude-sonnet-5` | `claude-haiku-4-5` |
| (none) | `claude-sonnet-4-6` | `claude-opus-5` → 400 budget |
| (none) | `claude-sonnet-5` | `claude-opus-5` → 400 budget |
| `claude-sonnet-5` | `claude-sonnet-5` | `claude-sonnet-5` |

**User-visible behaviour change**: the configured model now actually takes effect. Anyone who had a `model` pinned in `~/.claude/settings.json`, or who was silently running on the default tier, will see their profile's model used instead — with the corresponding cost and quality difference. Worth calling out in release notes.

Test results:

| Suite | Before | After |
|---|---|---|
| unit | 3950 passed | 3955 passed |
| cli | 263 passed | 272 passed |
| agent | 8 failed / 6 files | 2 failed / 2 files |

TC-020 and TC-021 now pass — they assert the session uses the profile's model, which is exactly what was broken, so they were correctly failing before.

## Known remaining failures (pre-existing, not addressed here)

- **TC-024** — `/model` switch session emits no metrics file. Present in every pre-fix run; verified unaffected by this change.
- **TC-029** — setup wizard needs a real interactive browser SSO login against a fresh temp home; cannot pass unattended.

Both were also verified to fail identically with #505 reverted, so neither is a regression from this release.

## Checklist
- [x] Self-reviewed
- [x] Manual testing performed (end-to-end request/response inspection with `CODEMIE_DEBUG=true`)
- [ ] Documentation updated — not done; the `ANTHROPIC_MODEL` mapping in `claude.plugin.ts:89,317` is now supplemented by `--model` and may warrant a note
- [ ] No breaking changes — **behaviour change**, see Impact above

https://claude.ai/code/session_01Ce5td85FtwMh65FG66LWaK