### PR TITLE
fix(agents): keep Claude plugin auto-updates working under the pinned binary

### DIFF
--- a/src/agents/plugins/claude/__tests__/claude.plugin.auto-update.test.ts
+++ b/src/agents/plugins/claude/__tests__/claude.plugin.auto-update.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the Claude plugin's auto-updater environment setup.
+ *
+ * `beforeRun` sets DISABLE_AUTOUPDATER=1 to pin the Claude Code binary to
+ * CLAUDE_SUPPORTED_VERSION, which CodeMie manages explicitly. That variable is
+ * broader than the intent: upstream gates plugin auto-update on the same
+ * predicate,
+ *
+ *   Pmt() = autoUpdaterDisabled() && !FORCE_AUTOUPDATE_PLUGINS
+ *
+ * and uses it both to skip the background plugin update pass ("Plugin
+ * autoupdate: skipped (auto-updater disabled)") and to decide whether the
+ * per-marketplace "Enable auto-update" item is pushed onto the /plugin
+ * Marketplaces menu at all. So pinning the binary silently left every CodeMie
+ * user without plugin auto-updates *and* without the control to turn them on.
+ *
+ * Setting FORCE_AUTOUPDATE_PLUGINS=1 alongside restores plugin auto-update
+ * while leaving the binary pinned.
+ *
+ * @group unit
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ClaudePluginMetadata } from '../claude.plugin.js';
+
+vi.mock('fs/promises');
+vi.mock('fs');
+
+describe('ClaudePluginMetadata.lifecycle.beforeRun — auto-updater env', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runBeforeRun(
+    env: Record<string, string> = {}
+  ): Promise<Record<string, string>> {
+    await ClaudePluginMetadata.lifecycle?.beforeRun?.(env as never);
+    return env;
+  }
+
+  it('pins the binary by disabling the auto-updater', async () => {
+    const env = await runBeforeRun();
+    expect(env.DISABLE_AUTOUPDATER).toBe('1');
+  });
+
+  it('keeps plugin auto-updates working alongside the pinned binary', async () => {
+    const env = await runBeforeRun();
+    expect(env.FORCE_AUTOUPDATE_PLUGINS).toBe('1');
+  });
+
+  it('does not override an explicit FORCE_AUTOUPDATE_PLUGINS opt-out', async () => {
+    const env = await runBeforeRun({ FORCE_AUTOUPDATE_PLUGINS: '0' });
+    expect(env.FORCE_AUTOUPDATE_PLUGINS).toBe('0');
+  });
+
+  it('does not override an explicit DISABLE_AUTOUPDATER value', async () => {
+    const env = await runBeforeRun({ DISABLE_AUTOUPDATER: '0' });
+    expect(env.DISABLE_AUTOUPDATER).toBe('0');
+  });
+});

--- a/src/agents/plugins/claude/claude.plugin.ts
+++ b/src/agents/plugins/claude/claude.plugin.ts
@@ -185,6 +185,19 @@ export const ClaudePluginMetadata: AgentMetadata = {
         env.DISABLE_AUTOUPDATER = '1';
       }
 
+      // ...but keep *plugin* auto-updates working. Upstream gates them on the
+      // same predicate as the binary updater:
+      //   Pmt() = autoUpdaterDisabled() && !FORCE_AUTOUPDATE_PLUGINS
+      // which both skips the background plugin update pass and hides the
+      // per-marketplace "Enable auto-update" item from the /plugin Marketplaces
+      // menu entirely. Without this, pinning the binary above silently leaves
+      // every CodeMie user on whatever plugin version they first installed,
+      // with no visible control to change it.
+      // https://code.claude.com/docs/en/discover-plugins#configure-auto-updates
+      if (!env.FORCE_AUTOUPDATE_PLUGINS) {
+        env.FORCE_AUTOUPDATE_PLUGINS = '1';
+      }
+
       // WORKAROUND: Disable tool search feature introduced in 2.1.69+
       // Claude Code 2.1.69+ fails to start without this flag when using CodeMie proxy
       if (!env.ENABLE_TOOL_SEARCH) {


### PR DESCRIPTION
## Summary
`beforeRun` sets `DISABLE_AUTOUPDATER=1` to hold the Claude Code binary at `CLAUDE_SUPPORTED_VERSION`, which CodeMie manages explicitly. Upstream gates *plugin* auto-update on that same flag (`autoUpdaterDisabled() && !FORCE_AUTOUPDATE_PLUGINS`), so pinning the binary silently left every CodeMie user on whatever plugin version they first installed — with no visible toggle to change it, since the same predicate also hides the "Enable auto-update" item from the `/plugin` Marketplaces menu. Found while investigating why a freshly published plugin version never reached clients.

## Changes
- Set `FORCE_AUTOUPDATE_PLUGINS=1` alongside `DISABLE_AUTOUPDATER=1` in `src/agents/plugins/claude/claude.plugin.ts`, restoring plugin auto-updates while keeping the binary pinned. An explicit value from the environment still wins.
- Add `src/agents/plugins/claude/__tests__/claude.plugin.auto-update.test.ts` covering the default behavior and both opt-out paths.

## Testing
- [x] Tests added/updated
- [ ] Manual testing done

## Checklist
- [x] Code follows project standards
- [ ] CI is green (`npm run ci`)
- [x] No merge conflicts with `main`

https://claude.ai/code/session_01GkfT91jsQhJzdhHXim8nZ7