### PR TITLE
fix(utils): normalize URL to host before hashing credential storage key

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -11,6 +11,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { URL } from 'url';
 import { SSOCredentials, JWTCredentials } from '../providers/core/types.js';
 import { getCodemiePath } from './paths.js';
 
@@ -301,12 +302,25 @@ export class CredentialStore {
   }
 
   /**
-   * Generate a storage key for a given base URL
-   * @param baseUrl - The base URL to hash
+   * Generate a storage key for a given URL.
+   *
+   * Reduces the URL to protocol+host before hashing so storage and retrieval
+   * always agree on a key regardless of which path a caller passes in (e.g.
+   * a bare portal URL from `codemie setup` vs. a full API URL from
+   * `codemie profile login --url <api-url>`). Only stripping a trailing
+   * slash here (without dropping the path) would make the key sensitive to
+   * whichever URL variant happened to be passed at store time.
+   * @param baseUrl - The URL to hash (path/query/hash, if any, are discarded)
    * @returns Storage key (e.g., "sso-abc123...")
    */
   private getUrlStorageKey(baseUrl: string): string {
-    const normalized = baseUrl.replace(/\/$/, '').toLowerCase();
+    let normalized: string;
+    try {
+      const parsed = new URL(baseUrl);
+      normalized = `${parsed.protocol}//${parsed.host}`.toLowerCase();
+    } catch {
+      normalized = baseUrl.replace(/\/$/, '').toLowerCase();
+    }
     const hash = crypto.createHash('sha256').update(normalized).digest('hex');
     return `sso-${hash}`;
   }


### PR DESCRIPTION
## Summary
`codemie profile login --url <api-url>` and `codemie setup` derived different SHA-256 storage keys for the same CodeMie origin, because credential storage hashed the raw URL while retrieval normalized it to `protocol//host` first. Logging in via `codemie profile login --url https://host/code-assistant-api` stored credentials under one key, but the proxy's lookup (via the normalized host) used a different key, so `codemie-claude` reported "SSO credentials not found" immediately after a successful login.

## Changes
- Move URL normalization (reduce to `protocol//host` before hashing) into `CredentialStore.getUrlStorageKey()` in `src/utils/security.ts`, so it is the single point of normalization shared by every SSO and JWT store/retrieve/clear operation.
- This also fixes the same latent asymmetry in the JWT credential path, which had no normalization anywhere previously.

## Testing
- [x] Tests added/updated — none added; existing `tests/integration/sso-per-url-credentials.test.ts` (23 tests) already covers per-URL storage/retrieval and passes against the fix.
- [x] Manual testing done — verified with a hash-comparison script that store/retrieve keys now match for `https://codemie-preview.lab.epam.com/code-assistant-api` (previously mismatched).

## Checklist
- [x] Code follows project standards
- [x] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`